### PR TITLE
refactor: use shared health opcodes from planetopia-protocol v0.3.0

### DIFF
--- a/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
+++ b/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
@@ -1,4 +1,5 @@
 #include "PIR_Adapter.h"
+#include "lib/planetopia-protocol/c/opcodes.h"
 #include <cstdint>
 #include <cstring>
 #include "src/core/Logger.h"
@@ -67,7 +68,7 @@ static void readOwnMac(uint8_t out[6]) {
 
 void PIR_Adapter::sendNodeHealth() {
   uint8_t data[64] = {0};
-  data[0] = 0xB2; // OP_NODE_HEALTH
+  data[0] = OP_NODE_HEALTH;
   data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::PIR_ADAPTER);
   uint8_t mac[6];
   readOwnMac(mac);

--- a/main/src/Adapter/Serial_Adapter/Serial_Adapter.h
+++ b/main/src/Adapter/Serial_Adapter/Serial_Adapter.h
@@ -22,6 +22,9 @@ public:
   void onMeshDataImpl(const planetopia::mesh::mesh_message& message) override;
 
   // Opcodes from planetopia-protocol/opcodes.h (included above):
+  //   OP_HEALTH_REQ    0xB0  [B0]
+  //   OP_HEALTH_REPORT 0xB1  [B1][1B adapterType][6B mac][4B uptime]
+  //   OP_NODE_HEALTH   0xB2  [B2][1B adapterType][6B mac][4B uptime]
   //   OP_NODE_ID_SET   0xC0  [C0][6B targetMAC][1B nodeId]
   //   OP_CONFIG_SET    0xC1  [C1][6B targetMac][1B adapterType]
   //   OP_TX_POWER_SET  0xC2  [C2][1B preset: 0=short 1=indoor 2=outdoor]
@@ -30,10 +33,6 @@ public:
   //   OP_LED_BLINK     0xD2
   //   OP_RELAY_SET     0xD8
   //   OP_COMMAND_ACK   0xE0  [E0][1B commandId]
-
-  // Health opcodes — Serial_Adapter internal only, not in shared protocol
-  static constexpr uint8_t OP_HEALTH_REQ = 0xB0;    // [B0]
-  static constexpr uint8_t OP_HEALTH_REPORT = 0xB1; // [B1][1B adapterType][6B mac][4B uptime]
 
   // Relay a completed enrollment public key to the server over serial
   static void relayEnrollmentToServer(const uint8_t mac[6], const uint8_t pubKey[32]);


### PR DESCRIPTION
Bump submodule to v0.3.0, remove local OP_HEALTH_REQ/OP_HEALTH_REPORT static constexpr members from Serial_Adapter.h (now provided by the shared opcodes.h), add opcodes.h include to PIR_Adapter.cpp, and replace the hardcoded 0xB2 magic number with OP_NODE_HEALTH.

## Summary
<!-- What does this PR do? One paragraph max. -->

## Type of change
- [ ] Bug fix
- [ ] New adapter
- [ ] Protocol change
- [ ] Documentation
- [ ] CI/tooling
- [ ] Other:

## Checklist
- [ ] `clang-format --style=file` applied — `git diff --check` clean
- [ ] No `new` / `malloc` after `setup()` (Tiger Style memory policy)
- [ ] All errors route through `src/error/Error.h`
- [ ] Unit tests added / updated for any logic change
- [ ] Documentation updated if behaviour changes
- [ ] `project_config.h` example MACs remain as `AA:BB:CC:...` placeholders

## Testing done
<!-- How did you verify this? Hardware tested? Unit tests? -->
