### PR TITLE
fix: check WiFi/ESP-NOW init results; filter vendored paths from CodeQL SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,3 +51,23 @@ jobs:
       - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: '/language:cpp'
+          upload: failure-only
+          output: sarif-results
+
+      # paths-ignore in the init config does not filter RESULTS for compiled
+      # languages — CodeQL extracts everything the build compiles, including
+      # FetchContent deps (googletest, mbedtls) and vendored code. Strip those
+      # from the SARIF before upload so third-party alerts never open.
+      - name: Filter vendored paths from SARIF
+        uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1
+        with:
+          patterns: |
+            -tests/build/**
+            -main/src/mesh/serialization/nanopb/**
+            -main/lib/lattice-protocol/**
+          input: sarif-results/cpp.sarif
+          output: sarif-results/cpp.sarif
+
+      - uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: sarif-results/cpp.sarif

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -48,7 +48,9 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t (&mac)[6]) { return lattice::utils::MacAddress(mac).toString(); };
+  auto macToStr = [](const uint8_t (&mac)[6]) {
+    return lattice::utils::MacAddress(mac).toString();
+  };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -48,7 +48,7 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t mac[6]) { return lattice::utils::MacAddress(mac).toString(); };
+  auto macToStr = [](const uint8_t (&mac)[6]) { return lattice::utils::MacAddress(mac).toString(); };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);
@@ -147,7 +147,11 @@ bool Mesh::init() {
 }
 
 bool Mesh::setupWiFi() {
-  WiFi.mode(WIFI_STA);
+  if (!WiFi.mode(WIFI_STA)) {
+    lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 6,
+                       "MESH: Failed to set WiFi mode STA");
+    return false;
+  }
   lattice::err::checkEsp(esp_wifi_set_channel(lattice::config::WIFI_CHANNEL, WIFI_SECOND_CHAN_NONE),
                          lattice::utils::ErrorType::HARDWARE_FAILURE, "Failed to set WiFi channel");
 
@@ -175,7 +179,8 @@ bool Mesh::setupEspNow() {
                        (String("MESH: esp_now_init failed: ") + esp_err_to_name(res)).c_str());
     return false;
   }
-  esp_now_set_pmk(meshKey);
+  lattice::err::checkEsp(esp_now_set_pmk(meshKey), lattice::utils::ErrorType::HARDWARE_FAILURE,
+                         "Failed to set ESP-NOW PMK");
 
   // Register the broadcast MAC so esp_now_send(broadcastMac, ...) reaches all
   // nodes — including unregistered ones. esp_now_send(nullptr, ...) only delivers
@@ -295,7 +300,7 @@ void Mesh::sendMessage(const uint8_t* target, const mesh_message& msg) {
   }
 }
 
-void Mesh::broadcastToAllPeers(mesh_message msg) {
+void Mesh::broadcastToAllPeers(const mesh_message& msg) {
   if (peers.peerCount == 0) {
     Logger::logln("MESH", "WARNING: No peers to broadcast to!", LogLevel::LOG_WARN);
     return;

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -48,9 +48,7 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t (&mac)[6]) {
-    return lattice::utils::MacAddress(mac).toString();
-  };
+  auto macToStr = [](const uint8_t(&mac)[6]) { return lattice::utils::MacAddress(mac).toString(); };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -79,7 +79,7 @@ private:
   PeerInfo* findNextHopToMaster();
 
   void sendMessage(const uint8_t* target, const mesh_message& msg);
-  void broadcastToAllPeers(mesh_message msg);
+  void broadcastToAllPeers(const mesh_message& msg);
 
   void transmitCore(const adapter_types type, const uint8_t* data,
                     MeshMessageType msgType = MESH_TYPE_ADAPTER_DATA,


### PR DESCRIPTION
Follow-up to #31 — the main-branch scan after merging revealed two things:

**1. `paths-ignore` doesn't filter results for compiled languages.** CodeQL extracts everything the build compiles, so the e2e suite's FetchContent deps (googletest, **mbedtls** — new since the e2e merge) opened ~250 vendored alerts. The analyze step now writes SARIF to disk, [`advanced-security/filter-sarif`](https://github.com/advanced-security/filter-sarif) strips `tests/build/**`, vendored nanopb, and the protocol submodule, and `upload-sarif` publishes the filtered file. Vendored alerts close on the next main scan.

**2. Two new warnings in our code** (`cpp/useless-expression`, alerts 277/278) — both ignored return values:
- `WiFi.mode(WIFI_STA)` — now fails fast on false.
- `esp_now_set_pmk(meshKey)` — now routed through `err::checkEsp`; a silent PMK failure would leave the mesh key unset.

Plus two notes: `printMeshMessage` lambda takes `const uint8_t (&)[6]`, `broadcastToAllPeers` takes `const mesh_message&` instead of by-value copy.

Tests: **128/128 pass** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)