### PR TITLE
fix: resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,13 @@ jobs:
           languages: cpp
           build-mode: manual
           queries: security-and-quality
+          config: |
+            paths-ignore:
+              # Vendored third-party code — not ours to fix
+              - main/src/mesh/serialization/nanopb
+              - main/lib/lattice-protocol
+              # Build tree (FetchContent-downloaded googletest sources)
+              - tests/build
 
       - name: Install CMake
         run: sudo apt-get install -y cmake

--- a/main/src/adapter/Adapter.cpp
+++ b/main/src/adapter/Adapter.cpp
@@ -108,19 +108,19 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
                         " (stub — no RGB driver)",
                     LogLevel::LOG_INFO);
       // Send OP_COMMAND_ACK back through the mesh
-      uint8_t ackData[12] = {0};
+      uint8_t ackData[64] = {0};
       ackData[0] = OP_COMMAND_ACK;
       ackData[1] = op; // echo the handled opcode as the command ID
       sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);
     } else if (op == OP_LED_OFF) {
       Logger::logln("ADAPTER", "OP_LED_OFF (stub — no RGB driver)", LogLevel::LOG_INFO);
-      uint8_t ackData[12] = {0};
+      uint8_t ackData[64] = {0};
       ackData[0] = OP_COMMAND_ACK;
       ackData[1] = op;
       sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);
     } else if (op == OP_LED_BLINK) {
       Logger::logln("ADAPTER", "OP_LED_BLINK (stub — no RGB driver)", LogLevel::LOG_INFO);
-      uint8_t ackData[12] = {0};
+      uint8_t ackData[64] = {0};
       ackData[0] = OP_COMMAND_ACK;
       ackData[1] = op;
       sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);

--- a/main/src/hardware/output/SevenSegDisplay.cpp
+++ b/main/src/hardware/output/SevenSegDisplay.cpp
@@ -130,7 +130,7 @@ uint8_t SevenSegDisplay::encodeDigit(int d) {
   return 0x00;
 }
 
-void SevenSegDisplay::setSegments(const uint8_t segs[4]) {
+void SevenSegDisplay::setSegments(const uint8_t (&segs)[4]) {
   start();
   writeByte(0x40); // automatic address increment mode
   stop();
@@ -170,7 +170,7 @@ void SevenSegDisplay::show(int value, bool leadingZeros) {
 
   uint8_t segs[4];
   for (int i = 0; i < 4; ++i) {
-    if (!leadingZeros && digits[i] == 0 && i < 3 && !negative)
+    if (!leadingZeros && i < 3 && digits[i] == 0 && !negative)
       segs[i] = 0x00;
     else
       segs[i] = encodeDigit(digits[i]);
@@ -202,7 +202,7 @@ void SevenSegDisplay::showWithDP(int value, bool leadingZeros) {
 
   uint8_t segs[4];
   for (int i = 0; i < 4; ++i) {
-    if (!leadingZeros && digits[i] == 0 && i < 3 && !negative)
+    if (!leadingZeros && i < 3 && digits[i] == 0 && !negative)
       segs[i] = 0x00;
     else
       segs[i] = encodeDigit(digits[i]);

--- a/main/src/hardware/output/SevenSegDisplay.h
+++ b/main/src/hardware/output/SevenSegDisplay.h
@@ -22,7 +22,7 @@ public:
   void showWithDP(int value, bool leadingZeros = false);
 
   // Low-level: write raw segment data (LSB=A, bit6=DP)
-  void setSegments(const uint8_t segs[4]);
+  void setSegments(const uint8_t (&segs)[4]);
 
   void clear();
 

--- a/main/src/persistence/EepromManager.cpp
+++ b/main/src/persistence/EepromManager.cpp
@@ -538,7 +538,7 @@ lattice::config::TxPowerPreset EepromManager::loadTxPowerPreset() {
   if (!ensureInitialized())
     return lattice::config::DEFAULT_TX_POWER_PRESET;
   uint8_t val = EEPROM.read(EEPROM_ADDRESSES::TX_POWER_PRESET);
-  if (val > 2 || val == 0xFF)
+  if (val > 2) // covers the 0xFF erased-EEPROM sentinel
     return lattice::config::DEFAULT_TX_POWER_PRESET;
   return static_cast<lattice::config::TxPowerPreset>(val);
 }

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -107,6 +107,7 @@ TEST_F(MeshLogicTest, BeaconRelay_SameEpochSeq_SuppressedRelay) {
   mesh.processMasterBeacon(makeBeacon(masterMac, 1, 5));
   // Relay should NOT fire — same epoch+seq
   EXPECT_FALSE(mesh.relayPending);
+  EXPECT_EQ(espNowSentPackets.size(), sendsBefore);
 }
 
 TEST_F(MeshLogicTest, BeaconRelay_NewerSeq_AllowsRelay) {


### PR DESCRIPTION
Fixes the actionable open code-scanning alerts:

| Alert | Rule | Fix |
|---|---|---|
| 138-140 (warning) | `cpp/array-arg-size-mismatch` | `ackData[12]` → `ackData[64]`. Real OOB: `Mesh::buildMessage` copies `sizeof(msg.data)` = 64 bytes from the caller's buffer, so LED acks read 52 bytes past the stack array. |
| 101/102 (high) | `cpp/offset-use-before-range-check` | Reorder `digits[i] == 0 && i < 3` → `i < 3 && digits[i] == 0` (loop already bounds `i`; ordering silences the FP for free). |
| 87 (note) | `cpp/array-in-interface` | `setSegments` now takes `const uint8_t (&)[4]` — size enforced at compile time. |
| 141 (warning) | `cpp/constant-comparison` | Drop redundant `val == 0xFF` (covered by `val > 2`). |
| 10 (note) | `cpp/unused-local-variable` | Assert `espNowSentPackets` unchanged on duplicate beacon (matches sibling tests) instead of leaving `sendsBefore` unused. |
| gtest/nanopb alerts | various | `paths-ignore` for vendored nanopb, the protocol submodule, and the FetchContent build tree. |

Remaining open alerts will be dismissed with reasons (intentional migration-ladder guard, heap-only singleton `this` escape, Arduino-mandated `ESP` mock name).

Tests: **128/128 pass** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)