### PR TITLE
feat: rename Planetopia → Lattice across nodes firmware

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "main/lib/planetopia-protocol"]
-	path = main/lib/planetopia-protocol
-	url = https://github.com/superbrobenji/planetopia-protocol
+[submodule "main/lib/lattice-protocol"]
+	path = main/lib/lattice-protocol
+	url = https://github.com/superbrobenji/lattice-protocol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Contributing to Planetopia Firmware
+# Contributing to Lattice Firmware
 
-Planetopia follows Tiger-Style engineering principles: safety first, performance always, zero technical debt.  The CI pipeline enforces these rules automatically.  Every pull-request **must** pass all gates before merge.
+Lattice follows Tiger-Style engineering principles: safety first, performance always, zero technical debt.  The CI pipeline enforces these rules automatically.  Every pull-request **must** pass all gates before merge.
 
 ## 0. Quick checklist before opening a PR
 
 - [ ] `arduino-cli compile -e --fqbn esp32:esp32:esp32da main` builds with **no warnings** (run locally — not in CI).
 - [ ] `clang-format -style=file` applied; `git diff --check` shows no whitespace errors.
 - [ ] No `new`, `malloc`, or unbounded `std::vector` growth after setup.
-- [ ] All errors funnel through `src/error/Error.h` (`planetopia::err::*`).
-- [ ] MAC handling uses `planetopia::utils::MacAddress` helper.
+- [ ] All errors funnel through `src/error/Error.h` (`lattice::err::*`).
+- [ ] MAC handling uses `lattice::utils::MacAddress` helper.
 - [ ] Added/updated unit tests (if applicable).
 - [ ] Updated documentation (README / docs/) if behaviour changes.
 
@@ -31,7 +31,7 @@ refactor/<area>    # structural changes
 
 ## 4. Error handling
 ```cpp
-if (!planetopia::err::checkEsp(esp_now_init(), utils::ErrorType::COMMUNICATION_FAIL,
+if (!lattice::err::checkEsp(esp_now_init(), utils::ErrorType::COMMUNICATION_FAIL,
                                "esp_now_init failed"))
     return false;
 ```
@@ -56,4 +56,4 @@ PR merges are blocked until all three jobs are green.
 > locally before submitting a PR that touches firmware source.
 
 ---
-Thank you for keeping Planetopia rock-solid! 💪
+Thank you for keeping Lattice rock-solid! 💪

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Planetopia — ESP-NOW Mesh Network Firmware
+# Lattice — ESP-NOW Mesh Network Firmware
 
