### PR TITLE
ci: bump codeql-action init+analyze together to v4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: cpp
           build-mode: manual
@@ -41,6 +41,6 @@ jobs:
           cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
           cmake --build tests/build --target lattice_e2e --parallel 2
 
-      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: '/language:cpp'


### PR DESCRIPTION
Supersedes #26 and #27.

Dependabot split the `init` and `analyze` bumps into separate PRs, but mixing v3/v4 codeql-action steps fails the Analyze job:

```
Loaded a configuration file for version '3.36.2', but running version '4.37.0'
```

This bumps both steps to `v4.37.0` (same pinned SHA) in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)