-[![CI](https://github.com/superbrobenji/Planetopia-nodes/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/superbrobenji/Planetopia-nodes/actions/workflows/unit-tests.yml)
+[![CI](https://github.com/superbrobenji/Lattice-nodes/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/superbrobenji/Lattice-nodes/actions/workflows/unit-tests.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
 Low-latency, encrypted, self-healing mesh network firmware for ESP32 devices.
@@ -48,7 +48,7 @@ main/
     ├── core/
     │   └── Logger.h / Logger.cpp   # Levelled logging (LOG_NONE suppresses all output)
     ├── error/
-    │   ├── Error.h                 # Public `planetopia::err::fail / fatal` helpers
+    │   ├── Error.h                 # Public `lattice::err::fail / fatal` helpers
     │   ├── ErrorCore.h / .cpp      # Blink patterns + TM1637 error codes
     │   └── ErrorCodes.h            # Numeric error registry
     ├── persistence/
@@ -104,8 +104,8 @@ Dependencies bundled in the repo (no library manager needed):
 ### 1. Clone
 
 ```bash
-git clone https://github.com/superbrobenji/Planetopia-nodes.git
-cd Planetopia-nodes
+git clone https://github.com/superbrobenji/Lattice-nodes.git
+cd Lattice-nodes
 ```
 
 ### 2. Configure
@@ -139,7 +139,7 @@ arduino-cli upload  --fqbn esp32:esp32:esp32da -p /dev/ttyUSB0 main
 
 On first boot, each unenrolled node prints its Curve25519 public key:
 ```
-PLANETOPIA_PUBKEY:3a7f2b...
+LATTICE_PUBKEY:3a7f2b...
 ```
 The host server must read this, approve the node, and send a `MESH_TYPE_JOIN_ACK`
 message (via the master's serial port) before the node begins forwarding sensor data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lattice — ESP-NOW Mesh Network Firmware
 
-[![CI](https://github.com/superbrobenji/Lattice-nodes/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/superbrobenji/Lattice-nodes/actions/workflows/unit-tests.yml)
+[![CI](https://github.com/superbrobenji/lattice-nodes/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/superbrobenji/lattice-nodes/actions/workflows/unit-tests.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
 Low-latency, encrypted, self-healing mesh network firmware for ESP32 devices.
@@ -104,7 +104,7 @@ Dependencies bundled in the repo (no library manager needed):
 ### 1. Clone
 
 ```bash
-git clone https://github.com/superbrobenji/Lattice-nodes.git
+git clone https://github.com/superbrobenji/lattice-nodes.git
 cd Lattice-nodes
 ```
 

--- a/REFACTORING_GUIDE.md
+++ b/REFACTORING_GUIDE.md
@@ -1,7 +1,7 @@
 # Architecture Guide
 
 This document describes the design principles and module responsibilities of
-the Planetopia firmware. It replaces an earlier draft that described planned
+the Lattice firmware. It replaces an earlier draft that described planned
 (but never implemented) refactor utilities.
 
 ## Design Principles
@@ -54,7 +54,7 @@ Levelled logging (`LOG_DEBUG` → `LOG_NONE`). Set `DEFAULT_LOG_LEVEL = LOG_NONE
 when the serial port is used for host-server framing — any text output corrupts frames.
 
 ### `src/error/`
-- `Error.h`: public API — `planetopia::err::fail()` / `planetopia::err::fatal()`.
+- `Error.h`: public API — `lattice::err::fail()` / `lattice::err::fatal()`.
 - `ErrorCore`: drives the error LED blink pattern and TM1637 display.
 - `ErrorCodes.h`: numeric `T·M·S` code registry.
 

--- a/docs/adapter_development_guide.md
+++ b/docs/adapter_development_guide.md
@@ -1,6 +1,6 @@
 # Adapter Development Guide
 
-This guide explains how to add new adapters to the Planetopia system and how to change the default adapter for testing purposes.
+This guide explains how to add new adapters to the Lattice system and how to change the default adapter for testing purposes.
 
 ## Table of Contents
 
@@ -21,7 +21,7 @@ Create a new header file in `main/src/Adapter/[AdapterName]_Adapter/[AdapterName
 
 #include "src/Adapter/Adapter.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 class [AdapterName]_Adapter : public Adapter {
@@ -31,7 +31,7 @@ public:
 
     // Required overrides
     void loop() override;
-    void onMeshDataImpl(const planetopia::mesh::mesh_message& message) override;
+    void onMeshDataImpl(const lattice::mesh::mesh_message& message) override;
 
 private:
     int _pin;
@@ -41,7 +41,7 @@ private:
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 
 #endif // [ADAPTERNAME]_ADAPTER_H
 ```
@@ -53,7 +53,7 @@ private:
 
 #include "src/Adapter/Adapter.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 class Temp_Adapter : public Adapter {
@@ -62,7 +62,7 @@ public:
     ~Temp_Adapter() = default;
 
     void loop() override;
-    void onMeshDataImpl(const planetopia::mesh::mesh_message& message) override;
+    void onMeshDataImpl(const lattice::mesh::mesh_message& message) override;
 
 private:
     int _pin;
@@ -74,7 +74,7 @@ private:
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 
 #endif // TEMP_ADAPTER_H
 ```
@@ -88,7 +88,7 @@ Create the corresponding `.cpp` file in `main/src/Adapter/[AdapterName]_Adapter/
 #include "src/Mesh/Mesh.h"
 #include "src/core/Logger.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 [AdapterName]_Adapter::[AdapterName]_Adapter(int pin) 
@@ -109,7 +109,7 @@ void [AdapterName]_Adapter::loop() {
     }
 }
 
-void [AdapterName]_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& message) {
+void [AdapterName]_Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
     // Handle incoming mesh messages specific to this adapter type
     // This method is only called for messages where dataType matches this adapter's type
     
@@ -130,7 +130,7 @@ void [AdapterName]_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message&
 // }
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 ```
 
 **Example Implementation:**
@@ -139,7 +139,7 @@ void [AdapterName]_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message&
 #include "src/Mesh/Mesh.h"
 #include "src/core/Logger.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 Temp_Adapter::Temp_Adapter(int pin) 
@@ -155,7 +155,7 @@ void Temp_Adapter::loop() {
     }
 }
 
-void Temp_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& message) {
+void Temp_Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
     if (message.dataType == TEMP_ADAPTER) {
         if (message.data[0] == 0x01) { // REQUEST_TEMP
             sendTemperatureData();
@@ -171,8 +171,8 @@ void Temp_Adapter::readTemperature() {
 
 void Temp_Adapter::sendTemperatureData() {
     if (mesh_transmit_fn) {
-        planetopia::mesh::mesh_message msg;
-        msg.messageType = planetopia::mesh::MESH_TYPE_ADAPTER_DATA;
+        lattice::mesh::mesh_message msg;
+        msg.messageType = lattice::mesh::MESH_TYPE_ADAPTER_DATA;
         msg.dataType = TEMP_ADAPTER;
         msg.data[0] = 0x02; // TEMP_DATA opcode
         msg.data[1] = (uint8_t)(_lastTemperature * 10); // Send temperature * 10 as integer
@@ -185,7 +185,7 @@ void Temp_Adapter::sendTemperatureData() {
 }
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 ```
 
 ### Step 3: Add the Adapter Type to the Enum
@@ -294,10 +294,10 @@ public:
     
     // Main interface methods
     virtual void loop() = 0;
-    virtual void onMeshDataImpl(const planetopia::mesh::mesh_message& message) = 0;
+    virtual void onMeshDataImpl(const lattice::mesh::mesh_message& message) = 0;
     
     // Mesh data handling (automatically filters by adapter type)
-    void onMeshData(const planetopia::mesh::mesh_message& message);
+    void onMeshData(const lattice::mesh::mesh_message& message);
     
     // Getter methods
     adapter_types getType() const { return _adapterType; }
@@ -407,10 +407,10 @@ Here's a complete example of a temperature sensor adapter:
 3. Send mesh message with `dataType = 4` to trigger temperature reading
 4. Verify temperature data is broadcast back to the mesh
 
-This guide should give you everything you need to add new adapters and test different configurations in the Planetopia system!
+This guide should give you everything you need to add new adapters and test different configurations in the Lattice system!
 
 ## 2025 Update – Build-time Defaults & GPIO Helpers
 
-* **DEFAULT_ADAPTER** – you no longer edit `main.ino` to pick a default adapter.  Instead change `planetopia::config::DEFAULT_ADAPTER` in `project_config.h`.
+* **DEFAULT_ADAPTER** – you no longer edit `main.ino` to pick a default adapter.  Instead change `lattice::config::DEFAULT_ADAPTER` in `project_config.h`.
 * **GPIO helpers** – validation and `_initialized` bookkeeping are handled by `GpioOutput` / `GpioInput`.  New adapter drivers can simply call `GpioOutput::isValidOutputPin(pin)` instead of duplicating pin tables.
 * **Seven-segment optional** – if your dev board lacks the TM1637 display set `ENABLE_SEVSEG_DISPLAY = false` in `project_config.h`; the ErrorCore will fall back to LED patterns.

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -62,7 +62,7 @@ Always use the helpers in `src/error/Error.h` – never call `ErrorCore` directl
 // Mesh peer-list overflow in Mesh module (sub-code 0x1)
 constexpr uint8_t MESH_PEER_OVERFLOW = 0x01;
 
-planetopia::err::fail(utils::ErrorType::MEMORY_ERROR,
+lattice::err::fail(utils::ErrorType::MEMORY_ERROR,
                       "Peer vector overflow");
 // Shows 0x431 (Memory / Mesh / 1) on the display and blinks the
 // error LED four times before performing a safe reboot (if configured).

--- a/docs/server_requirements.md
+++ b/docs/server_requirements.md
@@ -1,4 +1,4 @@
-## Planetopia server requirements (serial + mesh)
+## Lattice server requirements (serial + mesh)
 
 This document describes everything the server must implement to communicate with the master node over USB serial and control/query all mesh nodes. It includes the wire protocol, message schema, control opcodes, and reference implementation notes (with Go in mind).
 
@@ -257,7 +257,7 @@ When a node boots for the first time (or after an EEPROM wipe) it is
 
 1. Prints its Curve25519 public key to serial (master node only relays):
    ```
-   PLANETOPIA_PUBKEY:3a7f2b...  (64 hex chars = 32 bytes)
+   LATTICE_PUBKEY:3a7f2b...  (64 hex chars = 32 bytes)
    ```
 2. Broadcasts `MESH_TYPE_ENROLLMENT` (type=2) messages every 10 seconds with
    `enrollmentPublicKey` populated.

--- a/main/main.ino
+++ b/main/main.ino
@@ -13,51 +13,51 @@
 #include <memory>
 #include <esp_task_wdt.h>
 
-constexpr unsigned long MASTER_BEACON_INTERVAL_MS = planetopia::config::MASTER_BEACON_INTERVAL_MS;
+constexpr unsigned long MASTER_BEACON_INTERVAL_MS = lattice::config::MASTER_BEACON_INTERVAL_MS;
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 // Avoid 'mesh' ambiguity by not importing the namespace
-using namespace planetopia::adapter;
-using namespace planetopia::hardware;
+using namespace lattice::adapter;
+using namespace lattice::hardware;
 
 // Pins from config
-constexpr int RED_LED_PIN = planetopia::config::RED_LED_PIN;
-constexpr int GREEN_LED_PIN = planetopia::config::GREEN_LED_PIN;
-constexpr int CONFIG_BUTTON_PIN = planetopia::config::CONFIG_BUTTON_PIN;
-constexpr int RESET_BUTTON_PIN = planetopia::config::RESET_BUTTON_PIN;
+constexpr int RED_LED_PIN = lattice::config::RED_LED_PIN;
+constexpr int GREEN_LED_PIN = lattice::config::GREEN_LED_PIN;
+constexpr int CONFIG_BUTTON_PIN = lattice::config::CONFIG_BUTTON_PIN;
+constexpr int RESET_BUTTON_PIN = lattice::config::RESET_BUTTON_PIN;
 
 constexpr unsigned long BUTTON_HOLD_TIME_MS = 5000;  // 5 seconds
 
 // Compile-time dev flag
-constexpr bool DEV_MODE = planetopia::config::DEV_MODE;
+constexpr bool DEV_MODE = lattice::config::DEV_MODE;
 
 Led greenLed(GREEN_LED_PIN);
 Led redLed(RED_LED_PIN);
 Button configButton(CONFIG_BUTTON_PIN);
 Button resetButton(RESET_BUTTON_PIN);  // New reset button object
 
-SevenSegDisplay sevenSeg(planetopia::config::SEVSEG_DATA_PIN,
-                         planetopia::config::SEVSEG_CLK_PIN);
+SevenSegDisplay sevenSeg(lattice::config::SEVSEG_DATA_PIN,
+                         lattice::config::SEVSEG_CLK_PIN);
 
-planetopia::mesh::Mesh mesh;
-planetopia::mesh::mesh_message transmissionMessage;
+lattice::mesh::Mesh mesh;
+lattice::mesh::mesh_message transmissionMessage;
 
-std::unique_ptr<planetopia::adapter::Adapter> adapter;
+std::unique_ptr<lattice::adapter::Adapter> adapter;
 bool isDevMode = false;                                       // Global variable to track dev mode state
-bool devMasterFlag = planetopia::config::DEFAULT_DEV_MASTER;  // runtime master flag used in dev mode
+bool devMasterFlag = lattice::config::DEFAULT_DEV_MASTER;  // runtime master flag used in dev mode
 
 //define all known MAC addresses for your mesh (update with your real MACs!)
-const uint8_t (*defaultPeerList)[6] = planetopia::config::DEFAULT_PEERS;
-constexpr int NUM_DEFAULT_PEERS = planetopia::config::NUM_DEFAULT_PEERS;
+const uint8_t (*defaultPeerList)[6] = lattice::config::DEFAULT_PEERS;
+constexpr int NUM_DEFAULT_PEERS = lattice::config::NUM_DEFAULT_PEERS;
 
 // Validate configuration for server communication
 static inline void validateServerConfiguration() {
   // Check if this is a master node intended for server communication
   bool isMasterNode = isDevMode ? devMasterFlag : EEPROM_Manager::getInstance().loadMasterFlag();
-  bool hasSerialAdapter = (adapter && adapter->getAdapterType() == planetopia::adapter::adapter_types::SERIAL_ADAPTER);
-  bool loggingDisabled = (planetopia::config::DEFAULT_LOG_LEVEL == planetopia::utils::LogLevel::LOG_NONE);
+  bool hasSerialAdapter = (adapter && adapter->getAdapterType() == lattice::adapter::adapter_types::SERIAL_ADAPTER);
+  bool loggingDisabled = (lattice::config::DEFAULT_LOG_LEVEL == lattice::utils::LogLevel::LOG_NONE);
   
-  if (isMasterNode && !hasSerialAdapter && planetopia::config::DEFAULT_LOG_LEVEL != planetopia::utils::LogLevel::LOG_NONE) {
+  if (isMasterNode && !hasSerialAdapter && lattice::config::DEFAULT_LOG_LEVEL != lattice::utils::LogLevel::LOG_NONE) {
     // This is a potential misconfiguration - master node without serial adapter might cause issues
     Logger::logln("CONFIG", "WARNING: Master node without SERIAL_ADAPTER may cause server communication issues", LogLevel::LOG_WARN);
   }
@@ -70,7 +70,7 @@ static inline void validateServerConfiguration() {
 
 // Keep main thin; adapter handles health/config
 
-void dataRecvCallback(planetopia::mesh::mesh_message message) {
+void dataRecvCallback(lattice::mesh::mesh_message message) {
   Logger::logln("MESH", "Data received callback triggered", LogLevel::LOG_DEBUG);
   if (adapter) {
     adapter->onMeshData(message);
@@ -83,11 +83,11 @@ void setup() {
   
   // Only print startup message if logging is enabled (not LOG_NONE)
   // This prevents text output when using SERIAL_ADAPTER for server communication
-  if (planetopia::config::DEFAULT_LOG_LEVEL != planetopia::utils::LogLevel::LOG_NONE) {
-    Serial.println("Planetopia Starting...");
+  if (lattice::config::DEFAULT_LOG_LEVEL != lattice::utils::LogLevel::LOG_NONE) {
+    Serial.println("Lattice Starting...");
   }
   
-  Logger::setLogLevel(planetopia::config::DEFAULT_LOG_LEVEL);
+  Logger::setLogLevel(lattice::config::DEFAULT_LOG_LEVEL);
 
   // Check and log reset reason; escalate if WDT looping
   {
@@ -130,18 +130,18 @@ void setup() {
   }
 
   // Seven segment conditional init
-  if (planetopia::config::ENABLE_SEVSEG_DISPLAY) {
+  if (lattice::config::ENABLE_SEVSEG_DISPLAY) {
     sevenSeg.init();
-    planetopia::utils::ErrorCore::getInstance().init(&redLed, &sevenSeg);
+    lattice::utils::ErrorCore::getInstance().init(&redLed, &sevenSeg);
   } else {
-    planetopia::utils::ErrorCore::getInstance().init(&redLed, nullptr);
+    lattice::utils::ErrorCore::getInstance().init(&redLed, nullptr);
   }
 
   if (!greenLed.isInitialized()) {
     if (!greenLed.init()) {
       Logger::logln("MAIN", "FATAL: Failed to initialize green LED!", LogLevel::LOG_ERROR);
-      planetopia::err::fatal(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::CORE,
+      lattice::err::fatal(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::CORE,
                             1,
                             "MAIN: Failed to initialize green LED");
     }
@@ -149,19 +149,19 @@ void setup() {
 
   if (!configButton.init()) {
     Logger::error("Config button initialization failed!");
-    planetopia::err::fail(planetopia::utils::ErrorType::HARDWARE_FAILURE, "Config button init failed!");
+    lattice::err::fail(lattice::utils::ErrorType::HARDWARE_FAILURE, "Config button init failed!");
   }
 
   if (!resetButton.init()) {
     Logger::error("Reset button initialization failed!");
-    planetopia::err::fail(planetopia::utils::ErrorType::HARDWARE_FAILURE, "Reset button init failed!");
+    lattice::err::fail(lattice::utils::ErrorType::HARDWARE_FAILURE, "Reset button init failed!");
   }
 
   // Initialize EEPROM Manager
   if (!EEPROM_Manager::getInstance().init()) {
     Logger::logln("MAIN", "Failed to initialize EEPROM Manager", LogLevel::LOG_ERROR);
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::MEMORY,
-                          planetopia::core::ModuleDigit::CORE,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::MEMORY,
+                          lattice::core::ModuleDigit::CORE,
                           2,
                           "EEPROM Manager init failed!");
   }
@@ -179,7 +179,7 @@ void setup() {
   Logger::logln("MAIN", String("Running in ") + (isDevMode ? "DEV" : "PRODUCTION") + " mode", LogLevel::LOG_INFO);
 
   // Set dev mode in AdapterFactory and EEPROM Manager
-  planetopia::adapter::AdapterFactory::setDevMode(isDevMode);
+  lattice::adapter::AdapterFactory::setDevMode(isDevMode);
   EEPROM_Manager::getInstance().setDevMode(isDevMode);
 
   // Declare peers to EEPROM (only if not in dev mode and EEPROM is empty)
@@ -193,26 +193,26 @@ void setup() {
 
   // Initialize EEPROM defaults if not set (only if not in dev mode)
   if (!isDevMode) {
-    planetopia::adapter::AdapterFactory::initializeDefaultsIfUnset();
+    lattice::adapter::AdapterFactory::initializeDefaultsIfUnset();
   }
 
   // Create adapter (from EEPROM if production mode, or default if dev mode)
   if (isDevMode) {
     // In dev mode, create default adapter from config
-    adapter.reset(planetopia::adapter::AdapterFactory::createAdapter(
-      planetopia::config::DEFAULT_ADAPTER,
-      planetopia::adapter::AdapterFactory::getDefaultPinForAdapter(planetopia::config::DEFAULT_ADAPTER)));
+    adapter.reset(lattice::adapter::AdapterFactory::createAdapter(
+      lattice::config::DEFAULT_ADAPTER,
+      lattice::adapter::AdapterFactory::getDefaultPinForAdapter(lattice::config::DEFAULT_ADAPTER)));
     Logger::logln("MAIN", "Created default adapter (DEV mode)", LogLevel::LOG_INFO);
   } else {
     // In production mode, create from EEPROM
-    adapter.reset(planetopia::adapter::AdapterFactory::createFromEEPROM());
+    adapter.reset(lattice::adapter::AdapterFactory::createFromEEPROM());
     Logger::logln("MAIN", "Created adapter from EEPROM (PRODUCTION mode)", LogLevel::LOG_INFO);
   }
 
   if (!adapter) {
     Logger::logln("MAIN", "Failed to create adapter", LogLevel::LOG_ERROR);
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::HARDWARE,
-                          planetopia::core::ModuleDigit::CORE,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::HARDWARE,
+                          lattice::core::ModuleDigit::CORE,
                           3,
                           "MAIN: Failed to create PIR adapter");
   }
@@ -220,8 +220,8 @@ void setup() {
 
   if (!adapter->init()) {
     Logger::logln("MAIN", "Adapter failed to initialize", LogLevel::LOG_ERROR);
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::HARDWARE,
-                          planetopia::core::ModuleDigit::CORE,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::HARDWARE,
+                          lattice::core::ModuleDigit::CORE,
                           4,
                           "MAIN: Adapter failed to initialize");
   }
@@ -229,8 +229,8 @@ void setup() {
 
   if (!mesh.init()) {
     Logger::logln("MAIN", "Mesh init failed", LogLevel::LOG_ERROR);
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::MESH,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::MESH,
                           1,
                           "MAIN: Mesh init failed — cannot operate without mesh");
   }
@@ -249,7 +249,7 @@ void setup() {
   // The private key is NEVER printed — only the public key is output here.
   if (!mesh.isEnrolled()) {
     const uint8_t* pubKey = mesh.getDevicePublicKey();
-    Serial.print("PLANETOPIA_PUBKEY:");
+    Serial.print("LATTICE_PUBKEY:");
     for (int i = 0; i < 32; ++i) {
       if (pubKey[i] < 0x10) Serial.print("0");
       Serial.print(pubKey[i], HEX);
@@ -277,7 +277,7 @@ void setup() {
   Logger::logln("MESH", "Mesh initialized", LogLevel::LOG_INFO);
   Logger::logln("MAIN", String("Booted as: ") + (isMaster ? "MASTER" : "NODE"), LogLevel::LOG_INFO);
 
-  adapter->setTransmitFn(&planetopia::mesh::Mesh::transmit);
+  adapter->setTransmitFn(&lattice::mesh::Mesh::transmit);
 
   mesh.linkDataRecvCallback(dataRecvCallback);
 
@@ -296,7 +296,7 @@ void setup() {
 }
 
 void loop() {
-  planetopia::utils::ErrorCore::getInstance().drainPendingBlink();
+  lattice::utils::ErrorCore::getInstance().drainPendingBlink();
 
   static bool startupBlinkDone = false;
   if (!startupBlinkDone) {
@@ -310,12 +310,12 @@ void loop() {
   mesh.checkMasterTimeout();
 
   // Display state machine: show node identity on 7-segment display
-  if (planetopia::config::ENABLE_SEVSEG_DISPLAY) {
+  if (lattice::config::ENABLE_SEVSEG_DISPLAY) {
     static uint32_t lastDisplayToggleMs = 0;
     static bool dashVisible = false;
 
     bool enrolled = mesh.isEnrolled() || mesh.getIsMaster(); // master is always "enrolled"
-    uint8_t nodeId = planetopia::utils::EEPROM_Manager::getInstance().loadNodeId();
+    uint8_t nodeId = lattice::utils::EEPROM_Manager::getInstance().loadNodeId();
 
     if (!enrolled) {
       // Unenrolled: flash "----" at 500ms

--- a/main/project_config.h
+++ b/main/project_config.h
@@ -5,7 +5,7 @@
 #include "src/core/Logger.h"
 #include "src/Adapter/Adapter.h"
 
-namespace planetopia {
+namespace lattice {
 namespace config {
 
 // =====================
@@ -24,7 +24,7 @@ constexpr bool DEFAULT_DEV_MASTER = true;
 // =====================
 // Adapter instantiated on first boot or in DEV_MODE
 // IMPORTANT: For server communication via USB, MUST be SERIAL_ADAPTER
-constexpr planetopia::adapter::adapter_types DEFAULT_ADAPTER = planetopia::adapter::adapter_types::SERIAL_ADAPTER;
+constexpr lattice::adapter::adapter_types DEFAULT_ADAPTER = lattice::adapter::adapter_types::SERIAL_ADAPTER;
 // Primary mesh-beacon interval (milliseconds)
 constexpr unsigned long MASTER_BEACON_INTERVAL_MS = 3000;
 // Stale-master threshold: node clears master route after this many ms without a beacon (3× interval)
@@ -81,7 +81,7 @@ constexpr int NUM_DEFAULT_PEERS = sizeof(DEFAULT_PEERS) / sizeof(DEFAULT_PEERS[0
 // =====================
 // CRITICAL: For server communication, MUST be LOG_NONE to prevent text output
 // Only enable logging (LOG_DEBUG, LOG_INFO, etc.) for development/debugging
-constexpr planetopia::utils::LogLevel DEFAULT_LOG_LEVEL = planetopia::utils::LogLevel::LOG_NONE;
+constexpr lattice::utils::LogLevel DEFAULT_LOG_LEVEL = lattice::utils::LogLevel::LOG_NONE;
 
 // =====================
 // 7. TX Power Presets
@@ -122,6 +122,6 @@ constexpr uint32_t HEALTH_REPORT_INTERVAL_MS = 30000;
 // Future limits (message queue, buffer sizes, etc.) can be centralized here
 
 } // namespace config
-} // namespace planetopia
+} // namespace lattice
 
 #endif // PROJECT_CONFIG_H

--- a/main/src/Adapter/Adapter.cpp
+++ b/main/src/Adapter/Adapter.cpp
@@ -28,9 +28,8 @@ void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[6
     mesh_transmit_fn(type, data);
     Logger::logln("Adapter", "Data sent through mesh", LogLevel::LOG_DEBUG);
   } else {
-    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                          lattice::core::ModuleDigit::ADAPTER, 1,
-                          "Adapter: Transmit function not set");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
+                       1, "Adapter: Transmit function not set");
   }
 }
 

--- a/main/src/Adapter/Adapter.cpp
+++ b/main/src/Adapter/Adapter.cpp
@@ -5,14 +5,14 @@
 #include "src/Adapter/AdapterFactory.h"
 #include "src/Adapter/Serial_Adapter/Serial_Adapter.h"
 #include "src/persistence/EEPROM_Manager.h"
-#include "lib/planetopia-protocol/c/opcodes.h"
+#include "lib/lattice-protocol/c/opcodes.h"
 #include <esp_wifi.h>
 #include <cstring>
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 Adapter::Adapter(int pin)
     : _pin(pin), _adapterType(adapter_types::UNKNOWN_ADAPTER), mesh_transmit_fn(nullptr) {
@@ -28,8 +28,8 @@ void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[6
     mesh_transmit_fn(type, data);
     Logger::logln("Adapter", "Data sent through mesh", LogLevel::LOG_DEBUG);
   } else {
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                          planetopia::core::ModuleDigit::ADAPTER, 1,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                          lattice::core::ModuleDigit::ADAPTER, 1,
                           "Adapter: Transmit function not set");
   }
 }
@@ -39,11 +39,11 @@ void Adapter::setTransmitFn(TransmitPtr fn) {
   Logger::logln("Adapter", "Transmit function assigned", LogLevel::LOG_DEBUG);
 }
 
-void Adapter::onMeshData(const planetopia::mesh::mesh_message& message) {
+void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
   // Handle OP_CONFIG_SET for ALL adapter types — server can reconfigure any node.
   // This must run in the base class so virtual dispatch to per-type no-ops cannot
   // swallow the opcode on PIR/LED/WiFi nodes.
-  // OP_CONFIG_SET = 0xC1 (from lib/planetopia-protocol/opcodes.h)
+  // OP_CONFIG_SET = 0xC1 (from lib/lattice-protocol/opcodes.h)
   if (message.dataType == adapter_types::SERIAL_ADAPTER) {
     const uint8_t op = message.data[0];
     if (op == OP_CONFIG_SET) {
@@ -60,8 +60,8 @@ void Adapter::onMeshData(const planetopia::mesh::mesh_message& message) {
       bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
       if (isTarget) {
         adapter_types newType =
-            planetopia::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
-        planetopia::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
+            lattice::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
+        lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
         Logger::logln("ADAPTER", "CONFIG_SET received, restarting with new adapter type",
                       LogLevel::LOG_INFO);
         ESP.restart();
@@ -83,7 +83,7 @@ void Adapter::onMeshData(const planetopia::mesh::mesh_message& message) {
       bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
       if (isTarget) {
         uint8_t nodeId = message.data[7];
-        planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+        lattice::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
         Logger::logln("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
       }
     }
@@ -138,7 +138,7 @@ void Adapter::onMeshData(const planetopia::mesh::mesh_message& message) {
   onMeshDataImpl(message);
 }
 
-void Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& /*message*/) {
+void Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& /*message*/) {
   // Default no-op in base; subclasses optionally override
 }
 
@@ -147,4 +147,4 @@ bool Adapter::init() {
 }
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/Adapter/Adapter.h
+++ b/main/src/Adapter/Adapter.h
@@ -4,13 +4,13 @@
 #include <Arduino.h>
 
 // Forward declaration to avoid circular include with Mesh
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 struct mesh_message;
 }
-} // namespace planetopia
+} // namespace lattice
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 // Enum for identifying adapter types
@@ -46,13 +46,13 @@ public:
   // Handles OP_CONFIG_SET (SERIAL_ADAPTER dataType) for ALL node types in the base class
   // so that any node can be reconfigured regardless of its current adapter type.
   // For all other message types, filters by adapter type before dispatching to onMeshDataImpl().
-  void onMeshData(const planetopia::mesh::mesh_message& message);
+  void onMeshData(const lattice::mesh::mesh_message& message);
 
 protected:
   // Implement in subclasses: only called when message.dataType == this adapter's type
-  virtual void onMeshDataImpl(const planetopia::mesh::mesh_message& message);
+  virtual void onMeshDataImpl(const lattice::mesh::mesh_message& message);
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/Adapter/Adapter.h
+++ b/main/src/Adapter/Adapter.h
@@ -28,7 +28,7 @@ class Adapter {
 protected:
   int _pin;                   // Hardware pin associated with the adapter
   adapter_types _adapterType; // Type identifier for the adapter
-  typedef void (*TransmitPtr)(adapter_types, const uint8_t[64]);
+  typedef void (*TransmitPtr)(adapter_types, const uint8_t*);
   TransmitPtr mesh_transmit_fn;
 
 public:

--- a/main/src/Adapter/AdapterFactory.cpp
+++ b/main/src/Adapter/AdapterFactory.cpp
@@ -31,9 +31,8 @@ Adapter* AdapterFactory::createAdapter(adapter_types type, int pin) {
     return new Serial_Adapter(pin);
 
   default:
-    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                          lattice::core::ModuleDigit::ADAPTER, 2,
-                          "AdapterFactory: Unknown adapter type");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
+                       2, "AdapterFactory: Unknown adapter type");
     Logger::logln("Factory", "Error: Unknown adapter type", LogLevel::LOG_ERROR);
     return nullptr;
   }

--- a/main/src/Adapter/AdapterFactory.cpp
+++ b/main/src/Adapter/AdapterFactory.cpp
@@ -6,10 +6,10 @@
 #include "src/Adapter/PIR_Adapter/PIR_Adapter.h"
 #include "src/Adapter/Serial_Adapter/Serial_Adapter.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 // Initialize class static member
 bool AdapterFactory::isDevMode_ = false;
@@ -31,8 +31,8 @@ Adapter* AdapterFactory::createAdapter(adapter_types type, int pin) {
     return new Serial_Adapter(pin);
 
   default:
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                          planetopia::core::ModuleDigit::ADAPTER, 2,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                          lattice::core::ModuleDigit::ADAPTER, 2,
                           "AdapterFactory: Unknown adapter type");
     Logger::logln("Factory", "Error: Unknown adapter type", LogLevel::LOG_ERROR);
     return nullptr;
@@ -103,4 +103,4 @@ int AdapterFactory::getDefaultPinForAdapter(adapter_types type) {
 }
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/Adapter/AdapterFactory.h
+++ b/main/src/Adapter/AdapterFactory.h
@@ -4,7 +4,7 @@
 #include "Adapter.h"
 #include <Arduino.h>
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 // Default pins for each adapter type
@@ -44,5 +44,5 @@ private:
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
+++ b/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
@@ -28,9 +28,8 @@ bool PIR_Adapter::init() {
   }
 
   if (!_pir.init()) {
-    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                          lattice::core::ModuleDigit::ADAPTER, 1,
-                          "PIR_Adapter: PIR hardware failed to initialize.");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
+                       1, "PIR_Adapter: PIR hardware failed to initialize.");
     return false;
   }
 
@@ -109,8 +108,8 @@ void PIR_Adapter::loop() {
 
     if (!_pir.attachInterrupt(PIR_Adapter::detectMotionTrampoline, RISING)) {
       lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                            lattice::core::ModuleDigit::ADAPTER, 2,
-                            "PIR_Adapter: Could not re-attach interrupt (possible hardware error)");
+                         lattice::core::ModuleDigit::ADAPTER, 2,
+                         "PIR_Adapter: Could not re-attach interrupt (possible hardware error)");
       return;
     }
     _interruptEnabled = true;

--- a/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
+++ b/main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp
@@ -1,5 +1,5 @@
 #include "PIR_Adapter.h"
-#include "lib/planetopia-protocol/c/opcodes.h"
+#include "lib/lattice-protocol/c/opcodes.h"
 #include <cstdint>
 #include <cstring>
 #include "src/core/Logger.h"
@@ -8,10 +8,10 @@
 #include "src/Adapter/AdapterFactory.h"
 #include <esp_wifi.h>
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 PIR_Adapter* PIR_Adapter::instance = nullptr;
 
@@ -28,8 +28,8 @@ bool PIR_Adapter::init() {
   }
 
   if (!_pir.init()) {
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                          planetopia::core::ModuleDigit::ADAPTER, 1,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                          lattice::core::ModuleDigit::ADAPTER, 1,
                           "PIR_Adapter: PIR hardware failed to initialize.");
     return false;
   }
@@ -108,21 +108,21 @@ void PIR_Adapter::loop() {
     _motionSent = false;
 
     if (!_pir.attachInterrupt(PIR_Adapter::detectMotionTrampoline, RISING)) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::ADAPTER, 2,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::ADAPTER, 2,
                             "PIR_Adapter: Could not re-attach interrupt (possible hardware error)");
       return;
     }
     _interruptEnabled = true;
   }
 
-  if (now - _lastHealthMillis >= planetopia::config::HEALTH_REPORT_INTERVAL_MS) {
+  if (now - _lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
     _lastHealthMillis = now;
     sendNodeHealth();
   }
 }
 
-void PIR_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& /*message*/) {
+void PIR_Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& /*message*/) {
   // No-op for PIR: currently nothing to do on inbound messages of this type
 }
 
@@ -135,4 +135,4 @@ void PIR_Adapter::simulateMotion() {
 #endif
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/Adapter/PIR_Adapter/PIR_Adapter.h
+++ b/main/src/Adapter/PIR_Adapter/PIR_Adapter.h
@@ -5,7 +5,7 @@
 #include "src/hardware/input/Pir.h"
 #include <cstdint>
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 class PIR_Adapter : public Adapter {
@@ -13,7 +13,7 @@ public:
   explicit PIR_Adapter(int pin);
   bool init() override;
   void loop() override;
-  void onMeshDataImpl(const planetopia::mesh::mesh_message& message) override;
+  void onMeshDataImpl(const lattice::mesh::mesh_message& message) override;
 
   // Trampoline for interrupt (must be static):
   static void detectMotionTrampoline();
@@ -43,6 +43,6 @@ private:
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
+++ b/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
@@ -10,10 +10,10 @@
 #include "src/Adapter/PIR_Adapter/PIR_Adapter.h"
 #endif
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 uint32_t Serial_Adapter::lastHealthMillis = 0;
 
@@ -45,14 +45,14 @@ void Serial_Adapter::sendHealthReport() {
                     " Uptime: " + String(uptimeSec) + "s",
                 LogLevel::LOG_DEBUG);
 
-  if (planetopia::mesh::Mesh::transmit) {
-    planetopia::mesh::Mesh::transmit(adapter_types::SERIAL_ADAPTER, data);
+  if (lattice::mesh::Mesh::transmit) {
+    lattice::mesh::Mesh::transmit(adapter_types::SERIAL_ADAPTER, data);
     Logger::logln("Serial_Adapter", "Health report sent via mesh", LogLevel::LOG_DEBUG);
   } else {
     Logger::logln("Serial_Adapter", "Mesh transmit function not available for health report",
                   LogLevel::LOG_WARN);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::ADAPTER, 1,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::ADAPTER, 1,
                           "Serial_Adapter: Mesh transmit not available");
   }
 }
@@ -75,12 +75,12 @@ bool Serial_Adapter::init() {
 
 void Serial_Adapter::loop() {
   // Health report: send periodically every 30s, or immediately on hop count change
-  planetopia::mesh::Mesh* meshPtr = planetopia::mesh::Mesh::getInstance();
+  lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
   uint32_t currentHopCount = meshPtr ? meshPtr->getHopCount() : 0;
   bool stateChanged = (currentHopCount != lastReportedHopCount);
 
   if (stateChanged ||
-      millis() - lastHealthMillis >= planetopia::config::HEALTH_REPORT_INTERVAL_MS) {
+      millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
     lastHealthMillis = static_cast<uint32_t>(millis());
     Logger::logln("Serial_Adapter",
                   String(stateChanged ? "Health report triggered by state change (hopCount: "
@@ -105,8 +105,8 @@ void Serial_Adapter::loop() {
 
       if (frameLength == 0 || frameLength > MAX_PAYLOAD) {
         Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
-        planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                              planetopia::core::ModuleDigit::ADAPTER, 2,
+        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                              lattice::core::ModuleDigit::ADAPTER, 2,
                               "Serial_Adapter: Invalid frame length");
         // Reset on invalid length
         frameState = FrameState::AwaitingLen1;
@@ -121,8 +121,8 @@ void Serial_Adapter::loop() {
     case FrameState::AwaitingPayload:
       if (frameIndex >= MAX_PAYLOAD) {
         Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
-        planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                              planetopia::core::ModuleDigit::ADAPTER, 3,
+        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                              lattice::core::ModuleDigit::ADAPTER, 3,
                               "Serial_Adapter: Frame buffer overflow");
         frameState = FrameState::AwaitingLen1;
         frameLength = 0;
@@ -144,7 +144,7 @@ void Serial_Adapter::loop() {
   }
 }
 
-void Serial_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& message) {
+void Serial_Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
   Logger::logln("Serial_Adapter",
                 "Processing incoming mesh message - Type: " + String((uint8_t)message.messageType) +
                     " DataType: " + String(static_cast<int32_t>(message.dataType)) +
@@ -166,10 +166,10 @@ void Serial_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& messag
         Logger::logln("Serial_Adapter", "Invalid TX power preset from mesh, ignoring",
                       LogLevel::LOG_WARN);
       } else {
-        auto preset = static_cast<planetopia::config::TxPowerPreset>(presetByte);
+        auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
         EEPROM_Manager::getInstance().saveTxPowerPreset(preset);
         esp_err_t txErr = esp_wifi_set_max_tx_power(
-            static_cast<int8_t>(planetopia::config::TX_POWER_VALUES[presetByte]));
+            static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
           Logger::logln("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
                         LogLevel::LOG_WARN);
@@ -187,8 +187,8 @@ void Serial_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& messag
   if (n == 0) {
     Logger::logln("Serial_Adapter", "Failed to encode mesh message for serial output",
                   LogLevel::LOG_ERROR);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::ADAPTER, 4,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::ADAPTER, 4,
                           "Serial_Adapter: Message encoding failed");
     return;
   }
@@ -205,7 +205,7 @@ void Serial_Adapter::onMeshDataImpl(const planetopia::mesh::mesh_message& messag
   Logger::logln("Serial_Adapter", "Mesh message sent to serial successfully", LogLevel::LOG_DEBUG);
 }
 
-size_t Serial_Adapter::encodeMeshMessage(const planetopia::mesh::mesh_message& msg, uint8_t* out,
+size_t Serial_Adapter::encodeMeshMessage(const lattice::mesh::mesh_message& msg, uint8_t* out,
                                          size_t outCap) {
   Logger::logln("Serial_Adapter",
                 "Encoding mesh message - Type: " + String((uint8_t)msg.messageType) +
@@ -230,8 +230,8 @@ size_t Serial_Adapter::encodeMeshMessage(const planetopia::mesh::mesh_message& m
   memcpy(pbMsg.data.bytes, msg.data, sizeof(msg.data));
 
   // public_key: only encode for enrollment-related message types when non-zero
-  if (msg.messageType == planetopia::mesh::MeshMessageType::MESH_TYPE_ENROLLMENT ||
-      msg.messageType == planetopia::mesh::MeshMessageType::MESH_TYPE_JOIN_ACK) {
+  if (msg.messageType == lattice::mesh::MeshMessageType::MESH_TYPE_ENROLLMENT ||
+      msg.messageType == lattice::mesh::MeshMessageType::MESH_TYPE_JOIN_ACK) {
     bool nonZero = false;
     for (int i = 0; i < 32; ++i) {
       if (msg.enrollmentPublicKey[i]) {
@@ -259,7 +259,7 @@ size_t Serial_Adapter::encodeMeshMessage(const planetopia::mesh::mesh_message& m
 }
 
 bool Serial_Adapter::decodeMeshMessage(const uint8_t* data, size_t len,
-                                       planetopia::mesh::mesh_message& outMsg) {
+                                       lattice::mesh::mesh_message& outMsg) {
   Logger::logln("Serial_Adapter", "Decoding protobuf message of " + String(len) + " bytes",
                 LogLevel::LOG_DEBUG);
 
@@ -272,8 +272,8 @@ bool Serial_Adapter::decodeMeshMessage(const uint8_t* data, size_t len,
     return false;
   }
 
-  outMsg.messageType = static_cast<planetopia::mesh::MeshMessageType>(pbMsg.messageType);
-  outMsg.dataType = static_cast<planetopia::adapter::adapter_types>(pbMsg.dataType);
+  outMsg.messageType = static_cast<lattice::mesh::MeshMessageType>(pbMsg.messageType);
+  outMsg.dataType = static_cast<lattice::adapter::adapter_types>(pbMsg.dataType);
   outMsg.hopCount = static_cast<uint8_t>(pbMsg.hopCount);
   outMsg.epochNum = pbMsg.epochNum;
   outMsg.seqNum = static_cast<uint16_t>(pbMsg.seqNum);
@@ -293,8 +293,8 @@ bool Serial_Adapter::decodeMeshMessage(const uint8_t* data, size_t len,
   // fields on the wire are meaningful and must not be overwritten.
   // For device-originated relays (ADAPTER_DATA, MASTER_BEACON) the server
   // leaves routing fields blank, so we fill them in with our own MAC.
-  if (outMsg.messageType != planetopia::mesh::MESH_TYPE_JOIN_ACK &&
-      outMsg.messageType != planetopia::mesh::MESH_TYPE_SERIAL_CMD_BROADCAST) {
+  if (outMsg.messageType != lattice::mesh::MESH_TYPE_JOIN_ACK &&
+      outMsg.messageType != lattice::mesh::MESH_TYPE_SERIAL_CMD_BROADCAST) {
     readOwnMac(outMsg.originMacAddress);
     readOwnMac(outMsg.lastHopMacAddress);
   } else {
@@ -307,8 +307,8 @@ bool Serial_Adapter::decodeMeshMessage(const uint8_t* data, size_t len,
 }
 
 void Serial_Adapter::relayEnrollmentToServer(const uint8_t mac[6], const uint8_t pubKey[32]) {
-  planetopia::mesh::mesh_message msg = {};
-  msg.messageType = planetopia::mesh::MeshMessageType::MESH_TYPE_ENROLLMENT;
+  lattice::mesh::mesh_message msg = {};
+  msg.messageType = lattice::mesh::MeshMessageType::MESH_TYPE_ENROLLMENT;
   msg.protoVersion = 1;
   memcpy(msg.originMacAddress, mac, 6);
   memcpy(msg.enrollmentPublicKey, pubKey, 32);
@@ -336,32 +336,32 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     uint8_t op = data[0];
     if (op == OP_SIM_PIR_TRIGGER) {
       Logger::logln("SIM", "Injecting fake PIR event", LogLevel::LOG_WARN);
-      planetopia::adapter::PIR_Adapter* pirAdapter =
-          planetopia::adapter::PIR_Adapter::getInstance();
+      lattice::adapter::PIR_Adapter* pirAdapter =
+          lattice::adapter::PIR_Adapter::getInstance();
       if (pirAdapter)
         pirAdapter->simulateMotion();
       return;
 
     } else if (op == OP_SIM_FAKE_BEACON && len >= 13) {
       Logger::logln("SIM", "Injecting fake master beacon", LogLevel::LOG_WARN);
-      planetopia::mesh::mesh_message fakeBeacon{};
-      fakeBeacon.protoVersion = planetopia::mesh::PROTO_VERSION;
-      fakeBeacon.messageType = planetopia::mesh::MESH_TYPE_MASTER_BEACON;
+      lattice::mesh::mesh_message fakeBeacon{};
+      fakeBeacon.protoVersion = lattice::mesh::PROTO_VERSION;
+      fakeBeacon.messageType = lattice::mesh::MESH_TYPE_MASTER_BEACON;
       memcpy(fakeBeacon.originMacAddress, &data[1], 6);
       memcpy(&fakeBeacon.epochNum, &data[7], 4);
       memcpy(&fakeBeacon.seqNum, &data[11], 2);
-      planetopia::mesh::Mesh* meshRef = planetopia::mesh::Mesh::getInstance();
+      lattice::mesh::Mesh* meshRef = lattice::mesh::Mesh::getInstance();
       if (meshRef)
         meshRef->injectReceivedMessage(fakeBeacon.originMacAddress, fakeBeacon);
       return;
 
     } else if (op == OP_SIM_DUMP_STATE) {
       Logger::logln("SIM", "=== Mesh State Dump ===", LogLevel::LOG_WARN);
-      planetopia::mesh::Mesh* meshRef = planetopia::mesh::Mesh::getInstance();
+      lattice::mesh::Mesh* meshRef = lattice::mesh::Mesh::getInstance();
       if (meshRef) {
         meshRef->debugDumpRadio();
         for (size_t i = 0; i < meshRef->getPeerCount(); ++i) {
-          const planetopia::mesh::PeerInfo& p = meshRef->getPeerList()[i];
+          const lattice::mesh::PeerInfo& p = meshRef->getPeerList()[i];
           Serial.printf("  Peer[%d]: %02X:%02X:%02X:%02X:%02X:%02X last=%lums\n", (int)i, p.mac[0],
                         p.mac[1], p.mac[2], p.mac[3], p.mac[4], p.mac[5],
                         (unsigned long)p.lastSeenMillis);
@@ -372,11 +372,11 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
   }
 #endif
 
-  planetopia::mesh::mesh_message msg;
+  lattice::mesh::mesh_message msg;
   if (!decodeMeshMessage(data, len, msg)) {
     Logger::logln("Serial_Adapter", "Failed to decode protobuf frame", LogLevel::LOG_ERROR);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::ADAPTER, 5,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::ADAPTER, 5,
                           "Serial_Adapter: Failed to decode protobuf frame");
     return;
   }
@@ -387,7 +387,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
                 LogLevel::LOG_INFO);
 
   // JOIN_ACK (type=4): server responded to an enrollment request
-  if (msg.messageType == planetopia::mesh::MeshMessageType::MESH_TYPE_JOIN_ACK) {
+  if (msg.messageType == lattice::mesh::MeshMessageType::MESH_TYPE_JOIN_ACK) {
     bool hasKey = false;
     for (int i = 0; i < 32; ++i) {
       if (msg.enrollmentPublicKey[i]) {
@@ -398,7 +398,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     if (hasKey) {
       Logger::logln("Serial_Adapter", "Server approved enrollment, registering peer",
                     LogLevel::LOG_INFO);
-      planetopia::mesh::Mesh* meshInstance = planetopia::mesh::Mesh::getInstance();
+      lattice::mesh::Mesh* meshInstance = lattice::mesh::Mesh::getInstance();
       if (meshInstance) {
         meshInstance->enrollPeer(msg.targetMacAddress, msg.enrollmentPublicKey);
       }
@@ -409,7 +409,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
   }
 
   // Only forward adapter data via mesh transmit function; routing fields are managed by Mesh
-  if (msg.messageType == planetopia::mesh::MESH_TYPE_ADAPTER_DATA) {
+  if (msg.messageType == lattice::mesh::MESH_TYPE_ADAPTER_DATA) {
     Logger::logln("Serial_Adapter", "Forwarding adapter data via mesh transmit",
                   LogLevel::LOG_DEBUG);
 
@@ -419,14 +419,14 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       Logger::logln("Serial_Adapter", "Adapter data forwarded successfully", LogLevel::LOG_DEBUG);
     } else {
       Logger::logln("Serial_Adapter", "transmit function not set", LogLevel::LOG_ERROR);
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                            planetopia::core::ModuleDigit::ADAPTER, 6,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                            lattice::core::ModuleDigit::ADAPTER, 6,
                             "Serial_Adapter: transmit function not set");
     }
-  } else if (msg.messageType == planetopia::mesh::MESH_TYPE_SERIAL_CMD_BROADCAST) {
+  } else if (msg.messageType == lattice::mesh::MESH_TYPE_SERIAL_CMD_BROADCAST) {
     Logger::logln("Serial_Adapter", "Broadcasting adapter data to all peers", LogLevel::LOG_DEBUG);
     // Broadcast adapter data to all peers
-    planetopia::mesh::Mesh::broadcastAdapterDataStatic(msg.dataType, msg.data);
+    lattice::mesh::Mesh::broadcastAdapterDataStatic(msg.dataType, msg.data);
     Logger::logln("Serial_Adapter", "Broadcast sent successfully", LogLevel::LOG_DEBUG);
   } else {
     Logger::logln("Serial_Adapter", "Unknown message type: " + String(msg.messageType),
@@ -465,7 +465,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
                           String(static_cast<int32_t>(newType)),
                       LogLevel::LOG_INFO);
 
-        planetopia::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
+        lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
         Logger::logln("Serial_Adapter", "Adapter type saved to EEPROM successfully",
                       LogLevel::LOG_INFO);
         // Pin is automatically inferred from adapter type - no need to store it
@@ -484,10 +484,10 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       if (presetByte > 2) {
         Logger::logln("Serial_Adapter", "Invalid TX power preset, ignoring", LogLevel::LOG_WARN);
       } else {
-        auto preset = static_cast<planetopia::config::TxPowerPreset>(presetByte);
+        auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
         EEPROM_Manager::getInstance().saveTxPowerPreset(preset);
         esp_err_t txErr = esp_wifi_set_max_tx_power(
-            static_cast<int8_t>(planetopia::config::TX_POWER_VALUES[presetByte]));
+            static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
           Logger::logln("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
                         LogLevel::LOG_WARN);
@@ -496,13 +496,13 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
         }
 
         // Broadcast to all enrolled nodes so entire mesh updates
-        planetopia::mesh::Mesh* meshPtr = planetopia::mesh::Mesh::getInstance();
+        lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
         bool isMasterNode = meshPtr && meshPtr->getIsMaster();
         if (isMasterNode) {
           uint8_t fwdData[12] = {};
           fwdData[0] = OP_TX_POWER_SET;
           fwdData[1] = presetByte;
-          planetopia::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER,
+          lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER,
                                                              fwdData);
           Logger::logln("Serial_Adapter", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
         }
@@ -520,7 +520,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       bool isTarget = allFF || (memcmp(&msg.data[1], myMac, 6) == 0);
       if (isTarget) {
         uint8_t nodeId = msg.data[7];
-        planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+        lattice::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
         Logger::logln("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
       }
     } else {
@@ -576,4 +576,4 @@ bool Serial_Adapter::injectByte(uint8_t byteIn) {
 #endif
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
+++ b/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
@@ -51,9 +51,8 @@ void Serial_Adapter::sendHealthReport() {
   } else {
     Logger::logln("Serial_Adapter", "Mesh transmit function not available for health report",
                   LogLevel::LOG_WARN);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                          lattice::core::ModuleDigit::ADAPTER, 1,
-                          "Serial_Adapter: Mesh transmit not available");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER, 1,
+                       "Serial_Adapter: Mesh transmit not available");
   }
 }
 
@@ -79,8 +78,7 @@ void Serial_Adapter::loop() {
   uint32_t currentHopCount = meshPtr ? meshPtr->getHopCount() : 0;
   bool stateChanged = (currentHopCount != lastReportedHopCount);
 
-  if (stateChanged ||
-      millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
+  if (stateChanged || millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
     lastHealthMillis = static_cast<uint32_t>(millis());
     Logger::logln("Serial_Adapter",
                   String(stateChanged ? "Health report triggered by state change (hopCount: "
@@ -105,9 +103,8 @@ void Serial_Adapter::loop() {
 
       if (frameLength == 0 || frameLength > MAX_PAYLOAD) {
         Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
-        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                              lattice::core::ModuleDigit::ADAPTER, 2,
-                              "Serial_Adapter: Invalid frame length");
+        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER,
+                           2, "Serial_Adapter: Invalid frame length");
         // Reset on invalid length
         frameState = FrameState::AwaitingLen1;
         frameLength = 0;
@@ -121,9 +118,8 @@ void Serial_Adapter::loop() {
     case FrameState::AwaitingPayload:
       if (frameIndex >= MAX_PAYLOAD) {
         Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
-        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                              lattice::core::ModuleDigit::ADAPTER, 3,
-                              "Serial_Adapter: Frame buffer overflow");
+        lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER,
+                           3, "Serial_Adapter: Frame buffer overflow");
         frameState = FrameState::AwaitingLen1;
         frameLength = 0;
         frameIndex = 0;
@@ -187,9 +183,8 @@ void Serial_Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) 
   if (n == 0) {
     Logger::logln("Serial_Adapter", "Failed to encode mesh message for serial output",
                   LogLevel::LOG_ERROR);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                          lattice::core::ModuleDigit::ADAPTER, 4,
-                          "Serial_Adapter: Message encoding failed");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER, 4,
+                       "Serial_Adapter: Message encoding failed");
     return;
   }
 
@@ -336,8 +331,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     uint8_t op = data[0];
     if (op == OP_SIM_PIR_TRIGGER) {
       Logger::logln("SIM", "Injecting fake PIR event", LogLevel::LOG_WARN);
-      lattice::adapter::PIR_Adapter* pirAdapter =
-          lattice::adapter::PIR_Adapter::getInstance();
+      lattice::adapter::PIR_Adapter* pirAdapter = lattice::adapter::PIR_Adapter::getInstance();
       if (pirAdapter)
         pirAdapter->simulateMotion();
       return;
@@ -375,9 +369,8 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
   lattice::mesh::mesh_message msg;
   if (!decodeMeshMessage(data, len, msg)) {
     Logger::logln("Serial_Adapter", "Failed to decode protobuf frame", LogLevel::LOG_ERROR);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                          lattice::core::ModuleDigit::ADAPTER, 5,
-                          "Serial_Adapter: Failed to decode protobuf frame");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER, 5,
+                       "Serial_Adapter: Failed to decode protobuf frame");
     return;
   }
 
@@ -419,9 +412,8 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       Logger::logln("Serial_Adapter", "Adapter data forwarded successfully", LogLevel::LOG_DEBUG);
     } else {
       Logger::logln("Serial_Adapter", "transmit function not set", LogLevel::LOG_ERROR);
-      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                            lattice::core::ModuleDigit::ADAPTER, 6,
-                            "Serial_Adapter: transmit function not set");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
+                         6, "Serial_Adapter: transmit function not set");
     }
   } else if (msg.messageType == lattice::mesh::MESH_TYPE_SERIAL_CMD_BROADCAST) {
     Logger::logln("Serial_Adapter", "Broadcasting adapter data to all peers", LogLevel::LOG_DEBUG);
@@ -502,8 +494,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           uint8_t fwdData[12] = {};
           fwdData[0] = OP_TX_POWER_SET;
           fwdData[1] = presetByte;
-          lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER,
-                                                             fwdData);
+          lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER, fwdData);
           Logger::logln("Serial_Adapter", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
         }
       }

--- a/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
+++ b/main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
@@ -491,7 +491,7 @@ void Serial_Adapter::handleCompleteFrame(const uint8_t* data, size_t len) {
         lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
         bool isMasterNode = meshPtr && meshPtr->getIsMaster();
         if (isMasterNode) {
-          uint8_t fwdData[12] = {};
+          uint8_t fwdData[64] = {};
           fwdData[0] = OP_TX_POWER_SET;
           fwdData[1] = presetByte;
           lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER, fwdData);

--- a/main/src/Adapter/Serial_Adapter/Serial_Adapter.h
+++ b/main/src/Adapter/Serial_Adapter/Serial_Adapter.h
@@ -6,11 +6,11 @@
 #include "src/Mesh/serialization/nanopb/pb_encode.h"
 #include "src/Mesh/serialization/nanopb/pb_decode.h"
 #include "src/Mesh/serialization/mesh.pb.h"
-// Shared protocol constants — source of truth is planetopia-protocol repo (git submodule)
-#include "lib/planetopia-protocol/c/opcodes.h"
-#include "lib/planetopia-protocol/c/adapter_types.h"
+// Shared protocol constants — source of truth is lattice-protocol repo (git submodule)
+#include "lib/lattice-protocol/c/opcodes.h"
+#include "lib/lattice-protocol/c/adapter_types.h"
 
-namespace planetopia {
+namespace lattice {
 namespace adapter {
 
 class Serial_Adapter : public Adapter {
@@ -19,9 +19,9 @@ public:
 
   bool init() override;
   void loop() override;
-  void onMeshDataImpl(const planetopia::mesh::mesh_message& message) override;
+  void onMeshDataImpl(const lattice::mesh::mesh_message& message) override;
 
-  // Opcodes from planetopia-protocol/opcodes.h (included above):
+  // Opcodes from lattice-protocol/opcodes.h (included above):
   //   OP_HEALTH_REQ    0xB0  [B0]
   //   OP_HEALTH_REPORT 0xB1  [B1][1B adapterType][6B mac][4B uptime]
   //   OP_NODE_HEALTH   0xB2  [B2][1B adapterType][6B mac][4B uptime]
@@ -57,12 +57,12 @@ private:
   static constexpr size_t MAX_PAYLOAD = 256;
   uint8_t payloadBuffer[MAX_PAYLOAD];
 
-  static size_t encodeMeshMessage(const planetopia::mesh::mesh_message& msg, uint8_t* out,
+  static size_t encodeMeshMessage(const lattice::mesh::mesh_message& msg, uint8_t* out,
                                   size_t outCap);
   static bool decodeMeshMessage(const uint8_t* data, size_t len,
-                                planetopia::mesh::mesh_message& outMsg);
+                                lattice::mesh::mesh_message& outMsg);
   void handleCompleteFrame(const uint8_t* data, size_t len);
-  // Interpret messageType for Serial control (uses planetopia::mesh::MeshMessageType):
+  // Interpret messageType for Serial control (uses lattice::mesh::MeshMessageType):
   // MESH_TYPE_ADAPTER_DATA (0)         : targeted send via normal mesh transmit (to master)
   // MESH_TYPE_SERIAL_CMD_BROADCAST (3) : broadcast adapter data via mesh (server→device)
   // MESH_TYPE_JOIN_ACK (4)             : server approved or rejected enrollment (server→device)
@@ -85,6 +85,6 @@ private:
 };
 
 } // namespace adapter
-} // namespace planetopia
+} // namespace lattice
 
 #endif // SERIAL_ADAPTER_H

--- a/main/src/Mesh/Mesh.cpp
+++ b/main/src/Mesh/Mesh.cpp
@@ -8,24 +8,24 @@
 #include <WiFi.h>
 #include <cstring>
 #include "../../project_config.h"
-#include "lib/planetopia-protocol/c/opcodes.h"
+#include "lib/lattice-protocol/c/opcodes.h"
 #include <mbedtls/ecdh.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecp.h>
 #include <mbedtls/sha256.h>
 
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 Mesh* Mesh::instance = nullptr;
 
 // no longer need macEquals helper – use MacAddress equality directly
 
 // Derive a 16-byte LMK for a peer using ECDH + SHA256.
-// LMK = SHA256(ECDH_shared_secret || "planetopia-lmk")[0:16]
+// LMK = SHA256(ECDH_shared_secret || "lattice-lmk")[0:16]
 static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
                           uint8_t* lmk16Out) {
   mbedtls_ecdh_context ecdh;
@@ -37,19 +37,19 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
 
   int ret = 0;
 
-  const char* pers = "planetopia_ecdh";
+  const char* pers = "lattice_ecdh";
   ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                               reinterpret_cast<const uint8_t*>(pers), strlen(pers));
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 10,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 10,
                            "MESH: derivePeerLMK — ctr_drbg_seed failed");
   }
 
   ret = mbedtls_ecdh_setup(&ecdh, MBEDTLS_ECP_DP_CURVE25519);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 11,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 11,
                            "MESH: derivePeerLMK — ecdh_setup failed");
   }
 
@@ -58,8 +58,8 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(d), ownPrivateKey32,
       32);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 12,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 12,
                            "MESH: derivePeerLMK — mpi_read_binary (private key) failed");
   }
 
@@ -67,8 +67,8 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X),
       peerPublicKey32, 32);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 13,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 13,
                            "MESH: derivePeerLMK — mpi_read_binary (peer public key) failed");
   }
 
@@ -76,8 +76,8 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z),
       1);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 14,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 14,
                            "MESH: derivePeerLMK — mpi_lset (Qp.Z) failed");
   }
 
@@ -86,8 +86,8 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
   ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, sharedSecret, sizeof(sharedSecret),
                                  mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 15,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 15,
                            "MESH: derivePeerLMK — ecdh_calc_secret failed");
   }
 
@@ -95,37 +95,37 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
   mbedtls_ctr_drbg_free(&ctr_drbg);
   mbedtls_entropy_free(&entropy);
 
-  // KDF: SHA256(sharedSecret || "planetopia-lmk"), take first 16 bytes
+  // KDF: SHA256(sharedSecret || "lattice-lmk"), take first 16 bytes
   mbedtls_sha256_context sha;
   mbedtls_sha256_init(&sha);
 
   ret = mbedtls_sha256_starts(&sha, 0); // 0 = SHA-256, not SHA-224
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 16,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 16,
                            "MESH: derivePeerLMK — sha256_starts failed");
   }
 
   ret = mbedtls_sha256_update(&sha, sharedSecret, 32);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 17,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 17,
                            "MESH: derivePeerLMK — sha256_update (secret) failed");
   }
 
-  const uint8_t label[] = "planetopia-lmk";
+  const uint8_t label[] = "lattice-lmk";
   ret = mbedtls_sha256_update(&sha, label, sizeof(label) - 1);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 18,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 18,
                            "MESH: derivePeerLMK — sha256_update (label) failed");
   }
 
   uint8_t digest[32];
   ret = mbedtls_sha256_finish(&sha, digest);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 19,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 19,
                            "MESH: derivePeerLMK — sha256_finish failed");
   }
 
@@ -165,8 +165,8 @@ static void registerPeerWithEspNow(const uint8_t mac[6], const uint8_t* ownPriva
   info.encrypt = hasPublicKey;
   if (hasPublicKey)
     memcpy(info.lmk, lmk, 16);
-  planetopia::err::checkEsp(esp_now_add_peer(&info),
-                            planetopia::utils::ErrorType::COMMUNICATION_FAIL,
+  lattice::err::checkEsp(esp_now_add_peer(&info),
+                            lattice::utils::ErrorType::COMMUNICATION_FAIL,
                             "registerPeerWithEspNow: add_peer failed");
 }
 
@@ -174,7 +174,7 @@ Mesh::Mesh()
     : isMaster(false), lastBeaconMillis(0), lastMasterBeaconReceivedMs(0), bootEpoch(0),
       txSeqNum(0), replayCacheIdx(0), lastRelayedEpoch(0), lastRelayedSeqNum(0),
       hasMasterMac(false), knownMasterMacSecondary{}, hasMasterMacSecondary(false),
-      _dualMasterMode(planetopia::config::DUAL_MASTER_MODE), peerCount(0), recvQueueHead(0),
+      _dualMasterMode(lattice::config::DUAL_MASTER_MODE), peerCount(0), recvQueueHead(0),
       recvQueueTail(0), lastBeaconMs(0), relayPending(false), relayPendingAt(0) {
   instance = this;
   memset(currentMaster.mac, 0, 6);
@@ -202,19 +202,19 @@ bool Mesh::appendPeer(const PeerInfo& peer) {
 void Mesh::readMacAddress() {
   esp_err_t ret = esp_wifi_get_mac(WIFI_IF_STA, deviceMacAddress);
   if (ret != ESP_OK) {
-    planetopia::err::fail(
-        planetopia::core::ErrorTypeDigit::HARDWARE, planetopia::core::ModuleDigit::MESH, 1,
+    lattice::err::fail(
+        lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::MESH, 1,
         (String("MESH: Failed to read MAC address: ") + esp_err_to_name(ret)).c_str());
   } else {
     Logger::log("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
-    Logger::logln("MESH", planetopia::utils::MacAddress(deviceMacAddress).toString(),
+    Logger::logln("MESH", lattice::utils::MacAddress(deviceMacAddress).toString(),
                   LogLevel::LOG_DEBUG);
   }
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
   auto macToStr = [](const uint8_t mac[6]) {
-    return planetopia::utils::MacAddress(mac).toString();
+    return lattice::utils::MacAddress(mac).toString();
   };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
@@ -274,9 +274,9 @@ void Mesh::loadPeersFromEEPROM() {
   // Fallback in dev mode or when list is empty
   if (peerCount == 0) {
     Logger::logln("MESH", "Peer list empty; loading defaults from config", LogLevel::LOG_INFO);
-    for (int i = 0; i < planetopia::config::NUM_DEFAULT_PEERS; ++i) {
+    for (int i = 0; i < lattice::config::NUM_DEFAULT_PEERS; ++i) {
       PeerInfo peer;
-      memcpy(peer.mac, planetopia::config::DEFAULT_PEERS[i], 6);
+      memcpy(peer.mac, lattice::config::DEFAULT_PEERS[i], 6);
       memset(peer.publicKey, 0, 32); // Public key not known yet for config defaults
       peer.lastSeenMillis = 0;
       appendPeer(peer);
@@ -300,12 +300,12 @@ void Mesh::savePeersToEEPROM() {
 
 void Mesh::addPeerToEEPROM(const uint8_t mac[6]) {
   if (findPeer(mac) ||
-      planetopia::utils::MacAddress(mac) == planetopia::utils::MacAddress(deviceMacAddress))
+      lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(deviceMacAddress))
     return;
 
   if (peerCount >= MAX_PEERS) {
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::MEMORY,
-                          planetopia::core::ModuleDigit::MESH, 2,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
+                          lattice::core::ModuleDigit::MESH, 2,
                           "Peer list full! Cannot add new peer. MAX_PEERS reached.");
     return;
   }
@@ -323,21 +323,21 @@ void Mesh::addPeerToEEPROM(const uint8_t mac[6]) {
 
 void Mesh::removePeerFromEEPROM(const uint8_t mac[6]) {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (planetopia::utils::MacAddress(peerMacs[i].mac) == planetopia::utils::MacAddress(mac)) {
+    if (lattice::utils::MacAddress(peerMacs[i].mac) == lattice::utils::MacAddress(mac)) {
       peerMacs[i] = peerMacs[--peerCount]; // swap with last, shrink count
       break;
     }
   }
   savePeersToEEPROM();
   esp_err_t result = esp_now_del_peer(mac);
-  planetopia::err::checkEsp(result, planetopia::utils::ErrorType::COMMUNICATION_FAIL,
+  lattice::err::checkEsp(result, lattice::utils::ErrorType::COMMUNICATION_FAIL,
                             "removePeerFromEEPROM: del_peer failed");
   Logger::logln("MESH", "Removed ESP-NOW peer.", LogLevel::LOG_DEBUG);
 }
 
 PeerInfo* Mesh::findPeer(const uint8_t mac[6]) {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (planetopia::utils::MacAddress(peerMacs[i].mac) == planetopia::utils::MacAddress(mac))
+    if (lattice::utils::MacAddress(peerMacs[i].mac) == lattice::utils::MacAddress(mac))
       return &peerMacs[i];
   }
   return nullptr;
@@ -346,18 +346,18 @@ bool Mesh::isPeerInRange(const uint8_t mac[6]) {
   PeerInfo* peer = findPeer(mac);
   if (!peer)
     return false;
-  return millis() - peer->lastSeenMillis < planetopia::config::STALE_PEER_THRESHOLD_MS;
+  return millis() - peer->lastSeenMillis < lattice::config::STALE_PEER_THRESHOLD_MS;
 }
 PeerInfo* Mesh::findNextHopToMaster() {
   // For this mesh: nextHop == currentMaster.nextHop
   if (currentMaster.distance == 0xFF)
     return nullptr;
   for (size_t i = 0; i < peerCount; ++i) {
-    if (planetopia::utils::MacAddress(peerMacs[i].mac) ==
-            planetopia::utils::MacAddress(currentMaster.nextHop) &&
+    if (lattice::utils::MacAddress(peerMacs[i].mac) ==
+            lattice::utils::MacAddress(currentMaster.nextHop) &&
         isPeerInRange(peerMacs[i].mac) &&
-        planetopia::utils::MacAddress(peerMacs[i].mac) !=
-            planetopia::utils::MacAddress(deviceMacAddress))
+        lattice::utils::MacAddress(peerMacs[i].mac) !=
+            lattice::utils::MacAddress(deviceMacAddress))
       return &peerMacs[i];
   }
   return nullptr;
@@ -403,8 +403,8 @@ bool Mesh::init() {
 
   // 3a. Apply TX power preset from EEPROM (deployment-specific)
   {
-    planetopia::config::TxPowerPreset preset = EEPROM_Manager::getInstance().loadTxPowerPreset();
-    uint8_t txPowerVal = planetopia::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
+    lattice::config::TxPowerPreset preset = EEPROM_Manager::getInstance().loadTxPowerPreset();
+    uint8_t txPowerVal = lattice::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
     esp_err_t txErr = esp_wifi_set_max_tx_power(static_cast<int8_t>(txPowerVal));
     if (txErr != ESP_OK) {
       Logger::logln("MESH", String("TX power set failed: ") + esp_err_to_name(txErr),
@@ -423,9 +423,9 @@ bool Mesh::init() {
 
 bool Mesh::setupWiFi() {
   WiFi.mode(WIFI_STA);
-  planetopia::err::checkEsp(
-      esp_wifi_set_channel(planetopia::config::WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE),
-      planetopia::utils::ErrorType::HARDWARE_FAILURE, "Failed to set WiFi channel");
+  lattice::err::checkEsp(
+      esp_wifi_set_channel(lattice::config::WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE),
+      lattice::utils::ErrorType::HARDWARE_FAILURE, "Failed to set WiFi channel");
 
   readMacAddress();
   return true;
@@ -470,27 +470,27 @@ void Mesh::loadOrGenerateKeypair() {
   mbedtls_entropy_init(&entropy);
   mbedtls_ctr_drbg_init(&ctr_drbg);
 
-  const char* pers = "planetopia_keygen";
+  const char* pers = "lattice_keygen";
   int ret;
   ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                               reinterpret_cast<const uint8_t*>(pers), strlen(pers));
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 1,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 1,
                            "MESH: keypair gen — entropy seed failed");
   }
 
   ret = mbedtls_ecp_group_load(&grp, MBEDTLS_ECP_DP_CURVE25519);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 2,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 2,
                            "MESH: keypair gen — ecp_group_load failed");
   }
 
   ret = mbedtls_ecdh_gen_public(&grp, &d, &Q, mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret != 0) {
-    planetopia::err::fatal(planetopia::core::ErrorTypeDigit::CONFIG,
-                           planetopia::core::ModuleDigit::MESH, 3,
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
+                           lattice::core::ModuleDigit::MESH, 3,
                            "MESH: keypair gen — ecdh_gen_public failed");
   }
 
@@ -512,8 +512,8 @@ void Mesh::loadOrGenerateKeypair() {
 bool Mesh::setupEspNow() {
   esp_err_t res = esp_now_init();
   if (res != ESP_OK) {
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::MESH, 3,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::MESH, 3,
                           (String("MESH: esp_now_init failed: ") + esp_err_to_name(res)).c_str());
     return false;
   }
@@ -632,7 +632,7 @@ void IRAM_ATTR Mesh::dataRecvTrampoline(const esp_now_recv_info* mac_addr, const
 }
 
 void Mesh::sendMessage(const uint8_t target[6], mesh_message msg) {
-  if (planetopia::utils::MacAddress(target) == planetopia::utils::MacAddress(deviceMacAddress)) {
+  if (lattice::utils::MacAddress(target) == lattice::utils::MacAddress(deviceMacAddress)) {
     Logger::logln("MESH", "Not sending to self. Skipped.", LogLevel::LOG_DEBUG);
     return;
   }
@@ -640,8 +640,8 @@ void Mesh::sendMessage(const uint8_t target[6], mesh_message msg) {
   if (result == ESP_OK) {
     Logger::logln("MESH", "Message sent to peer", LogLevel::LOG_DEBUG);
   } else {
-    planetopia::err::fail(
-        planetopia::core::ErrorTypeDigit::COMM, planetopia::core::ModuleDigit::MESH, 5,
+    lattice::err::fail(
+        lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 5,
         (String("MESH: Error sending message: ") + esp_err_to_name(result)).c_str());
   }
 }
@@ -675,14 +675,14 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMe
 
   // Routing: always use next hop if possible
   PeerInfo* nextHop = findNextHopToMaster();
-  if (nextHop && planetopia::utils::MacAddress(nextHop->mac) !=
-                     planetopia::utils::MacAddress(deviceMacAddress)) {
+  if (nextHop && lattice::utils::MacAddress(nextHop->mac) !=
+                     lattice::utils::MacAddress(deviceMacAddress)) {
     sendMessage(nextHop->mac, msg);
   } else {
     Logger::logln("MESH", "No next hop to master — message dropped. Master timeout or unreachable.",
                   LogLevel::LOG_WARN);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::COMM,
-                          planetopia::core::ModuleDigit::MESH, 8,
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
+                          lattice::core::ModuleDigit::MESH, 8,
                           "MESH: message dropped, no route to master");
   }
 }
@@ -706,7 +706,7 @@ void Mesh::linkDataRecvCallback(std::function<void(mesh_message)> recvCallback) 
 // --- Periodically called in main loop if this node is master ---
 void Mesh::broadcastMasterBeacon() {
   unsigned long now = millis();
-  if (now - lastBeaconMillis < planetopia::config::MASTER_BEACON_INTERVAL_MS)
+  if (now - lastBeaconMillis < lattice::config::MASTER_BEACON_INTERVAL_MS)
     return;
   lastBeaconMillis = now;
 
@@ -729,8 +729,8 @@ void Mesh::broadcastMasterBeacon() {
 void Mesh::addPeer(const uint8_t mac[6]) {
   if (!findPeer(mac)) {
     if (peerCount >= MAX_PEERS) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::MEMORY,
-                            planetopia::core::ModuleDigit::MESH, 6,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
+                            lattice::core::ModuleDigit::MESH, 6,
                             "Peer list full! Cannot add new peer. MAX_PEERS reached.");
       Logger::logln("MESH", "Peer list is full, skipping add", LogLevel::LOG_WARN);
       return;
@@ -756,8 +756,8 @@ void Mesh::loadMeshKeyFromEEPROM() {
   }
 
   // If in DEV_MODE always override with compile-time key
-  if (planetopia::config::DEV_MODE) {
-    memcpy(meshKey, planetopia::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
+  if (lattice::config::DEV_MODE) {
+    memcpy(meshKey, lattice::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
     Logger::logln("MESH", "DEV_MODE: Overriding mesh key with compile-time default",
                   LogLevel::LOG_INFO);
   }
@@ -773,7 +773,7 @@ void Mesh::loadMeshKeyFromEEPROM() {
 
   if (unset) {
     Logger::logln("MESH", "Mesh key unset, loading default from config", LogLevel::LOG_INFO);
-    memcpy(meshKey, planetopia::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
+    memcpy(meshKey, lattice::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
     saveMeshKeyToEEPROM(meshKey); // Will be skipped automatically in dev mode
   }
 }
@@ -842,7 +842,7 @@ void Mesh::checkMasterTimeout() {
 void Mesh::updatePeerLastSeen(const uint8_t mac[6]) {
   if (!mac)
     return;
-  if (planetopia::utils::MacAddress(mac) == planetopia::utils::MacAddress(deviceMacAddress))
+  if (lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(deviceMacAddress))
     return;
   // Enrollment is the only path for new peers — do not auto-add unknown senders here.
   // Unknown senders are silently ignored for non-enrollment messages.
@@ -854,7 +854,7 @@ void Mesh::updatePeerLastSeen(const uint8_t mac[6]) {
 
 void Mesh::processMasterBeacon(const mesh_message& msg) {
   // Guard: drop beacon if hop count would overflow uint8_t or exceed limit
-  if (msg.hopCount >= planetopia::config::MAX_HOPS) {
+  if (msg.hopCount >= lattice::config::MAX_HOPS) {
     Logger::logln("MESH", "Beacon hop count exceeded MAX_HOPS, dropping relay", LogLevel::LOG_WARN);
     return;
   }
@@ -893,15 +893,15 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     }
   }
 
-  if (planetopia::utils::MacAddress(lastSeenMasterMac) !=
-          planetopia::utils::MacAddress(msg.originMacAddress) &&
+  if (lattice::utils::MacAddress(lastSeenMasterMac) !=
+          lattice::utils::MacAddress(msg.originMacAddress) &&
       lastSeenMasterMac[0] != 0) {
     if (_dualMasterMode) {
       Logger::logln("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
     } else {
       Logger::logln("MESH", "WARNING: Multiple masters detected!", LogLevel::LOG_WARN);
-      planetopia::err::fail(
-          planetopia::core::ErrorTypeDigit::CONFIG, planetopia::core::ModuleDigit::MESH, 7,
+      lattice::err::fail(
+          lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 7,
           "Multiple master nodes detected! Network split or misconfiguration likely.");
     }
   }
@@ -910,8 +910,8 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 
   uint8_t newDistance = msg.hopCount + 1;
   if (currentMaster.distance == 0xFF ||
-      planetopia::utils::MacAddress(currentMaster.mac) !=
-          planetopia::utils::MacAddress(msg.originMacAddress) ||
+      lattice::utils::MacAddress(currentMaster.mac) !=
+          lattice::utils::MacAddress(msg.originMacAddress) ||
       newDistance < currentMaster.distance) {
     memcpy(currentMaster.mac, msg.originMacAddress, 6);
     currentMaster.distance = newDistance;
@@ -935,7 +935,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     // nodes and eliminate the collision burst that occurs when all nodes relay
     // within milliseconds of receiving the same beacon.
     // Jitter window: 10–73 ms (10 + esp_random() % RELAY_JITTER_MAX_MS)
-    uint8_t jitterMs = static_cast<uint8_t>(esp_random() % planetopia::config::RELAY_JITTER_MAX_MS);
+    uint8_t jitterMs = static_cast<uint8_t>(esp_random() % lattice::config::RELAY_JITTER_MAX_MS);
     relayPendingMsg = msg;
     relayPendingMsg.hopCount = newDistance;
     memcpy(relayPendingMsg.lastHopMacAddress, deviceMacAddress, 6);
@@ -945,7 +945,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 }
 
 void Mesh::processAdapterData(const mesh_message& msg) {
-  // OP_CONFIG_SET = 0xC1 (from lib/planetopia-protocol/opcodes.h)
+  // OP_CONFIG_SET = 0xC1 (from lib/lattice-protocol/opcodes.h)
   static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   bool addressedToSelf = (memcmp(msg.targetMacAddress, deviceMacAddress, 6) == 0);
@@ -956,7 +956,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   if (!isMaster && !addressedToSelf && !isBroadcastTarget) {
     if (addressedToMaster) {
       // Uplink: relay toward master via routing table
-      if (msg.hopCount >= planetopia::config::MAX_HOPS)
+      if (msg.hopCount >= lattice::config::MAX_HOPS)
         return;
       mesh_message relay = msg;
       relay.hopCount++;
@@ -991,7 +991,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
 }
 
 void Mesh::relayDownlink(const mesh_message& msg) {
-  if (msg.hopCount >= planetopia::config::MAX_HOPS)
+  if (msg.hopCount >= lattice::config::MAX_HOPS)
     return;
   mesh_message relay = msg;
   relay.hopCount++;
@@ -1135,4 +1135,4 @@ void Mesh::loop() {
 }
 
 } // namespace mesh
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/Mesh/Mesh.cpp
+++ b/main/src/Mesh/Mesh.cpp
@@ -41,16 +41,14 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
   ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                               reinterpret_cast<const uint8_t*>(pers), strlen(pers));
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 10,
-                           "MESH: derivePeerLMK — ctr_drbg_seed failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 10,
+                        "MESH: derivePeerLMK — ctr_drbg_seed failed");
   }
 
   ret = mbedtls_ecdh_setup(&ecdh, MBEDTLS_ECP_DP_CURVE25519);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 11,
-                           "MESH: derivePeerLMK — ecdh_setup failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 11,
+                        "MESH: derivePeerLMK — ecdh_setup failed");
   }
 
   // Load own private key and peer public key (X coordinate only for Curve25519)
@@ -58,27 +56,24 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(d), ownPrivateKey32,
       32);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 12,
-                           "MESH: derivePeerLMK — mpi_read_binary (private key) failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 12,
+                        "MESH: derivePeerLMK — mpi_read_binary (private key) failed");
   }
 
   ret = mbedtls_mpi_read_binary(
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X),
       peerPublicKey32, 32);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 13,
-                           "MESH: derivePeerLMK — mpi_read_binary (peer public key) failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 13,
+                        "MESH: derivePeerLMK — mpi_read_binary (peer public key) failed");
   }
 
   ret = mbedtls_mpi_lset(
       &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z),
       1);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 14,
-                           "MESH: derivePeerLMK — mpi_lset (Qp.Z) failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 14,
+                        "MESH: derivePeerLMK — mpi_lset (Qp.Z) failed");
   }
 
   uint8_t sharedSecret[32] = {};
@@ -86,9 +81,8 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
   ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, sharedSecret, sizeof(sharedSecret),
                                  mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 15,
-                           "MESH: derivePeerLMK — ecdh_calc_secret failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 15,
+                        "MESH: derivePeerLMK — ecdh_calc_secret failed");
   }
 
   mbedtls_ecdh_free(&ecdh);
@@ -101,32 +95,28 @@ static void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
 
   ret = mbedtls_sha256_starts(&sha, 0); // 0 = SHA-256, not SHA-224
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 16,
-                           "MESH: derivePeerLMK — sha256_starts failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 16,
+                        "MESH: derivePeerLMK — sha256_starts failed");
   }
 
   ret = mbedtls_sha256_update(&sha, sharedSecret, 32);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 17,
-                           "MESH: derivePeerLMK — sha256_update (secret) failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 17,
+                        "MESH: derivePeerLMK — sha256_update (secret) failed");
   }
 
   const uint8_t label[] = "lattice-lmk";
   ret = mbedtls_sha256_update(&sha, label, sizeof(label) - 1);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 18,
-                           "MESH: derivePeerLMK — sha256_update (label) failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 18,
+                        "MESH: derivePeerLMK — sha256_update (label) failed");
   }
 
   uint8_t digest[32];
   ret = mbedtls_sha256_finish(&sha, digest);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 19,
-                           "MESH: derivePeerLMK — sha256_finish failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 19,
+                        "MESH: derivePeerLMK — sha256_finish failed");
   }
 
   mbedtls_sha256_free(&sha);
@@ -165,9 +155,8 @@ static void registerPeerWithEspNow(const uint8_t mac[6], const uint8_t* ownPriva
   info.encrypt = hasPublicKey;
   if (hasPublicKey)
     memcpy(info.lmk, lmk, 16);
-  lattice::err::checkEsp(esp_now_add_peer(&info),
-                            lattice::utils::ErrorType::COMMUNICATION_FAIL,
-                            "registerPeerWithEspNow: add_peer failed");
+  lattice::err::checkEsp(esp_now_add_peer(&info), lattice::utils::ErrorType::COMMUNICATION_FAIL,
+                         "registerPeerWithEspNow: add_peer failed");
 }
 
 Mesh::Mesh()
@@ -213,9 +202,7 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t mac[6]) {
-    return lattice::utils::MacAddress(mac).toString();
-  };
+  auto macToStr = [](const uint8_t mac[6]) { return lattice::utils::MacAddress(mac).toString(); };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.originMacAddress), LogLevel::LOG_DEBUG);
@@ -304,9 +291,8 @@ void Mesh::addPeerToEEPROM(const uint8_t mac[6]) {
     return;
 
   if (peerCount >= MAX_PEERS) {
-    lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
-                          lattice::core::ModuleDigit::MESH, 2,
-                          "Peer list full! Cannot add new peer. MAX_PEERS reached.");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::MESH, 2,
+                       "Peer list full! Cannot add new peer. MAX_PEERS reached.");
     return;
   }
 
@@ -331,7 +317,7 @@ void Mesh::removePeerFromEEPROM(const uint8_t mac[6]) {
   savePeersToEEPROM();
   esp_err_t result = esp_now_del_peer(mac);
   lattice::err::checkEsp(result, lattice::utils::ErrorType::COMMUNICATION_FAIL,
-                            "removePeerFromEEPROM: del_peer failed");
+                         "removePeerFromEEPROM: del_peer failed");
   Logger::logln("MESH", "Removed ESP-NOW peer.", LogLevel::LOG_DEBUG);
 }
 
@@ -356,8 +342,7 @@ PeerInfo* Mesh::findNextHopToMaster() {
     if (lattice::utils::MacAddress(peerMacs[i].mac) ==
             lattice::utils::MacAddress(currentMaster.nextHop) &&
         isPeerInRange(peerMacs[i].mac) &&
-        lattice::utils::MacAddress(peerMacs[i].mac) !=
-            lattice::utils::MacAddress(deviceMacAddress))
+        lattice::utils::MacAddress(peerMacs[i].mac) != lattice::utils::MacAddress(deviceMacAddress))
       return &peerMacs[i];
   }
   return nullptr;
@@ -423,9 +408,8 @@ bool Mesh::init() {
 
 bool Mesh::setupWiFi() {
   WiFi.mode(WIFI_STA);
-  lattice::err::checkEsp(
-      esp_wifi_set_channel(lattice::config::WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE),
-      lattice::utils::ErrorType::HARDWARE_FAILURE, "Failed to set WiFi channel");
+  lattice::err::checkEsp(esp_wifi_set_channel(lattice::config::WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE),
+                         lattice::utils::ErrorType::HARDWARE_FAILURE, "Failed to set WiFi channel");
 
   readMacAddress();
   return true;
@@ -475,23 +459,20 @@ void Mesh::loadOrGenerateKeypair() {
   ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                               reinterpret_cast<const uint8_t*>(pers), strlen(pers));
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 1,
-                           "MESH: keypair gen — entropy seed failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 1,
+                        "MESH: keypair gen — entropy seed failed");
   }
 
   ret = mbedtls_ecp_group_load(&grp, MBEDTLS_ECP_DP_CURVE25519);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 2,
-                           "MESH: keypair gen — ecp_group_load failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 2,
+                        "MESH: keypair gen — ecp_group_load failed");
   }
 
   ret = mbedtls_ecdh_gen_public(&grp, &d, &Q, mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG,
-                           lattice::core::ModuleDigit::MESH, 3,
-                           "MESH: keypair gen — ecdh_gen_public failed");
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 3,
+                        "MESH: keypair gen — ecdh_gen_public failed");
   }
 
   // Export private scalar (d) — 32 bytes big-endian (NEVER printed to serial)
@@ -512,9 +493,8 @@ void Mesh::loadOrGenerateKeypair() {
 bool Mesh::setupEspNow() {
   esp_err_t res = esp_now_init();
   if (res != ESP_OK) {
-    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                          lattice::core::ModuleDigit::MESH, 3,
-                          (String("MESH: esp_now_init failed: ") + esp_err_to_name(res)).c_str());
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 3,
+                       (String("MESH: esp_now_init failed: ") + esp_err_to_name(res)).c_str());
     return false;
   }
   esp_now_set_pmk(meshKey);
@@ -640,9 +620,8 @@ void Mesh::sendMessage(const uint8_t target[6], mesh_message msg) {
   if (result == ESP_OK) {
     Logger::logln("MESH", "Message sent to peer", LogLevel::LOG_DEBUG);
   } else {
-    lattice::err::fail(
-        lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 5,
-        (String("MESH: Error sending message: ") + esp_err_to_name(result)).c_str());
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 5,
+                       (String("MESH: Error sending message: ") + esp_err_to_name(result)).c_str());
   }
 }
 
@@ -675,15 +654,14 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMe
 
   // Routing: always use next hop if possible
   PeerInfo* nextHop = findNextHopToMaster();
-  if (nextHop && lattice::utils::MacAddress(nextHop->mac) !=
-                     lattice::utils::MacAddress(deviceMacAddress)) {
+  if (nextHop &&
+      lattice::utils::MacAddress(nextHop->mac) != lattice::utils::MacAddress(deviceMacAddress)) {
     sendMessage(nextHop->mac, msg);
   } else {
     Logger::logln("MESH", "No next hop to master — message dropped. Master timeout or unreachable.",
                   LogLevel::LOG_WARN);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM,
-                          lattice::core::ModuleDigit::MESH, 8,
-                          "MESH: message dropped, no route to master");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 8,
+                       "MESH: message dropped, no route to master");
   }
 }
 
@@ -729,9 +707,8 @@ void Mesh::broadcastMasterBeacon() {
 void Mesh::addPeer(const uint8_t mac[6]) {
   if (!findPeer(mac)) {
     if (peerCount >= MAX_PEERS) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
-                            lattice::core::ModuleDigit::MESH, 6,
-                            "Peer list full! Cannot add new peer. MAX_PEERS reached.");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::MESH, 6,
+                         "Peer list full! Cannot add new peer. MAX_PEERS reached.");
       Logger::logln("MESH", "Peer list is full, skipping add", LogLevel::LOG_WARN);
       return;
     }

--- a/main/src/Mesh/Mesh.cpp
+++ b/main/src/Mesh/Mesh.cpp
@@ -348,8 +348,7 @@ PeerInfo* Mesh::findNextHopToMaster() {
   return nullptr;
 }
 
-mesh_message Mesh::buildMessage(adapter_types type, const uint8_t data[64],
-                                MeshMessageType msgType) {
+mesh_message Mesh::buildMessage(adapter_types type, const uint8_t* data, MeshMessageType msgType) {
   mesh_message msg = {};
   msg.protoVersion = PROTO_VERSION;
   msg.messageType = msgType;
@@ -637,7 +636,7 @@ void Mesh::broadcastToAllPeers(mesh_message msg) {
   }
 }
 
-void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMessageType msgType,
+void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessageType msgType,
                         const mesh_message* msgOverride) {
   mesh_message msg;
   if (msgOverride) {
@@ -665,7 +664,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMe
   }
 }
 
-void Mesh::transmit(const adapter_types type, const uint8_t data[64]) {
+void Mesh::transmit(const adapter_types type, const uint8_t* data) {
   if (!instance) {
     Logger::logln("MESH", "transmit() called before init", LogLevel::LOG_WARN);
     return;
@@ -774,13 +773,13 @@ bool Mesh::meshKeyIsSet() const {
   return false;
 }
 
-void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[64]) {
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t* data) {
   mesh_message msg = buildMessage(type, data, MESH_TYPE_ADAPTER_DATA);
   memset(msg.targetMacAddress, 0xFF, 6); // broadcast indicator — relayed by intermediate nodes
   broadcastToAllPeers(msg);
 }
 
-void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t data[64]) {
+void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t* data) {
   if (instance)
     instance->broadcastAdapterData(type, data);
 }

--- a/main/src/Mesh/Mesh.h
+++ b/main/src/Mesh/Mesh.h
@@ -14,16 +14,16 @@
 
 #ifdef UNIT_TEST
 // Forward declarations for test fixture classes (global namespace) so that
-// friend declarations inside planetopia::mesh::Mesh are valid.
+// friend declarations inside lattice::mesh::Mesh are valid.
 class ReplayCacheTest;
 class MeshLogicTest;
 #endif
 
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 
-using planetopia::adapter::adapter_types;
-using planetopia::utils::EEPROM_SIZES::MAX_PEERS; // Use constant from EEPROM_Manager
+using lattice::adapter::adapter_types;
+using lattice::utils::EEPROM_SIZES::MAX_PEERS; // Use constant from EEPROM_Manager
 
 // --- Mesh protocol message type ---
 enum MeshMessageType : uint8_t {
@@ -114,7 +114,7 @@ private:
   uint32_t lastBeaconMillis;
   uint32_t lastMasterBeaconReceivedMs;
   static constexpr uint32_t STALE_MASTER_THRESHOLD_MS =
-      planetopia::config::STALE_MASTER_THRESHOLD_MS;
+      lattice::config::STALE_MASTER_THRESHOLD_MS;
 
   // Peer EEPROM management
   void loadPeersFromEEPROM();
@@ -288,6 +288,6 @@ public:
 };
 
 } // namespace mesh
-} // namespace planetopia
+} // namespace lattice
 
 #endif // MESH_H

--- a/main/src/Mesh/Mesh.h
+++ b/main/src/Mesh/Mesh.h
@@ -113,8 +113,7 @@ private:
   bool isMaster;
   uint32_t lastBeaconMillis;
   uint32_t lastMasterBeaconReceivedMs;
-  static constexpr uint32_t STALE_MASTER_THRESHOLD_MS =
-      lattice::config::STALE_MASTER_THRESHOLD_MS;
+  static constexpr uint32_t STALE_MASTER_THRESHOLD_MS = lattice::config::STALE_MASTER_THRESHOLD_MS;
 
   // Peer EEPROM management
   void loadPeersFromEEPROM();

--- a/main/src/Mesh/Mesh.h
+++ b/main/src/Mesh/Mesh.h
@@ -105,7 +105,7 @@ private:
   static void IRAM_ATTR dataRecvTrampoline(const esp_now_recv_info* mac_addr, const uint8_t* data,
                                            int len);
 
-  mesh_message buildMessage(adapter_types type, const uint8_t data[64], MeshMessageType msgType);
+  mesh_message buildMessage(adapter_types type, const uint8_t* data, MeshMessageType msgType);
 
   std::function<void(mesh_message)> externalRecvCallback;
 
@@ -132,7 +132,7 @@ private:
   void sendMessage(const uint8_t target[6], mesh_message msg);
   void broadcastToAllPeers(mesh_message msg);
 
-  void transmitCore(const adapter_types type, const uint8_t data[64],
+  void transmitCore(const adapter_types type, const uint8_t* data,
                     MeshMessageType msgType = MESH_TYPE_ADAPTER_DATA,
                     const mesh_message* msgOverride = nullptr);
 
@@ -221,7 +221,7 @@ public:
   bool init();
 
   // Static trampoline for Adapter usage
-  static void transmit(const adapter_types type, const uint8_t data[64]);
+  static void transmit(const adapter_types type, const uint8_t* data);
 
   void linkDataRecvCallback(std::function<void(mesh_message)> recvCallback);
 
@@ -247,10 +247,10 @@ public:
   size_t getPeerCount() const { return peerCount; }
 
   // Broadcast adapter data to all peers
-  void broadcastAdapterData(adapter_types type, const uint8_t data[64]);
+  void broadcastAdapterData(adapter_types type, const uint8_t* data);
 
   // Serial adapter helper (optional broadcast)
-  static void broadcastAdapterDataStatic(adapter_types type, const uint8_t data[64]);
+  static void broadcastAdapterDataStatic(adapter_types type, const uint8_t* data);
 
   // Debug helper
   void debugDumpRadio();

--- a/main/src/Mesh/serialization/mesh.pb.h
+++ b/main/src/Mesh/serialization/mesh.pb.h
@@ -13,56 +13,65 @@
 typedef PB_BYTES_ARRAY_T(64) mesh_MeshMessage_data_t;
 typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_public_key_t;
 typedef struct _mesh_MeshMessage {
-    uint32_t messageType;
-    int32_t dataType;
-    pb_byte_t originMacAddress[6];
-    pb_byte_t targetMacAddress[6];
-    pb_byte_t lastHopMacAddress[6];
-    bool has_data;
-    mesh_MeshMessage_data_t data;
-    uint32_t hopCount;
-    uint32_t epochNum;
-    uint32_t seqNum;
-    uint32_t protoVersion;
-    bool has_public_key;
-    mesh_MeshMessage_public_key_t public_key;
+  uint32_t messageType;
+  int32_t dataType;
+  pb_byte_t originMacAddress[6];
+  pb_byte_t targetMacAddress[6];
+  pb_byte_t lastHopMacAddress[6];
+  bool has_data;
+  mesh_MeshMessage_data_t data;
+  uint32_t hopCount;
+  uint32_t epochNum;
+  uint32_t seqNum;
+  uint32_t protoVersion;
+  bool has_public_key;
+  mesh_MeshMessage_public_key_t public_key;
 } mesh_MeshMessage;
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define mesh_MeshMessage_init_default            {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}}
-#define mesh_MeshMessage_init_zero               {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}}
+#define mesh_MeshMessage_init_default                                                              \
+  {                                                                                                \
+    0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {                                     \
+      0, {0}                                                                                       \
+    }                                                                                              \
+  }
+#define mesh_MeshMessage_init_zero                                                                 \
+  {                                                                                                \
+    0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {                                     \
+      0, {0}                                                                                       \
+    }                                                                                              \
+  }
 
 /* Field tags (for use in manual encoding/decoding) */
-#define mesh_MeshMessage_messageType_tag         1
-#define mesh_MeshMessage_dataType_tag            2
-#define mesh_MeshMessage_originMacAddress_tag    3
-#define mesh_MeshMessage_targetMacAddress_tag    4
-#define mesh_MeshMessage_lastHopMacAddress_tag   5
-#define mesh_MeshMessage_data_tag                6
-#define mesh_MeshMessage_hopCount_tag            7
-#define mesh_MeshMessage_epochNum_tag            8
-#define mesh_MeshMessage_seqNum_tag              9
-#define mesh_MeshMessage_protoVersion_tag        10
-#define mesh_MeshMessage_public_key_tag          11
+#define mesh_MeshMessage_messageType_tag 1
+#define mesh_MeshMessage_dataType_tag 2
+#define mesh_MeshMessage_originMacAddress_tag 3
+#define mesh_MeshMessage_targetMacAddress_tag 4
+#define mesh_MeshMessage_lastHopMacAddress_tag 5
+#define mesh_MeshMessage_data_tag 6
+#define mesh_MeshMessage_hopCount_tag 7
+#define mesh_MeshMessage_epochNum_tag 8
+#define mesh_MeshMessage_seqNum_tag 9
+#define mesh_MeshMessage_protoVersion_tag 10
+#define mesh_MeshMessage_public_key_tag 11
 
 /* Struct field encoding specification for nanopb */
-#define mesh_MeshMessage_FIELDLIST(X, a) \
-X(a, STATIC,   SINGULAR, UINT32,   messageType,       1) \
-X(a, STATIC,   SINGULAR, SINT32,   dataType,          2) \
-X(a, STATIC,   SINGULAR, FIXED_LENGTH_BYTES, originMacAddress,   3) \
-X(a, STATIC,   SINGULAR, FIXED_LENGTH_BYTES, targetMacAddress,   4) \
-X(a, STATIC,   SINGULAR, FIXED_LENGTH_BYTES, lastHopMacAddress,   5) \
-X(a, STATIC,   OPTIONAL, BYTES,    data,              6) \
-X(a, STATIC,   SINGULAR, UINT32,   hopCount,          7) \
-X(a, STATIC,   SINGULAR, UINT32,   epochNum,          8) \
-X(a, STATIC,   SINGULAR, UINT32,   seqNum,            9) \
-X(a, STATIC,   SINGULAR, UINT32,   protoVersion,     10) \
-X(a, STATIC,   OPTIONAL, BYTES,    public_key,       11)
+#define mesh_MeshMessage_FIELDLIST(X, a)                                                           \
+  X(a, STATIC, SINGULAR, UINT32, messageType, 1)                                                   \
+  X(a, STATIC, SINGULAR, SINT32, dataType, 2)                                                      \
+  X(a, STATIC, SINGULAR, FIXED_LENGTH_BYTES, originMacAddress, 3)                                  \
+  X(a, STATIC, SINGULAR, FIXED_LENGTH_BYTES, targetMacAddress, 4)                                  \
+  X(a, STATIC, SINGULAR, FIXED_LENGTH_BYTES, lastHopMacAddress, 5)                                 \
+  X(a, STATIC, OPTIONAL, BYTES, data, 6)                                                           \
+  X(a, STATIC, SINGULAR, UINT32, hopCount, 7)                                                      \
+  X(a, STATIC, SINGULAR, UINT32, epochNum, 8)                                                      \
+  X(a, STATIC, SINGULAR, UINT32, seqNum, 9)                                                        \
+  X(a, STATIC, SINGULAR, UINT32, protoVersion, 10)                                                 \
+  X(a, STATIC, OPTIONAL, BYTES, public_key, 11)
 #define mesh_MeshMessage_CALLBACK NULL
 #define mesh_MeshMessage_DEFAULT NULL
 
@@ -72,8 +81,8 @@ extern const pb_msgdesc_t mesh_MeshMessage_msg;
 #define mesh_MeshMessage_fields &mesh_MeshMessage_msg
 
 /* Maximum encoded size of messages (where known) */
-#define MESH_MAIN_PROTO_MESH_PB_H_MAX_SIZE       mesh_MeshMessage_size
-#define mesh_MeshMessage_size                    160
+#define MESH_MAIN_PROTO_MESH_PB_H_MAX_SIZE mesh_MeshMessage_size
+#define mesh_MeshMessage_size 160
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/main/src/core/Logger.cpp
+++ b/main/src/core/Logger.cpp
@@ -1,6 +1,6 @@
 #include "Logger.h"
 
-namespace planetopia {
+namespace lattice {
 namespace utils {
 
 LogLevel Logger::currentLevel = LogLevel::LOG_DEBUG;
@@ -76,4 +76,4 @@ void Logger::log(const char* tag, const String& message, LogLevel level) {
 }
 
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/core/Logger.h
+++ b/main/src/core/Logger.h
@@ -4,11 +4,11 @@
 #include <Arduino.h>
 #include <cstdio>
 
-#ifndef PLANETOPIA_LOG_LEVEL
-#define PLANETOPIA_LOG_LEVEL 3 // 0=none 1=error 2=warn 3=info 4=debug
+#ifndef LATTICE_LOG_LEVEL
+#define LATTICE_LOG_LEVEL 3 // 0=none 1=error 2=warn 3=info 4=debug
 #endif
 
-#if PLANETOPIA_LOG_LEVEL >= 4
+#if LATTICE_LOG_LEVEL >= 4
 #define LOG_D(tag, fmt, ...)                                                                       \
   do {                                                                                             \
     char _buf[128];                                                                                \
@@ -21,7 +21,7 @@
   } while (0)
 #endif
 
-namespace planetopia {
+namespace lattice {
 namespace utils {
 
 enum class LogLevel : uint8_t {
@@ -50,5 +50,5 @@ private:
 };
 
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/error/Error.h
+++ b/main/src/error/Error.h
@@ -7,12 +7,12 @@
 #include <esp_err.h>
 #include <cstdint>
 
-namespace planetopia {
+namespace lattice {
 namespace err {
 
 // Helper: map legacy ErrorType to ErrorTypeDigit
-inline ::planetopia::core::ErrorTypeDigit toDigit(utils::ErrorType t) {
-  using namespace planetopia::core;
+inline ::lattice::core::ErrorTypeDigit toDigit(utils::ErrorType t) {
+  using namespace lattice::core;
   switch (t) {
   case utils::ErrorType::GENERIC:
     return ErrorTypeDigit::GENERIC;
@@ -32,7 +32,7 @@ inline ::planetopia::core::ErrorTypeDigit toDigit(utils::ErrorType t) {
 }
 
 // Primary fail overload using digit components
-inline bool fail(::planetopia::core::ErrorTypeDigit t, ::planetopia::core::ModuleDigit m,
+inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m,
                  uint8_t sub, const char* msg) {
   utils::Logger::logln("ERROR", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
@@ -41,17 +41,17 @@ inline bool fail(::planetopia::core::ErrorTypeDigit t, ::planetopia::core::Modul
 
 // Legacy fail – keeps compatibility while showing a generic error code (sub-code 0)
 inline bool fail(utils::ErrorType type, const char* msg) {
-  return fail(toDigit(type), ::planetopia::core::ModuleDigit::CORE, 0, msg);
+  return fail(toDigit(type), ::lattice::core::ModuleDigit::CORE, 0, msg);
 }
-[[noreturn]] inline void fatal(::planetopia::core::ErrorTypeDigit t,
-                               ::planetopia::core::ModuleDigit m, uint8_t sub, const char* msg) {
+[[noreturn]] inline void fatal(::lattice::core::ErrorTypeDigit t,
+                               ::lattice::core::ModuleDigit m, uint8_t sub, const char* msg) {
   utils::Logger::logln("FATAL", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
   while (true) {
   }
 }
 [[noreturn]] inline void fatal(utils::ErrorType type, const char* msg) {
-  fatal(toDigit(type), ::planetopia::core::ModuleDigit::CORE, 0, msg);
+  fatal(toDigit(type), ::lattice::core::ModuleDigit::CORE, 0, msg);
 }
 inline bool check(bool condition, utils::ErrorType type, const char* msg) {
   return condition ? true : fail(type, msg);
@@ -64,18 +64,18 @@ inline bool checkEsp(esp_err_t status, utils::ErrorType type, const char* msg) {
   return fail(type, msg);
 }
 } // namespace err
-} // namespace planetopia
+} // namespace lattice
 
 template <typename... Args> inline bool ERROR_ASSERT(bool cond, const char* msg) {
-  return planetopia::err::check(cond, planetopia::utils::ErrorType::CONFIG_ERROR, msg);
+  return lattice::err::check(cond, lattice::utils::ErrorType::CONFIG_ERROR, msg);
 }
 
 template <typename T> inline bool ERROR_CHECK(bool cond, T t, const char* msg) {
-  return planetopia::err::check(cond, t, msg);
+  return lattice::err::check(cond, t, msg);
 }
 
 template <typename T> inline bool ERROR_CHECK_ESP_OK(esp_err_t expr, T t, const char* msg) {
-  return planetopia::err::checkEsp(expr, t, msg);
+  return lattice::err::checkEsp(expr, t, msg);
 }
 
 #endif

--- a/main/src/error/Error.h
+++ b/main/src/error/Error.h
@@ -32,8 +32,8 @@ inline ::lattice::core::ErrorTypeDigit toDigit(utils::ErrorType t) {
 }
 
 // Primary fail overload using digit components
-inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m,
-                 uint8_t sub, const char* msg) {
+inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m, uint8_t sub,
+                 const char* msg) {
   utils::Logger::logln("ERROR", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
   return false;
@@ -43,8 +43,8 @@ inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit
 inline bool fail(utils::ErrorType type, const char* msg) {
   return fail(toDigit(type), ::lattice::core::ModuleDigit::CORE, 0, msg);
 }
-[[noreturn]] inline void fatal(::lattice::core::ErrorTypeDigit t,
-                               ::lattice::core::ModuleDigit m, uint8_t sub, const char* msg) {
+[[noreturn]] inline void fatal(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m,
+                               uint8_t sub, const char* msg) {
   utils::Logger::logln("FATAL", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
   while (true) {

--- a/main/src/error/ErrorCodes.h
+++ b/main/src/error/ErrorCodes.h
@@ -1,6 +1,6 @@
 #ifndef PLANETOPA_ERRORCODES_H
 #define PLANETOPA_ERRORCODES_H
-namespace planetopia {
+namespace lattice {
 namespace core {
 enum class ErrorTypeDigit : uint8_t {
   GENERIC = 1,
@@ -22,5 +22,5 @@ constexpr uint16_t makeErrorCode(ErrorTypeDigit t, ModuleDigit m, uint8_t sub) {
                                (sub % 10));
 }
 } // namespace core
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/error/ErrorCore.cpp
+++ b/main/src/error/ErrorCore.cpp
@@ -1,10 +1,10 @@
 #include "ErrorCore.h"
 #include "../core/Logger.h"
 #include <esp_system.h>
-using planetopia::core::ErrorTypeDigit;
-using planetopia::core::makeErrorCode;
-using planetopia::core::ModuleDigit;
-namespace planetopia {
+using lattice::core::ErrorTypeDigit;
+using lattice::core::makeErrorCode;
+using lattice::core::ModuleDigit;
+namespace lattice {
 namespace utils {
 ErrorCore::ErrorCore()
     : _errorLed(nullptr), _display(nullptr), _initialized(false), _pendingBlink(false),
@@ -101,4 +101,4 @@ bool ErrorCore::shouldRestart(ErrorType t) const {
   ESP.restart();
 }
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/error/ErrorCore.h
+++ b/main/src/error/ErrorCore.h
@@ -6,7 +6,7 @@
 #include "ErrorCodes.h"
 #include "../core/Logger.h"
 #include <Arduino.h>
-namespace planetopia {
+namespace lattice {
 namespace utils {
 enum class ErrorType : uint8_t {
   GENERIC = 0,
@@ -21,8 +21,8 @@ enum class ErrorType : uint8_t {
 class ErrorCore {
 public:
   static ErrorCore& getInstance();
-  void init(planetopia::hardware::Led* led,
-            planetopia::hardware::SevenSegDisplay* display = nullptr);
+  void init(lattice::hardware::Led* led,
+            lattice::hardware::SevenSegDisplay* display = nullptr);
   void signalError(core::ErrorTypeDigit t, core::ModuleDigit m, uint8_t sub,
                    const char* msg = nullptr);
   void signalError(ErrorType type, const char* msg = nullptr);
@@ -33,8 +33,8 @@ public:
 
 private:
   ErrorCore();
-  planetopia::hardware::Led* _errorLed;
-  planetopia::hardware::SevenSegDisplay* _display;
+  lattice::hardware::Led* _errorLed;
+  lattice::hardware::SevenSegDisplay* _display;
   bool _initialized;
   volatile bool _pendingBlink;
   ErrorType _pendingBlinkType;
@@ -44,5 +44,5 @@ private:
   [[noreturn]] void restartDevice();
 };
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/error/ErrorCore.h
+++ b/main/src/error/ErrorCore.h
@@ -21,8 +21,7 @@ enum class ErrorType : uint8_t {
 class ErrorCore {
 public:
   static ErrorCore& getInstance();
-  void init(lattice::hardware::Led* led,
-            lattice::hardware::SevenSegDisplay* display = nullptr);
+  void init(lattice::hardware::Led* led, lattice::hardware::SevenSegDisplay* display = nullptr);
   void signalError(core::ErrorTypeDigit t, core::ModuleDigit m, uint8_t sub,
                    const char* msg = nullptr);
   void signalError(ErrorType type, const char* msg = nullptr);

--- a/main/src/hardware/input/Button.cpp
+++ b/main/src/hardware/input/Button.cpp
@@ -2,7 +2,7 @@
 #include <Arduino.h>
 #include <cstdint>
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 Button::Button(uint8_t pin) : GpioInput(pin) {}
@@ -46,4 +46,4 @@ bool Button::waitForHold(uint32_t ms) {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/input/Button.h
+++ b/main/src/hardware/input/Button.h
@@ -3,7 +3,7 @@
 
 #include "GpioInput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class Button : public GpioInput {
@@ -22,6 +22,6 @@ private:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/hardware/input/GpioInput.cpp
+++ b/main/src/hardware/input/GpioInput.cpp
@@ -1,6 +1,6 @@
 #include "GpioInput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 GpioInput::GpioInput(uint8_t pin) : _pin(pin), _initialized(false) {}
@@ -52,4 +52,4 @@ bool GpioInput::isInitialized() const {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/input/GpioInput.h
+++ b/main/src/hardware/input/GpioInput.h
@@ -3,7 +3,7 @@
 
 #include <Arduino.h>
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class GpioInput {
@@ -21,6 +21,6 @@ protected:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/hardware/input/Pir.cpp
+++ b/main/src/hardware/input/Pir.cpp
@@ -1,6 +1,6 @@
 #include "Pir.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 Pir::Pir(uint8_t pin) : GpioInput(pin), _motionDetected(false) {}
@@ -38,4 +38,4 @@ void Pir::signalMotion() {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/input/Pir.h
+++ b/main/src/hardware/input/Pir.h
@@ -3,7 +3,7 @@
 
 #include "GpioInput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class Pir : public GpioInput {
@@ -27,5 +27,5 @@ private:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 #endif

--- a/main/src/hardware/output/GpioOutput.cpp
+++ b/main/src/hardware/output/GpioOutput.cpp
@@ -1,6 +1,6 @@
 #include "GpioOutput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 GpioOutput::GpioOutput(uint8_t pin) : _pin(pin), _initialized(false) {}
@@ -46,4 +46,4 @@ bool GpioOutput::isInitialized() const {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/output/GpioOutput.h
+++ b/main/src/hardware/output/GpioOutput.h
@@ -3,7 +3,7 @@
 
 #include <Arduino.h>
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class GpioOutput {
@@ -21,6 +21,6 @@ protected:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/hardware/output/Led.cpp
+++ b/main/src/hardware/output/Led.cpp
@@ -2,10 +2,10 @@
 #include "src/core/Logger.h"
 #include "src/error/Error.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 // Static member init
 Led* Led::_systemErrorLed = nullptr;
@@ -26,8 +26,8 @@ bool Led::init() {
   // Use GpioOutput::init() for validation and pinMode
   if (!GpioOutput::init()) {
     if (this != _systemErrorLed) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                            planetopia::core::ModuleDigit::HW, 1, "Led: Invalid pin number");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                            lattice::core::ModuleDigit::HW, 1, "Led: Invalid pin number");
     }
     Logger::logln("Led", "ERROR: Invalid pin number for LED: " + String(_pin), LogLevel::LOG_ERROR);
     return false;
@@ -41,8 +41,8 @@ bool Led::init() {
 bool Led::on() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::HW, 2,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::HW, 2,
                             "Led: on() called before initialization");
     }
     Logger::logln("Led", "ERROR: on() called before initialization", LogLevel::LOG_ERROR);
@@ -54,8 +54,8 @@ bool Led::on() {
 bool Led::off() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::HW, 3,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::HW, 3,
                             "Led: off() called before initialization");
     }
     Logger::logln("Led", "ERROR: off() called before initialization", LogLevel::LOG_ERROR);
@@ -67,8 +67,8 @@ bool Led::off() {
 bool Led::toggle() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::HW, 4,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::HW, 4,
                             "Led: toggle() called before initialization");
     }
     Logger::logln("Led", "ERROR: toggle() called before initialization", LogLevel::LOG_ERROR);
@@ -104,8 +104,8 @@ void Led::setSystemErrorLed(Led* led) {
 bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                            planetopia::core::ModuleDigit::HW, 5,
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                            lattice::core::ModuleDigit::HW, 5,
                             "Led: blink() called before initialization");
     }
     Logger::logln("Led", "ERROR: blink() called before initialization", LogLevel::LOG_ERROR);
@@ -124,4 +124,4 @@ bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/output/Led.cpp
+++ b/main/src/hardware/output/Led.cpp
@@ -26,8 +26,8 @@ bool Led::init() {
   // Use GpioOutput::init() for validation and pinMode
   if (!GpioOutput::init()) {
     if (this != _systemErrorLed) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                            lattice::core::ModuleDigit::HW, 1, "Led: Invalid pin number");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
+                         "Led: Invalid pin number");
     }
     Logger::logln("Led", "ERROR: Invalid pin number for LED: " + String(_pin), LogLevel::LOG_ERROR);
     return false;
@@ -41,9 +41,8 @@ bool Led::init() {
 bool Led::on() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                            lattice::core::ModuleDigit::HW, 2,
-                            "Led: on() called before initialization");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 2,
+                         "Led: on() called before initialization");
     }
     Logger::logln("Led", "ERROR: on() called before initialization", LogLevel::LOG_ERROR);
     return false;
@@ -54,9 +53,8 @@ bool Led::on() {
 bool Led::off() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                            lattice::core::ModuleDigit::HW, 3,
-                            "Led: off() called before initialization");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 3,
+                         "Led: off() called before initialization");
     }
     Logger::logln("Led", "ERROR: off() called before initialization", LogLevel::LOG_ERROR);
     return false;
@@ -67,9 +65,8 @@ bool Led::off() {
 bool Led::toggle() {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                            lattice::core::ModuleDigit::HW, 4,
-                            "Led: toggle() called before initialization");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 4,
+                         "Led: toggle() called before initialization");
     }
     Logger::logln("Led", "ERROR: toggle() called before initialization", LogLevel::LOG_ERROR);
     return false;
@@ -104,9 +101,8 @@ void Led::setSystemErrorLed(Led* led) {
 bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
   if (!_initialized) {
     if (this != _systemErrorLed) {
-      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                            lattice::core::ModuleDigit::HW, 5,
-                            "Led: blink() called before initialization");
+      lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 5,
+                         "Led: blink() called before initialization");
     }
     Logger::logln("Led", "ERROR: blink() called before initialization", LogLevel::LOG_ERROR);
     return false;

--- a/main/src/hardware/output/Led.h
+++ b/main/src/hardware/output/Led.h
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 #include "GpioOutput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class Led : public GpioOutput {
@@ -36,6 +36,6 @@ private:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/hardware/output/SevenSegDisplay.cpp
+++ b/main/src/hardware/output/SevenSegDisplay.cpp
@@ -36,8 +36,8 @@ SevenSegDisplay::SevenSegDisplay(uint8_t dio, uint8_t clk)
 bool SevenSegDisplay::init() {
   if (!GpioOutput::isValidOutputPin(_dioPin) || !GpioOutput::isValidOutputPin(_clkPin)) {
     Logger::logln("7SEG", "Invalid GPIO pins", lattice::utils::LogLevel::LOG_ERROR);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
-                          lattice::core::ModuleDigit::HW, 1, "7Seg invalid pins");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
+                       "7Seg invalid pins");
     return false;
   }
   pinMode(_dioPin, OUTPUT);
@@ -116,8 +116,8 @@ bool SevenSegDisplay::writeByte(uint8_t b) {
   digitalWrite(_clkPin, LOW);
   if (!ack) {
     Logger::logln("7SEG", "ACK timeout", lattice::utils::LogLevel::LOG_WARN);
-    lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
-                          lattice::core::ModuleDigit::HW, 2, "7Seg ACK timeout");
+    lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 2,
+                       "7Seg ACK timeout");
   }
   return ack;
 }

--- a/main/src/hardware/output/SevenSegDisplay.cpp
+++ b/main/src/hardware/output/SevenSegDisplay.cpp
@@ -3,11 +3,11 @@
 #include "src/core/Logger.h"
 #include "src/error/Error.h"
 
-using planetopia::core::ErrorTypeDigit;
-using planetopia::core::ModuleDigit;
-using planetopia::utils::Logger;
+using lattice::core::ErrorTypeDigit;
+using lattice::core::ModuleDigit;
+using lattice::utils::Logger;
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 // 0b0GFEDCBA – bit7 is DP
@@ -35,16 +35,16 @@ SevenSegDisplay::SevenSegDisplay(uint8_t dio, uint8_t clk)
 
 bool SevenSegDisplay::init() {
   if (!GpioOutput::isValidOutputPin(_dioPin) || !GpioOutput::isValidOutputPin(_clkPin)) {
-    Logger::logln("7SEG", "Invalid GPIO pins", planetopia::utils::LogLevel::LOG_ERROR);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::CONFIG,
-                          planetopia::core::ModuleDigit::HW, 1, "7Seg invalid pins");
+    Logger::logln("7SEG", "Invalid GPIO pins", lattice::utils::LogLevel::LOG_ERROR);
+    lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG,
+                          lattice::core::ModuleDigit::HW, 1, "7Seg invalid pins");
     return false;
   }
   pinMode(_dioPin, OUTPUT);
   pinMode(_clkPin, OUTPUT);
   digitalWrite(_clkPin, HIGH);
   digitalWrite(_dioPin, HIGH);
-  Logger::logln("7SEG", "SevenSegDisplay initialized", planetopia::utils::LogLevel::LOG_INFO);
+  Logger::logln("7SEG", "SevenSegDisplay initialized", lattice::utils::LogLevel::LOG_INFO);
   // Self-test: flash all segments 0x7F (88:88)
   uint8_t testSeg[4] = {0x7F, 0x7F, 0x7F, 0x7F};
   setSegments(testSeg);
@@ -115,9 +115,9 @@ bool SevenSegDisplay::writeByte(uint8_t b) {
   pinMode(_dioPin, OUTPUT);
   digitalWrite(_clkPin, LOW);
   if (!ack) {
-    Logger::logln("7SEG", "ACK timeout", planetopia::utils::LogLevel::LOG_WARN);
-    planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
-                          planetopia::core::ModuleDigit::HW, 2, "7Seg ACK timeout");
+    Logger::logln("7SEG", "ACK timeout", lattice::utils::LogLevel::LOG_WARN);
+    lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE,
+                          lattice::core::ModuleDigit::HW, 2, "7Seg ACK timeout");
   }
   return ack;
 }
@@ -212,4 +212,4 @@ void SevenSegDisplay::showWithDP(int value, bool leadingZeros) {
 }
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/hardware/output/SevenSegDisplay.h
+++ b/main/src/hardware/output/SevenSegDisplay.h
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 #include "GpioOutput.h"
 
-namespace planetopia {
+namespace lattice {
 namespace hardware {
 
 class SevenSegDisplay {
@@ -37,6 +37,6 @@ private:
 };
 
 } // namespace hardware
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/network/MacAddress.h
+++ b/main/src/network/MacAddress.h
@@ -4,7 +4,7 @@
 #include <Arduino.h>
 #include <cstring>
 
-namespace planetopia {
+namespace lattice {
 namespace utils {
 
 struct MacAddress {
@@ -54,6 +54,6 @@ inline MacAddress::MacAddress(const String& macString) {
 }
 
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice
 
 #endif

--- a/main/src/persistence/EEPROM_Manager.cpp
+++ b/main/src/persistence/EEPROM_Manager.cpp
@@ -1,7 +1,7 @@
 #include "EEPROM_Manager.h"
 #include "src/error/Error.h"
 
-namespace planetopia {
+namespace lattice {
 namespace utils {
 
 EEPROM_Manager::EEPROM_Manager()
@@ -28,8 +28,8 @@ bool EEPROM_Manager::beginEEPROM() {
 
 void EEPROM_Manager::handleInitFailure() {
   Logger::logln("EEPROM", "Failed to initialize EEPROM", LogLevel::LOG_ERROR);
-  planetopia::err::fail(planetopia::core::ErrorTypeDigit::MEMORY,
-                        planetopia::core::ModuleDigit::EEPROM, 1,
+  lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
+                        lattice::core::ModuleDigit::EEPROM, 1,
                         "EEPROM_Manager: EEPROM.begin failed");
 }
 
@@ -272,7 +272,7 @@ void EEPROM_Manager::saveMeshKey(const uint8_t* key, size_t keySize) {
 // Peer list operations
 // Each peer record is PEER_RECORD_SIZE (38) bytes: 6-byte MAC + 32-byte Curve25519 public key.
 bool EEPROM_Manager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
-  planetopia::err::check(peerRecords != nullptr, planetopia::utils::ErrorType::CONFIG_ERROR,
+  lattice::err::check(peerRecords != nullptr, lattice::utils::ErrorType::CONFIG_ERROR,
                          "loadPeerList: peerRecords null");
   if (!ensureInitialized())
     return false;
@@ -289,7 +289,7 @@ bool EEPROM_Manager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
 }
 
 void EEPROM_Manager::savePeerList(const uint8_t* peerRecords, size_t numPeers) {
-  planetopia::err::check(peerRecords != nullptr, planetopia::utils::ErrorType::CONFIG_ERROR,
+  lattice::err::check(peerRecords != nullptr, lattice::utils::ErrorType::CONFIG_ERROR,
                          "savePeerList: peerRecords null");
   if (!ensureInitialized())
     return;
@@ -535,16 +535,16 @@ void EEPROM_Manager::clearKnownMasterMacSecondary() {
 }
 
 // TX power preset operations
-planetopia::config::TxPowerPreset EEPROM_Manager::loadTxPowerPreset() {
+lattice::config::TxPowerPreset EEPROM_Manager::loadTxPowerPreset() {
   if (!ensureInitialized())
-    return planetopia::config::DEFAULT_TX_POWER_PRESET;
+    return lattice::config::DEFAULT_TX_POWER_PRESET;
   uint8_t val = EEPROM.read(EEPROM_ADDRESSES::TX_POWER_PRESET);
   if (val > 2 || val == 0xFF)
-    return planetopia::config::DEFAULT_TX_POWER_PRESET;
-  return static_cast<planetopia::config::TxPowerPreset>(val);
+    return lattice::config::DEFAULT_TX_POWER_PRESET;
+  return static_cast<lattice::config::TxPowerPreset>(val);
 }
 
-void EEPROM_Manager::saveTxPowerPreset(planetopia::config::TxPowerPreset preset) {
+void EEPROM_Manager::saveTxPowerPreset(lattice::config::TxPowerPreset preset) {
   if (!ensureInitialized() || isDevMode)
     return;
   EEPROM.write(EEPROM_ADDRESSES::TX_POWER_PRESET, static_cast<uint8_t>(preset));
@@ -643,4 +643,4 @@ void EEPROM_Manager::printAddress(uint16_t address, uint16_t length) {
 }
 
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice

--- a/main/src/persistence/EEPROM_Manager.cpp
+++ b/main/src/persistence/EEPROM_Manager.cpp
@@ -28,9 +28,8 @@ bool EEPROM_Manager::beginEEPROM() {
 
 void EEPROM_Manager::handleInitFailure() {
   Logger::logln("EEPROM", "Failed to initialize EEPROM", LogLevel::LOG_ERROR);
-  lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY,
-                        lattice::core::ModuleDigit::EEPROM, 1,
-                        "EEPROM_Manager: EEPROM.begin failed");
+  lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::EEPROM, 1,
+                     "EEPROM_Manager: EEPROM.begin failed");
 }
 
 // --- refactored init with formal schema versioning ---
@@ -273,7 +272,7 @@ void EEPROM_Manager::saveMeshKey(const uint8_t* key, size_t keySize) {
 // Each peer record is PEER_RECORD_SIZE (38) bytes: 6-byte MAC + 32-byte Curve25519 public key.
 bool EEPROM_Manager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
   lattice::err::check(peerRecords != nullptr, lattice::utils::ErrorType::CONFIG_ERROR,
-                         "loadPeerList: peerRecords null");
+                      "loadPeerList: peerRecords null");
   if (!ensureInitialized())
     return false;
   if (maxPeers > EEPROM_SIZES::MAX_PEERS) {
@@ -290,7 +289,7 @@ bool EEPROM_Manager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
 
 void EEPROM_Manager::savePeerList(const uint8_t* peerRecords, size_t numPeers) {
   lattice::err::check(peerRecords != nullptr, lattice::utils::ErrorType::CONFIG_ERROR,
-                         "savePeerList: peerRecords null");
+                      "savePeerList: peerRecords null");
   if (!ensureInitialized())
     return;
   if (numPeers > EEPROM_SIZES::MAX_PEERS) {

--- a/main/src/persistence/EEPROM_Manager.h
+++ b/main/src/persistence/EEPROM_Manager.h
@@ -6,7 +6,7 @@
 #include "src/core/Logger.h"
 #include "../../project_config.h"
 
-namespace planetopia {
+namespace lattice {
 namespace utils {
 
 // EEPROM address constants - centralized in one place
@@ -155,8 +155,8 @@ public:
   void clearKnownMasterMacSecondary();
 
   // TX power preset — deployment-specific, persisted across reboots
-  planetopia::config::TxPowerPreset loadTxPowerPreset();
-  void saveTxPowerPreset(planetopia::config::TxPowerPreset preset);
+  lattice::config::TxPowerPreset loadTxPowerPreset();
+  void saveTxPowerPreset(lattice::config::TxPowerPreset preset);
 
   // Node ID — logical node ID assigned by server (0 = unset)
   uint8_t loadNodeId();
@@ -180,6 +180,6 @@ public:
 };
 
 } // namespace utils
-} // namespace planetopia
+} // namespace lattice
 
 #endif // EEPROM_MANAGER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(planetopia_tests C CXX)
+project(lattice_tests C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 99)
 

--- a/tests/integration/harness.py
+++ b/tests/integration/harness.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 BAUD_RATE = 115200
 
-# Serial opcodes (must match planetopia-protocol/c/opcodes.h)
+# Serial opcodes (must match lattice-protocol/c/opcodes.h)
 OP_NODE_ID_SET        = 0xC0
 OP_CONFIG_SET         = 0xC1
 OP_TX_POWER_SET       = 0xC2
@@ -82,11 +82,11 @@ class Node:
         return False
 
     def get_public_key(self, timeout: float = 5.0) -> Optional[bytes]:
-        """Read PLANETOPIA_PUBKEY:... line from serial, return 32 bytes."""
-        line = wait_for_line(self.port, 'PLANETOPIA_PUBKEY:', timeout)
+        """Read LATTICE_PUBKEY:... line from serial, return 32 bytes."""
+        line = wait_for_line(self.port, 'LATTICE_PUBKEY:', timeout)
         if not line:
             return None
-        hex_str = line.split('PLANETOPIA_PUBKEY:')[1].strip()
+        hex_str = line.split('LATTICE_PUBKEY:')[1].strip()
         return bytes.fromhex(hex_str) if len(hex_str) == 64 else None
 
     def send_enrollment_approve(self, mac: bytes, server_url: str, admin_key: str) -> None:

--- a/tests/integration/test_enrollment.py
+++ b/tests/integration/test_enrollment.py
@@ -32,7 +32,7 @@ def node():
 def test_node_prints_public_key_on_boot(node):
     """New node should print its public key to serial for provisioning."""
     pub_key = node.get_public_key(timeout=10.0)
-    assert pub_key is not None, "Node did not print PLANETOPIA_PUBKEY"
+    assert pub_key is not None, "Node did not print LATTICE_PUBKEY"
     assert len(pub_key) == 32
 
 

--- a/tests/mocks/firmware_stubs.cpp
+++ b/tests/mocks/firmware_stubs.cpp
@@ -11,7 +11,7 @@
 // Mesh.cpp is not compiled on host (it pulls in mbedtls, esp_now internals, etc.)
 // Provide minimal stubs for the symbols Serial_Adapter.cpp and Adapter.cpp reference.
 
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 
 // Forward declaration matching Mesh.h types
@@ -22,7 +22,7 @@ class Mesh;
 Mesh* Mesh_instance_stub = nullptr;
 
 } // namespace mesh
-} // namespace planetopia
+} // namespace lattice
 
 // Mesh::instance — defined as a static member in Mesh.h; we need the storage
 // We can't easily stub the class here without including Mesh.h (which drags in esp_now.h etc.)
@@ -35,18 +35,18 @@ Mesh* Mesh_instance_stub = nullptr;
 // Now include Mesh.h to get the class definition
 #include "src/Mesh/Mesh.h"
 
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 
 // Static member definition
 Mesh* Mesh::instance = nullptr;
 
 // transmit — static function pointer; defined as a static member
-void Mesh::transmit(const planetopia::adapter::adapter_types, const uint8_t[64]) {
+void Mesh::transmit(const lattice::adapter::adapter_types, const uint8_t[64]) {
   // stub: no-op in tests
 }
 
-void Mesh::broadcastAdapterDataStatic(planetopia::adapter::adapter_types, const uint8_t[64]) {
+void Mesh::broadcastAdapterDataStatic(lattice::adapter::adapter_types, const uint8_t[64]) {
   // stub: no-op in tests
 }
 
@@ -134,6 +134,6 @@ void Mesh::loadOrGenerateKeypair() {}
 // drainRecvQueue are implemented in mesh_logic_impl.cpp (real logic)
 
 } // namespace mesh
-} // namespace planetopia
+} // namespace lattice
 
 // skipField is defined in ProtobufCodec.cpp with external linkage — no stub needed here.

--- a/tests/mocks/firmware_stubs.cpp
+++ b/tests/mocks/firmware_stubs.cpp
@@ -42,11 +42,11 @@ namespace mesh {
 Mesh* Mesh::instance = nullptr;
 
 // transmit — static function pointer; defined as a static member
-void Mesh::transmit(const lattice::adapter::adapter_types, const uint8_t[64]) {
+void Mesh::transmit(const lattice::adapter::adapter_types, const uint8_t*) {
   // stub: no-op in tests
 }
 
-void Mesh::broadcastAdapterDataStatic(lattice::adapter::adapter_types, const uint8_t[64]) {
+void Mesh::broadcastAdapterDataStatic(lattice::adapter::adapter_types, const uint8_t*) {
   // stub: no-op in tests
 }
 
@@ -91,7 +91,7 @@ void Mesh::onDataSentCallback(const wifi_tx_info_t*, esp_now_send_status_t) {}
 void Mesh::IRAM_ATTR dataRecvTrampoline(const esp_now_recv_info*, const uint8_t*, int) {}
 void Mesh::IRAM_ATTR onDataRecvCallback(const esp_now_recv_info*, const uint8_t*, int) {}
 
-mesh_message Mesh::buildMessage(adapter_types, const uint8_t[64], MeshMessageType) {
+mesh_message Mesh::buildMessage(adapter_types, const uint8_t*, MeshMessageType) {
   return mesh_message{};
 }
 

--- a/tests/mocks/mesh_logic_impl.cpp
+++ b/tests/mocks/mesh_logic_impl.cpp
@@ -11,13 +11,13 @@
 #include "src/core/Logger.h"
 #include "src/persistence/EEPROM_Manager.h"
 #include "../../main/project_config.h"
-#include "lib/planetopia-protocol/c/opcodes.h"
+#include "lib/lattice-protocol/c/opcodes.h"
 #include <cstring>
 
-namespace planetopia {
+namespace lattice {
 namespace mesh {
 
-using namespace planetopia::utils;
+using namespace lattice::utils;
 
 bool Mesh::isReplay(const mesh_message& msg) {
   for (size_t i = 0; i < REPLAY_CACHE_SIZE; ++i) {
@@ -36,7 +36,7 @@ bool Mesh::isReplay(const mesh_message& msg) {
 
 void Mesh::processMasterBeacon(const mesh_message& msg) {
   // Guard: drop beacon if hop count would overflow uint8_t or exceed limit
-  if (msg.hopCount >= planetopia::config::MAX_HOPS) {
+  if (msg.hopCount >= lattice::config::MAX_HOPS) {
     Logger::logln("MESH", "Beacon hop count exceeded MAX_HOPS, dropping relay", LogLevel::LOG_WARN);
     return;
   }
@@ -75,8 +75,8 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     }
   }
 
-  if (planetopia::utils::MacAddress(lastSeenMasterMac) !=
-          planetopia::utils::MacAddress(msg.originMacAddress) &&
+  if (lattice::utils::MacAddress(lastSeenMasterMac) !=
+          lattice::utils::MacAddress(msg.originMacAddress) &&
       lastSeenMasterMac[0] != 0) {
     if (_dualMasterMode) {
       Logger::logln("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
@@ -89,8 +89,8 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 
   uint8_t newDistance = msg.hopCount + 1;
   if (currentMaster.distance == 0xFF ||
-      planetopia::utils::MacAddress(currentMaster.mac) !=
-          planetopia::utils::MacAddress(msg.originMacAddress) ||
+      lattice::utils::MacAddress(currentMaster.mac) !=
+          lattice::utils::MacAddress(msg.originMacAddress) ||
       newDistance < currentMaster.distance) {
     memcpy(currentMaster.mac, msg.originMacAddress, 6);
     currentMaster.distance = newDistance;
@@ -109,7 +109,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     lastRelayedSeqNum = msg.seqNum;
 
     // Defer relay with jitter (esp_random() returns deterministic 42 in tests)
-    uint8_t jitterMs = static_cast<uint8_t>(esp_random() % planetopia::config::RELAY_JITTER_MAX_MS);
+    uint8_t jitterMs = static_cast<uint8_t>(esp_random() % lattice::config::RELAY_JITTER_MAX_MS);
     relayPendingMsg = msg;
     relayPendingMsg.hopCount = newDistance;
     memcpy(relayPendingMsg.lastHopMacAddress, deviceMacAddress, 6);
@@ -169,7 +169,7 @@ bool Mesh::appendPeer(const PeerInfo& peer) {
 }
 
 void Mesh::sendMessage(const uint8_t target[6], mesh_message msg) {
-  if (planetopia::utils::MacAddress(target) == planetopia::utils::MacAddress(deviceMacAddress)) {
+  if (lattice::utils::MacAddress(target) == lattice::utils::MacAddress(deviceMacAddress)) {
     Logger::logln("MESH", "Not sending to self. Skipped.", LogLevel::LOG_DEBUG);
     return;
   }
@@ -182,7 +182,7 @@ void Mesh::sendMessage(const uint8_t target[6], mesh_message msg) {
 }
 
 void Mesh::relayDownlink(const mesh_message& msg) {
-  if (msg.hopCount >= planetopia::config::MAX_HOPS)
+  if (msg.hopCount >= lattice::config::MAX_HOPS)
     return;
   mesh_message relay = msg;
   relay.hopCount++;
@@ -233,8 +233,8 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMe
 
   // Routing: always use next hop if possible
   PeerInfo* nextHop = findNextHopToMaster();
-  if (nextHop && planetopia::utils::MacAddress(nextHop->mac) !=
-                     planetopia::utils::MacAddress(deviceMacAddress)) {
+  if (nextHop && lattice::utils::MacAddress(nextHop->mac) !=
+                     lattice::utils::MacAddress(deviceMacAddress)) {
     sendMessage(nextHop->mac, msg);
   } else {
     // Intentionally stubbed: production calls err::fail(); tests never hit this
@@ -256,7 +256,7 @@ bool Mesh::isPeerInRange(const uint8_t mac[6]) {
   PeerInfo* peer = findPeer(mac);
   if (!peer)
     return false;
-  return millis() - peer->lastSeenMillis < planetopia::config::STALE_PEER_THRESHOLD_MS;
+  return millis() - peer->lastSeenMillis < lattice::config::STALE_PEER_THRESHOLD_MS;
 }
 
 PeerInfo* Mesh::findNextHopToMaster() {
@@ -264,11 +264,11 @@ PeerInfo* Mesh::findNextHopToMaster() {
   if (currentMaster.distance == 0xFF)
     return nullptr;
   for (size_t i = 0; i < peerCount; ++i) {
-    if (planetopia::utils::MacAddress(peerMacs[i].mac) ==
-            planetopia::utils::MacAddress(currentMaster.nextHop) &&
+    if (lattice::utils::MacAddress(peerMacs[i].mac) ==
+            lattice::utils::MacAddress(currentMaster.nextHop) &&
         isPeerInRange(peerMacs[i].mac) &&
-        planetopia::utils::MacAddress(peerMacs[i].mac) !=
-            planetopia::utils::MacAddress(deviceMacAddress))
+        lattice::utils::MacAddress(peerMacs[i].mac) !=
+            lattice::utils::MacAddress(deviceMacAddress))
       return &peerMacs[i];
   }
   return nullptr;
@@ -297,7 +297,7 @@ void Mesh::linkDataRecvCallback(std::function<void(mesh_message)> recvCallback) 
 }
 
 void Mesh::processAdapterData(const mesh_message& msg) {
-  // OP_CONFIG_SET = 0xC1 (from main/lib/planetopia-protocol/opcodes.h)
+  // OP_CONFIG_SET = 0xC1 (from main/lib/lattice-protocol/opcodes.h)
   static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   bool addressedToSelf = (memcmp(msg.targetMacAddress, deviceMacAddress, 6) == 0);
@@ -308,7 +308,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   if (!isMaster && !addressedToSelf && !isBroadcastTarget) {
     if (addressedToMaster) {
       // Uplink: relay toward master via routing table
-      if (msg.hopCount >= planetopia::config::MAX_HOPS)
+      if (msg.hopCount >= lattice::config::MAX_HOPS)
         return;
       mesh_message relay = msg;
       relay.hopCount++;
@@ -382,4 +382,4 @@ void Mesh::drainPendingEnrollment() {
 }
 
 } // namespace mesh
-} // namespace planetopia
+} // namespace lattice

--- a/tests/unit/test_eeprom_manager.cpp
+++ b/tests/unit/test_eeprom_manager.cpp
@@ -3,9 +3,9 @@
 #include "persistence/EEPROM_Manager.h"
 #include "Mesh/Mesh.h" // for PeerInfo and PEER_RECORD_SIZE constants
 
-using planetopia::mesh::PeerInfo;
-using planetopia::utils::EEPROM_Manager;
-using planetopia::utils::EEPROM_SIZES::PEER_RECORD_SIZE;
+using lattice::mesh::PeerInfo;
+using lattice::utils::EEPROM_Manager;
+using lattice::utils::EEPROM_SIZES::PEER_RECORD_SIZE;
 
 // -----------------------------------------------------------------------
 // Test fixture
@@ -155,7 +155,7 @@ TEST_F(EEPROMMgrTest, Keypair_Load_CorruptedData_ReturnsFalse) {
   mgr.saveKeypair(priv, pub);
 
   // Corrupt one byte in the private key region
-  using namespace planetopia::utils::EEPROM_ADDRESSES;
+  using namespace lattice::utils::EEPROM_ADDRESSES;
   EEPROM._data[PRIVATE_KEY + 5] ^= 0xFF;
 
   uint8_t p1[32]{}, p2[32]{};
@@ -224,13 +224,13 @@ TEST_F(EEPROMMgrTest, ForceFlush_CommitsImmediately) {
 TEST_F(EEPROMMgrTest, TxPower_DefaultIsOutdoor) {
   // Blank EEPROM (0xFF) → default preset
   auto preset = EEPROM_Manager::getInstance().loadTxPowerPreset();
-  EXPECT_EQ(preset, planetopia::config::TxPowerPreset::OUTDOOR);
+  EXPECT_EQ(preset, lattice::config::TxPowerPreset::OUTDOOR);
 }
 
 TEST_F(EEPROMMgrTest, TxPower_SaveAndLoad) {
   auto& mgr = EEPROM_Manager::getInstance();
-  mgr.saveTxPowerPreset(planetopia::config::TxPowerPreset::INDOOR);
-  EXPECT_EQ(mgr.loadTxPowerPreset(), planetopia::config::TxPowerPreset::INDOOR);
+  mgr.saveTxPowerPreset(lattice::config::TxPowerPreset::INDOOR);
+  EXPECT_EQ(mgr.loadTxPowerPreset(), lattice::config::TxPowerPreset::INDOOR);
 }
 
 // -----------------------------------------------------------------------

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -4,7 +4,7 @@
 #include "time_mock.h"
 #include "EEPROM.h"
 
-using namespace planetopia::mesh;
+using namespace lattice::mesh;
 
 class MeshLogicTest : public ::testing::Test {
 protected:
@@ -281,7 +281,7 @@ TEST_F(RelayDownlinkTest, DropsAtMaxHops) {
   mesh.appendPeer(p1);
 
   auto msg = makeDataMsg(kOriginMac, kPeer1Mac, 1, 1,
-                         /*hopCount=*/planetopia::config::MAX_HOPS);
+                         /*hopCount=*/lattice::config::MAX_HOPS);
 
   mesh.relayDownlink(msg);
 

--- a/tests/unit/test_pir_adapter.cpp
+++ b/tests/unit/test_pir_adapter.cpp
@@ -9,7 +9,7 @@
 #include "persistence/EEPROM_Manager.h"
 #include "Mesh/Mesh.h"
 
-using namespace planetopia::adapter;
+using namespace lattice::adapter;
 
 // Capture buffer for transmitted data
 static adapter_types lastTxType;
@@ -26,7 +26,7 @@ class PIRHealthTest : public ::testing::Test {
 protected:
   void SetUp() override {
     EEPROM.reset();
-    planetopia::utils::EEPROM_Manager::getInstance().init();
+    lattice::utils::EEPROM_Manager::getInstance().init();
     resetMillis();
     resetWifiMock();
     lastTxType = adapter_types::UNKNOWN_ADAPTER;
@@ -159,7 +159,7 @@ TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
   mockDeviceMac[4] = 0x55;
   mockDeviceMac[5] = 0x66;
 
-  planetopia::mesh::mesh_message msg{};
+  lattice::mesh::mesh_message msg{};
   msg.dataType = adapter_types::SERIAL_ADAPTER;
   msg.data[0] = 0xC0; // OP_NODE_ID_SET
   // target MAC = mockDeviceMac
@@ -168,7 +168,7 @@ TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
 
   pir->onMeshData(msg);
 
-  EXPECT_EQ(planetopia::utils::EEPROM_Manager::getInstance().loadNodeId(), 99u);
+  EXPECT_EQ(lattice::utils::EEPROM_Manager::getInstance().loadNodeId(), 99u);
   delete pir;
 }
 
@@ -183,7 +183,7 @@ TEST_F(PIRHealthTest, OpNodeIdSet_IgnoresMessage_WhenTargetMismatch) {
   mockDeviceMac[4] = 0xEE;
   mockDeviceMac[5] = 0xFF;
 
-  planetopia::mesh::mesh_message msg{};
+  lattice::mesh::mesh_message msg{};
   msg.dataType = adapter_types::SERIAL_ADAPTER;
   msg.data[0] = 0xC0;
   uint8_t differentMac[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
@@ -192,6 +192,6 @@ TEST_F(PIRHealthTest, OpNodeIdSet_IgnoresMessage_WhenTargetMismatch) {
 
   pir->onMeshData(msg);
 
-  EXPECT_EQ(planetopia::utils::EEPROM_Manager::getInstance().loadNodeId(), 0u);
+  EXPECT_EQ(lattice::utils::EEPROM_Manager::getInstance().loadNodeId(), 0u);
   delete pir;
 }

--- a/tests/unit/test_pir_adapter.cpp
+++ b/tests/unit/test_pir_adapter.cpp
@@ -149,7 +149,7 @@ TEST_F(PIRHealthTest, UptimeReflectsActualMillis) {
 
 TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
   PIR_Adapter* pir = new PIR_Adapter(2);
-  pir->setTransmitFn([](adapter_types, const uint8_t[64]) {});
+  pir->setTransmitFn([](adapter_types, const uint8_t*) {});
 
   // Set mockDeviceMac to known value
   mockDeviceMac[0] = 0x11;
@@ -174,7 +174,7 @@ TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
 
 TEST_F(PIRHealthTest, OpNodeIdSet_IgnoresMessage_WhenTargetMismatch) {
   PIR_Adapter* pir = new PIR_Adapter(2);
-  pir->setTransmitFn([](adapter_types, const uint8_t[64]) {});
+  pir->setTransmitFn([](adapter_types, const uint8_t*) {});
 
   mockDeviceMac[0] = 0xAA;
   mockDeviceMac[1] = 0xBB;

--- a/tests/unit/test_replay_cache.cpp
+++ b/tests/unit/test_replay_cache.cpp
@@ -4,7 +4,7 @@
 #include "time_mock.h"
 #include "EEPROM.h"
 
-using namespace planetopia::mesh;
+using namespace lattice::mesh;
 
 // ReplayCache is tested via Mesh's isReplay() method.
 // We construct a Mesh instance in test mode and call isReplay directly.


### PR DESCRIPTION
## Summary
- Renames submodule path `main/lib/planetopia-protocol` → `main/lib/lattice-protocol`
- Updates `.gitmodules` URL to `github.com/superbrobenji/lattice-protocol`
- Renames all C++ namespaces `planetopia::*` → `lattice::*`
- Updates ECDH persona strings (`"planetopia_ecdh"` → `"lattice_ecdh"`) — existing node enrollments will be invalidated after flashing
- Renames CMake project and all Planetopia references in tests, harness, and README

## Test plan
- [ ] CMake build passes
- [ ] 70/70 integration tests pass
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)