### PR TITLE
feat: Phase 1 — protocol v3 + end-to-end AEAD payload crypto

### DIFF
--- a/docs/design-gaps/multihop-data-uplink.md
+++ b/docs/design-gaps/multihop-data-uplink.md
@@ -3,6 +3,9 @@
 # Design Gap: Multi-Hop Data Uplink
 
 **Status:** Open — needs its own design/brainstorming session.
+**Update 2026-07-19:** Phase 1 (protocol v3 + E2E payload AEAD, spec
+`docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md`) landed —
+keying groundwork done; the routing gap itself closes in Phase 2.
 **Discovered:** 2026-07-15, while building the e2e mesh simulation suite (Task 9).
 **Executable spec:** `tests/e2e/scenarios/test_multihop_e2e.cpp` →
 `DISABLED_SensorOutOfMasterRangeRelaysThroughMiddleNode` (committed disabled;

--- a/docs/design-gaps/multihop-data-uplink.md
+++ b/docs/design-gaps/multihop-data-uplink.md
@@ -59,12 +59,17 @@ Three mechanisms combine so that a distance-2 node has no route:
    hop is the relay, which is not a registered peer, so the lookup returns
    `nullptr`.
 
-Underlying constraint: ESP-NOW links are encrypted with a **per-peer LMK derived
-by Curve25519 ECDH** (`MeshCrypto.h`), and there is **no shared mesh-wide key**.
-A node can only send an encrypted frame to a peer it has performed the ECDH
-handshake with. It has done so with the master, not with the relay — so even if
-the relay were added to the registry, there is no key material to encrypt the
-hop to it.
+Underlying constraint (updated post-Task 8/Phase 1): the ESP-NOW link layer is
+now **unencrypted** — per-peer LMK link encryption was removed, and end-to-end
+AEAD (proto v3, Phase 1) is the security boundary instead, sealing payloads
+node→master and master→node with keys derived per (node, master) ECDH pair.
+That removes the "no key material for the hop" problem, but it does not by
+itself give a distance-2 leaf a route: the leaf's E2E keys are still derived
+against the *master's* public key, not the relay's, and the relay is still not
+a registered peer of the leaf. The remaining gap is **next-hop peer
+registration / route establishment** — the leaf needs a way to discover and
+register its next hop toward the master (or an equivalent per-hop authenticated
+relationship), not new key material for the link itself.
 
 ## Side effect introduced by the Task 9b enrollment-relay fix
 

--- a/docs/superpowers/plans/2026-07-16-phase1-proto-v3-e2e-aead.md
+++ b/docs/superpowers/plans/2026-07-16-phase1-proto-v3-e2e-aead.md
@@ -1,0 +1,1050 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Phase 1: Protocol v3 + E2E AEAD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Protocol v3 wire format with end-to-end ChaCha20-Poly1305 payload sealing between enrolled nodes and their master (direct range only), replacing per-peer ESP-NOW LMK encryption.
+
+**Architecture:** Wire format changes land in the `../lattice-protocol` repo (source of truth: `message/message.go` → codegen → `c/mesh_message.h`), then the submodule is bumped here. New header-only `E2ECrypto.h` derives direction-split keys (HKDF-SHA256 over the existing Curve25519 ECDH secret) and seals/opens `msg.data[64]` in place with the AEAD tag in a new `auth_tag[16]` field. A small `E2EKeyStore` caches derived keys per peer. Leaf nodes seal self-originated uplink (`ADAPTER_DATA`, `ROUTE_REPORT`); the master opens on local delivery. Relays never touch the payload.
+
+**Tech Stack:** C++ (ESP32 firmware, host-tested), mbedtls 3.6.2 (`chachapoly.h`, `hkdf.h` — both enabled in host build and ESP-IDF), Go (lattice-protocol codegen), GoogleTest + sim harness (`tests/`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md` (Sections 1, 2, 6, 8; Phase 1 of Section 9).
+- `PROTO_VERSION = 3`; flag day — no v2 compatibility (`Mesh.h:34`).
+- Nonce (12B): `epoch_num(4, LE) || seq_num(2, LE) || origin_mac(6)`. Nonce reuse is fatal — the seq-wrap epoch bump (Task 7) is mandatory.
+- AAD (24B): `proto_version(1) || message_type(1) || data_type(4, LE) || origin_mac(6) || target_mac(6) || epoch_num(4, LE) || seq_num(2, LE)`. Mutable-in-flight fields (`last_hop`, `hop_count`, `route_len`, `route_path`) are NEVER in the AAD.
+- HKDF labels: `"lattice-e2e-up-v3"` (node→master) and `"lattice-e2e-down-v3"` (master→node). Uplink seals with `k_up` only in Phase 1.
+- Sealed types: `MESH_TYPE_ADAPTER_DATA` and `MESH_TYPE_ROUTE_REPORT`, only when self-originated by a non-master node. Beacons, enrollment, JOIN_ACK, `SERIAL_CMD_BROADCAST`, and all downlink stay plaintext in Phase 1 (downlink seals in Phase 3).
+- Decrypt/tag failure → quiet drop + `LOG_WARN` (finding-#9 pattern; never `err::fail` in a periodic path).
+- New compile-time knob: `LATTICE_E2E_KEYCACHE_MAX` (default `MAX_PEERS`) in `main/project_config.h`.
+- All firmware test hooks `#ifdef UNIT_TEST`-gated (PR #28 convention).
+- Verification loop: `cmake --build tests/build --parallel` then `ctest --test-dir tests/build --output-on-failure`. Configure once with `cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release`. There is no device build in CI.
+- lattice-protocol CI requires `go generate ./...` output committed (`git diff --exit-code c/`).
+
+---
+
+### Task 1: Protocol v3 wire format (lattice-protocol repo)
+
+**Files:**
+- Modify: `../lattice-protocol/message/message.go`
+- Regenerate: `../lattice-protocol/c/mesh_message.h`, `../lattice-protocol/proto/mesh.proto` (via `go generate`)
+
+**Interfaces:**
+- Produces: packed `mesh_message` with new trailing fields `route_len(u8)`, `route_path[60]`, `auth_tag[16]`, `secondary_master_mac[6]`, `secondary_public_key[32]`; `sizeof(mesh_message) == 242`. All later tasks rely on `msg.auth_tag`.
+- New fields append AFTER `enrollment_public_key` — the existing 127-byte prefix layout is unchanged.
+
+- [ ] **Step 1: Create feature branch in ../lattice-protocol**
+
+```bash
+cd ../lattice-protocol && git checkout -b feat/proto-v3-e2e-aead
+```
+
+- [ ] **Step 2: Add v3 fields to the struct**
+
+In `message/message.go`, replace the struct and constant with:
+
+```go
+// MeshMessage is the 242-byte packed wire-format frame for the Lattice mesh (protocol v3).
+// Field order matches the packed C struct — do not reorder without updating the static_assert.
+// v3 additions (route_len..secondary_public_key) append after enrollment_public_key so the
+// 127-byte v2 prefix layout is unchanged.
+type MeshMessage struct {
+	ProtoVersion        uint8    `c:"uint8_t"     proto:"10,uint32"`
+	MessageType         uint8    `c:"uint8_t"     proto:"1,uint32"`
+	DataType            int32    `c:"int32_t"     proto:"2,sint32"`
+	OriginMacAddress    [6]byte  `c:"uint8_t[6]"  proto:"3,bytes"`
+	TargetMacAddress    [6]byte  `c:"uint8_t[6]"  proto:"4,bytes"`
+	LastHopMacAddress   [6]byte  `c:"uint8_t[6]"  proto:"5,bytes"`
+	Data                [64]byte `c:"uint8_t[64]" proto:"6,bytes,optional"`
+	HopCount            uint8    `c:"uint8_t"     proto:"7,uint32"`
+	EpochNum            uint32   `c:"uint32_t"    proto:"8,uint32"`
+	SeqNum              uint16   `c:"uint16_t"    proto:"9,uint32"`
+	EnrollmentPublicKey [32]byte `c:"uint8_t[32]" proto:"11,bytes,optional,public_key"`
+	// v3: downlink source route (Phase 3) / uplink path accumulator. 60 = MAX_HOPS(10) × 6.
+	RouteLen  uint8    `c:"uint8_t"     proto:"12,uint32,optional"`
+	RoutePath [60]byte `c:"uint8_t[60]" proto:"13,bytes,optional"`
+	// v3: ChaCha20-Poly1305 tag over data[64] (E2E AEAD).
+	AuthTag [16]byte `c:"uint8_t[16]" proto:"14,bytes,optional"`
+	// v3: dual-master provisioning in JOIN_ACK (Phase 4). Zero elsewhere.
+	SecondaryMasterMac  [6]byte  `c:"uint8_t[6]"  proto:"15,bytes,optional"`
+	SecondaryPublicKey  [32]byte `c:"uint8_t[32]" proto:"16,bytes,optional"`
+}
+
+// WireSize is the expected packed byte size — enforced by static_assert in the generated C header.
+// 127 (v2 prefix) + 1 + 60 + 16 + 6 + 32 = 242. Must stay ≤ 250 (ESP-NOW frame limit).
+const WireSize = 242
+```
+
+- [ ] **Step 3: Regenerate and test**
+
+```bash
+cd ../lattice-protocol && go generate ./... && go test ./... && git diff --stat
+```
+
+Expected: tests PASS; diff shows `message/message.go`, `c/mesh_message.h`, `proto/mesh.proto`. Verify the generated header ends with `static_assert(sizeof(mesh_message) == 242, ...)` and the new fields appear after `enrollment_public_key`. If `gen-headers` rejects a tag form, match the exact tag syntax used by existing optional fields (`proto:"11,bytes,optional,public_key"` is the reference).
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+cd ../lattice-protocol && git add -A && \
+git commit -m "feat: protocol v3 — route path, AEAD auth tag, dual-master JOIN_ACK fields" && \
+git push -u origin feat/proto-v3-e2e-aead
+```
+
+(Push is required so the lattice-nodes CI can fetch the submodule commit.)
+
+---
+
+### Task 2: Submodule bump + PROTO_VERSION 3
+
+**Files:**
+- Modify: `main/lib/lattice-protocol` (submodule pointer)
+- Modify: `main/src/mesh/Mesh.h:34` (`PROTO_VERSION`)
+
+**Interfaces:**
+- Consumes: Task 1's commit in ../lattice-protocol.
+- Produces: `mesh_message` with `auth_tag` visible to firmware; all nodes stamp/require `proto_version == 3`.
+
+- [ ] **Step 1: Create feature branch in lattice-nodes, point submodule at Task 1's commit**
+
+```bash
+git checkout -b feat/phase1-proto-v3-e2e-aead
+cd main/lib/lattice-protocol && git fetch && git checkout feat/proto-v3-e2e-aead && cd ../../..
+```
+
+- [ ] **Step 2: Bump PROTO_VERSION**
+
+In `main/src/mesh/Mesh.h:34` change the value `2` to `3` (keep the constant name and type).
+
+- [ ] **Step 3: Build and run full suite**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: ALL PASS. Every sim node compiles against the new struct and speaks v3; nothing checks the old 127-byte size outside the regenerated header. If a harness file fails to compile on struct size, fix it here — it was relying on layout it shouldn't.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/lib/lattice-protocol main/src/mesh/Mesh.h
+git commit -m "feat: bump lattice-protocol to proto v3 wire format; PROTO_VERSION=3"
+```
+
+---
+
+### Task 3: E2ECrypto — shared secret + HKDF key derivation
+
+**Files:**
+- Create: `main/src/mesh/E2ECrypto.h`
+- Create: `tests/unit/test_e2e_crypto.cpp`
+- Modify: `tests/CMakeLists.txt` (add unit target)
+
+**Interfaces:**
+- Consumes: `crypto::generateKeypair()` from `MeshCrypto.h` (test only).
+- Produces:
+  - `lattice::mesh::crypto::computeSharedSecret(const uint8_t ownPriv32[32], const uint8_t peerPub32[32], uint8_t secret32Out[32])` — X25519 ECDH, `err::fatal` on mbedtls failure (same pattern/digits as `derivePeerLMK`).
+  - `lattice::mesh::crypto::deriveE2EKeys(const uint8_t ownPriv32[32], const uint8_t peerPub32[32], uint8_t kUp32Out[32], uint8_t kDown32Out[32])`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_e2e_crypto.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/MeshCrypto.h"
+#include "src/mesh/E2ECrypto.h"
+
+using namespace lattice::mesh::crypto;
+
+TEST(E2ECrypto, SharedSecretIsSymmetric) {
+  uint8_t privA[32], pubA[32], privB[32], pubB[32];
+  generateKeypair(privA, pubA);
+  generateKeypair(privB, pubB);
+  uint8_t sAB[32], sBA[32];
+  computeSharedSecret(privA, pubB, sAB);
+  computeSharedSecret(privB, pubA, sBA);
+  EXPECT_EQ(0, memcmp(sAB, sBA, 32));
+  // Sanity: secret is not all-zero
+  uint8_t zero[32] = {};
+  EXPECT_NE(0, memcmp(sAB, zero, 32));
+}
+
+TEST(E2ECrypto, DerivedKeysAreSymmetricAndDirectionSplit) {
+  uint8_t privA[32], pubA[32], privB[32], pubB[32];
+  generateKeypair(privA, pubA);
+  generateKeypair(privB, pubB);
+  uint8_t upA[32], downA[32], upB[32], downB[32];
+  deriveE2EKeys(privA, pubB, upA, downA);
+  deriveE2EKeys(privB, pubA, upB, downB);
+  EXPECT_EQ(0, memcmp(upA, upB, 32));     // both sides agree on k_up
+  EXPECT_EQ(0, memcmp(downA, downB, 32)); // and on k_down
+  EXPECT_NE(0, memcmp(upA, downA, 32));   // directions differ
+}
+
+TEST(E2ECrypto, DifferentPeersDifferentKeys) {
+  uint8_t priv[32], pub[32], privB[32], pubB[32], privC[32], pubC[32];
+  generateKeypair(priv, pub);
+  generateKeypair(privB, pubB);
+  generateKeypair(privC, pubC);
+  uint8_t upB[32], downB[32], upC[32], downC[32];
+  deriveE2EKeys(priv, pubB, upB, downB);
+  deriveE2EKeys(priv, pubC, upC, downC);
+  EXPECT_NE(0, memcmp(upB, upC, 32));
+}
+```
+
+Add the target to `tests/CMakeLists.txt` next to the existing `add_unit_test` calls (copy their exact form; the macro at `tests/CMakeLists.txt:82-96` handles sources/links):
+
+```cmake
+add_unit_test(test_e2e_crypto unit/test_e2e_crypto.cpp)
+```
+
+(If the macro's real signature differs, mirror an existing call like `test_pir_adapter` exactly.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --target test_e2e_crypto --parallel
+```
+
+Expected: FAIL — `E2ECrypto.h: No such file or directory`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `main/src/mesh/E2ECrypto.h`:
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/hkdf.h>
+#include <mbedtls/md.h>
+#include "src/error/Error.h"
+#include "src/error/ErrorCore.h"
+
+namespace lattice {
+namespace mesh {
+namespace crypto {
+
+// X25519 ECDH shared secret. Same mbedtls flow as derivePeerLMK (MeshCrypto.h),
+// without the LMK KDF step. err::fatal digits 20-25 (LMK path uses 10-19).
+inline void computeSharedSecret(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
+                                uint8_t* secret32Out) {
+  mbedtls_ecdh_context ecdh;
+  mbedtls_entropy_context entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_ecdh_init(&ecdh);
+  mbedtls_entropy_init(&entropy);
+  mbedtls_ctr_drbg_init(&ctr_drbg);
+
+  const char* pers = "lattice_ecdh_e2e";
+  int ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                  reinterpret_cast<const uint8_t*>(pers), strlen(pers));
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 20,
+                        "MESH: computeSharedSecret — ctr_drbg_seed failed");
+  }
+  ret = mbedtls_ecdh_setup(&ecdh, MBEDTLS_ECP_DP_CURVE25519);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 21,
+                        "MESH: computeSharedSecret — ecdh_setup failed");
+  }
+  ret = mbedtls_mpi_read_binary(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(d), ownPrivateKey32,
+      32);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 22,
+                        "MESH: computeSharedSecret — mpi_read_binary (private key) failed");
+  }
+  ret = mbedtls_mpi_read_binary(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X),
+      peerPublicKey32, 32);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 23,
+                        "MESH: computeSharedSecret — mpi_read_binary (peer public key) failed");
+  }
+  ret = mbedtls_mpi_lset(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z),
+      1);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 24,
+                        "MESH: computeSharedSecret — mpi_lset (Qp.Z) failed");
+  }
+  size_t outLen = 0;
+  ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, secret32Out, 32, mbedtls_ctr_drbg_random,
+                                 &ctr_drbg);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 25,
+                        "MESH: computeSharedSecret — ecdh_calc_secret failed");
+  }
+  mbedtls_ecdh_free(&ecdh);
+  mbedtls_ctr_drbg_free(&ctr_drbg);
+  mbedtls_entropy_free(&entropy);
+}
+
+// Direction-split E2E keys (spec §2): HKDF-SHA256 over the ECDH secret.
+// k_up seals node→master payloads, k_down master→node.
+inline void deriveE2EKeys(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
+                          uint8_t* kUp32Out, uint8_t* kDown32Out) {
+  uint8_t secret[32];
+  computeSharedSecret(ownPrivateKey32, peerPublicKey32, secret);
+  const mbedtls_md_info_t* md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  static const uint8_t upLabel[] = "lattice-e2e-up-v3";
+  static const uint8_t downLabel[] = "lattice-e2e-down-v3";
+  int ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, upLabel, sizeof(upLabel) - 1, kUp32Out, 32);
+  if (ret == 0) {
+    ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, downLabel, sizeof(downLabel) - 1, kDown32Out,
+                       32);
+  }
+  memset(secret, 0, sizeof(secret));
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 26,
+                        "MESH: deriveE2EKeys — hkdf failed");
+  }
+}
+
+} // namespace crypto
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cmake --build tests/build --target test_e2e_crypto --parallel && ctest --test-dir tests/build -R e2e_crypto --output-on-failure
+```
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/src/mesh/E2ECrypto.h tests/unit/test_e2e_crypto.cpp tests/CMakeLists.txt
+git commit -m "feat: E2E key derivation — X25519 shared secret + HKDF-SHA256 direction-split keys"
+```
+
+---
+
+### Task 4: E2ECrypto — seal/open payload (ChaCha20-Poly1305)
+
+**Files:**
+- Modify: `main/src/mesh/E2ECrypto.h`
+- Modify: `tests/unit/test_e2e_crypto.cpp`
+
+**Interfaces:**
+- Produces:
+  - `crypto::sealPayload(const uint8_t key32[32], mesh_message& msg)` — encrypts `msg.data` in place, writes `msg.auth_tag`. Returns `bool` (false on mbedtls error).
+  - `crypto::openPayload(const uint8_t key32[32], mesh_message& msg)` — decrypts in place; returns `false` on tag mismatch (caller drops quietly).
+  - Nonce/AAD layout per Global Constraints.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_e2e_crypto.cpp` (add `#include "mesh_message.h"` — the include path already resolves lattice-protocol headers for existing tests; mirror how `Mesh.cpp` includes it):
+
+```cpp
+static mesh_message makeMsg() {
+  mesh_message m = {};
+  m.proto_version = 3;
+  m.message_type = 0; // MESH_TYPE_ADAPTER_DATA
+  m.data_type = 1;
+  const uint8_t origin[6] = {0x02, 0, 0, 0, 0, 0x01};
+  const uint8_t target[6] = {0x02, 0, 0, 0, 0, 0xAA};
+  memcpy(m.origin_mac_address, origin, 6);
+  memcpy(m.target_mac_address, target, 6);
+  m.epoch_num = 7;
+  m.seq_num = 42;
+  for (int i = 0; i < 64; ++i) m.data[i] = static_cast<uint8_t>(i);
+  return m;
+}
+
+TEST(E2EAead, SealOpenRoundtrip) {
+  uint8_t key[32];
+  for (int i = 0; i < 32; ++i) key[i] = static_cast<uint8_t>(0xA0 + i);
+  mesh_message m = makeMsg();
+  mesh_message orig = m;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  EXPECT_NE(0, memcmp(m.data, orig.data, 64)); // actually encrypted
+  ASSERT_TRUE(lattice::mesh::crypto::openPayload(key, m));
+  EXPECT_EQ(0, memcmp(m.data, orig.data, 64));
+}
+
+TEST(E2EAead, TamperedCiphertextFailsOpen) {
+  uint8_t key[32] = {1};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.data[10] ^= 0x01;
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+TEST(E2EAead, TamperedAadFieldFailsOpen) {
+  uint8_t key[32] = {2};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.data_type = 99; // AAD-bound field
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+TEST(E2EAead, MutableFieldsNotBound) {
+  uint8_t key[32] = {3};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.hop_count = 5;                              // relays rewrite these
+  memset(m.last_hop_mac_address, 0xBB, 6);
+  m.route_len = 2;
+  EXPECT_TRUE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+// RFC 8439 §2.8.2 known-answer vector, exercised against the same mbedtls
+// primitive sealPayload uses (spec §7: AEAD KAT). Guards against a broken or
+// misconfigured chachapoly build on either host or target toolchains.
+TEST(E2EAead, Rfc8439KnownAnswer) {
+  const uint8_t key[32] = {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a,
+                           0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95,
+                           0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f};
+  const uint8_t nonce[12] = {0x07, 0x00, 0x00, 0x00, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47};
+  const uint8_t aad[12] = {0x50, 0x51, 0x52, 0x53, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7};
+  const char* plaintext =
+      "Ladies and Gentlemen of the class of '99: If I could offer you "
+      "only one tip for the future, sunscreen would be it.";
+  const uint8_t expectedTag[16] = {0x1a, 0xe1, 0x0b, 0x59, 0x4f, 0x09, 0xe2, 0x6a,
+                                   0x7e, 0x90, 0x2e, 0xcb, 0xd0, 0x60, 0x06, 0x91};
+  uint8_t ct[114], tag[16];
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  ASSERT_EQ(0, mbedtls_chachapoly_setkey(&ctx, key));
+  ASSERT_EQ(0, mbedtls_chachapoly_encrypt_and_tag(
+                   &ctx, 114, nonce, aad, sizeof(aad),
+                   reinterpret_cast<const uint8_t*>(plaintext), ct, tag));
+  mbedtls_chachapoly_free(&ctx);
+  EXPECT_EQ(0, memcmp(tag, expectedTag, 16));
+  EXPECT_EQ(0x64, ct[0]); // first ciphertext byte per RFC 8439 §2.8.2
+}
+
+TEST(E2EAead, WrongKeyFailsOpen) {
+  uint8_t key[32] = {4}, wrong[32] = {5};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(wrong, m));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cmake --build tests/build --target test_e2e_crypto --parallel
+```
+
+Expected: FAIL — `sealPayload` not declared.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `main/src/mesh/E2ECrypto.h` (inside the namespaces; add `#include <mbedtls/chachapoly.h>` and `#include "mesh_message.h"` at the top with the existing includes — use the same include form as `Mesh.h` uses for the protocol header):
+
+```cpp
+// AEAD framing (spec §1/§2).
+// Nonce (12B): epoch(4 LE) || seq(2 LE) || origin_mac(6) — unique per key given the
+// boot-epoch counter and the seq-wrap epoch bump.
+// AAD (24B): version, type, data_type, origin, target, epoch, seq — immutable fields only.
+constexpr size_t E2E_AAD_LEN = 24;
+constexpr size_t E2E_NONCE_LEN = 12;
+
+inline void buildNonce(const mesh_message& msg, uint8_t nonce[E2E_NONCE_LEN]) {
+  nonce[0] = static_cast<uint8_t>(msg.epoch_num);
+  nonce[1] = static_cast<uint8_t>(msg.epoch_num >> 8);
+  nonce[2] = static_cast<uint8_t>(msg.epoch_num >> 16);
+  nonce[3] = static_cast<uint8_t>(msg.epoch_num >> 24);
+  nonce[4] = static_cast<uint8_t>(msg.seq_num);
+  nonce[5] = static_cast<uint8_t>(msg.seq_num >> 8);
+  memcpy(nonce + 6, msg.origin_mac_address, 6);
+}
+
+inline void buildAad(const mesh_message& msg, uint8_t aad[E2E_AAD_LEN]) {
+  aad[0] = msg.proto_version;
+  aad[1] = msg.message_type;
+  aad[2] = static_cast<uint8_t>(msg.data_type);
+  aad[3] = static_cast<uint8_t>(msg.data_type >> 8);
+  aad[4] = static_cast<uint8_t>(msg.data_type >> 16);
+  aad[5] = static_cast<uint8_t>(msg.data_type >> 24);
+  memcpy(aad + 6, msg.origin_mac_address, 6);
+  memcpy(aad + 12, msg.target_mac_address, 6);
+  aad[18] = static_cast<uint8_t>(msg.epoch_num);
+  aad[19] = static_cast<uint8_t>(msg.epoch_num >> 8);
+  aad[20] = static_cast<uint8_t>(msg.epoch_num >> 16);
+  aad[21] = static_cast<uint8_t>(msg.epoch_num >> 24);
+  aad[22] = static_cast<uint8_t>(msg.seq_num);
+  aad[23] = static_cast<uint8_t>(msg.seq_num >> 8);
+}
+
+// Encrypts msg.data in place and writes msg.auth_tag. Returns false on mbedtls error.
+inline bool sealPayload(const uint8_t* key32, mesh_message& msg) {
+  uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
+  buildNonce(msg, nonce);
+  buildAad(msg, aad);
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  if (ret == 0) {
+    ret = mbedtls_chachapoly_encrypt_and_tag(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+                                             msg.data, msg.data, msg.auth_tag);
+  }
+  mbedtls_chachapoly_free(&ctx);
+  return ret == 0;
+}
+
+// Decrypts msg.data in place, verifying msg.auth_tag. Returns false on tag mismatch
+// or mbedtls error — callers drop the frame quietly (finding-#9 pattern).
+inline bool openPayload(const uint8_t* key32, mesh_message& msg) {
+  uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
+  buildNonce(msg, nonce);
+  buildAad(msg, aad);
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  if (ret == 0) {
+    ret = mbedtls_chachapoly_auth_decrypt(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+                                          msg.auth_tag, msg.data, msg.data);
+  }
+  mbedtls_chachapoly_free(&ctx);
+  return ret == 0;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cmake --build tests/build --target test_e2e_crypto --parallel && ctest --test-dir tests/build -R e2e_crypto --output-on-failure
+```
+
+Expected: 9 tests PASS (3 key-derivation + 6 AEAD).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/src/mesh/E2ECrypto.h tests/unit/test_e2e_crypto.cpp
+git commit -m "feat: ChaCha20-Poly1305 payload seal/open with header-bound AAD"
+```
+
+---
+
+### Task 5: E2EKeyStore — per-peer derived-key cache
+
+**Files:**
+- Create: `main/src/mesh/E2EKeyStore.h`
+- Create: `tests/unit/test_e2e_keystore.cpp`
+- Modify: `main/project_config.h` (add knob), `tests/CMakeLists.txt` (add target)
+
+**Interfaces:**
+- Consumes: `crypto::deriveE2EKeys` (Task 3).
+- Produces:
+  - `class lattice::mesh::E2EKeyStore` with
+    `bool getKeys(const uint8_t mac[6], const uint8_t ownPriv32[32], const uint8_t peerPub32[32], const uint8_t** kUpOut, const uint8_t** kDownOut)`
+    — returns cached keys or derives+caches; returns `false` (and derives nothing) when `peerPub32` is null or all-zero. Round-robin overwrite when full.
+  - `void clear()` — drops all cached keys (call on re-key).
+  - `LATTICE_E2E_KEYCACHE_MAX` in `lattice::config` (default `= MAX_PEERS`).
+
+- [ ] **Step 1: Add the config knob**
+
+In `main/project_config.h`, next to the other mesh constants (near `MAX_HOPS` at line ~115):
+
+```cpp
+// E2E AEAD derived-key cache entries (spec §2). One entry per (peer, master) pair;
+// masters need one per enrolled node, leaves need one per master. Default: MAX_PEERS.
+inline constexpr size_t LATTICE_E2E_KEYCACHE_MAX = lattice::utils::EEPROM_SIZES::MAX_PEERS;
+```
+
+(If `MAX_PEERS` isn't visible in this header, use the literal `10` with a comment `// = MAX_PEERS`.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/test_e2e_keystore.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/MeshCrypto.h"
+#include "src/mesh/E2EKeyStore.h"
+
+using namespace lattice::mesh;
+
+TEST(E2EKeyStore, DerivesAndCaches) {
+  uint8_t priv[32], pub[32], peerPriv[32], peerPub[32];
+  crypto::generateKeypair(priv, pub);
+  crypto::generateKeypair(peerPriv, peerPub);
+  const uint8_t mac[6] = {2, 0, 0, 0, 0, 1};
+  E2EKeyStore store;
+  const uint8_t *up1, *down1, *up2, *down2;
+  ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up1, &down1));
+  ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up2, &down2));
+  EXPECT_EQ(up1, up2); // cache hit: same storage, no re-derivation
+  EXPECT_EQ(0, memcmp(down1, down2, 32));
+}
+
+TEST(E2EKeyStore, RejectsZeroPubkey) {
+  uint8_t priv[32], pub[32];
+  crypto::generateKeypair(priv, pub);
+  const uint8_t mac[6] = {2, 0, 0, 0, 0, 2};
+  uint8_t zeroPub[32] = {};
+  E2EKeyStore store;
+  const uint8_t *up, *down;
+  EXPECT_FALSE(store.getKeys(mac, priv, zeroPub, &up, &down));
+  EXPECT_FALSE(store.getKeys(mac, priv, nullptr, &up, &down));
+}
+
+TEST(E2EKeyStore, OverwritesWhenFullAndClearWorks) {
+  uint8_t priv[32], pub[32], peerPriv[32], peerPub[32];
+  crypto::generateKeypair(priv, pub);
+  crypto::generateKeypair(peerPriv, peerPub);
+  E2EKeyStore store;
+  const uint8_t *up, *down;
+  // Fill beyond capacity — must not crash, oldest entries overwritten
+  for (int i = 0; i < static_cast<int>(lattice::config::LATTICE_E2E_KEYCACHE_MAX) + 3; ++i) {
+    uint8_t mac[6] = {2, 0, 0, 0, 0, static_cast<uint8_t>(i)};
+    ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up, &down));
+  }
+  store.clear();
+  const uint8_t mac0[6] = {2, 0, 0, 0, 0, 0};
+  ASSERT_TRUE(store.getKeys(mac0, priv, peerPub, &up, &down)); // re-derives after clear
+}
+```
+
+Add to `tests/CMakeLists.txt`:
+
+```cmake
+add_unit_test(test_e2e_keystore unit/test_e2e_keystore.cpp)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --target test_e2e_keystore --parallel
+```
+
+Expected: FAIL — `E2EKeyStore.h: No such file or directory`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `main/src/mesh/E2EKeyStore.h`:
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "E2ECrypto.h"
+#include "../../project_config.h"
+
+namespace lattice {
+namespace mesh {
+
+// RAM-only cache of derived E2E key pairs, one entry per peer MAC (spec §2).
+// Derivation costs an X25519 exchange (~ms on ESP32) — cache so the periodic
+// uplink path never re-derives. Round-robin overwrite when full; wrong evictions
+// only cost a re-derivation.
+class E2EKeyStore {
+public:
+  bool getKeys(const uint8_t mac[6], const uint8_t* ownPriv32, const uint8_t* peerPub32,
+               const uint8_t** kUpOut, const uint8_t** kDownOut) {
+    for (size_t i = 0; i < config::LATTICE_E2E_KEYCACHE_MAX; ++i) {
+      if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0) {
+        *kUpOut = entries[i].kUp;
+        *kDownOut = entries[i].kDown;
+        return true;
+      }
+    }
+    if (!peerPub32)
+      return false;
+    bool allZero = true;
+    for (int i = 0; i < 32; ++i) {
+      if (peerPub32[i] != 0) {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero)
+      return false;
+    Entry& e = entries[nextSlot];
+    nextSlot = (nextSlot + 1) % config::LATTICE_E2E_KEYCACHE_MAX;
+    crypto::deriveE2EKeys(ownPriv32, peerPub32, e.kUp, e.kDown);
+    memcpy(e.mac, mac, 6);
+    e.valid = true;
+    *kUpOut = e.kUp;
+    *kDownOut = e.kDown;
+    return true;
+  }
+
+  void clear() {
+    memset(entries, 0, sizeof(entries));
+    nextSlot = 0;
+  }
+
+private:
+  struct Entry {
+    uint8_t mac[6];
+    bool valid;
+    uint8_t kUp[32];
+    uint8_t kDown[32];
+  };
+  Entry entries[config::LATTICE_E2E_KEYCACHE_MAX]{};
+  size_t nextSlot{0};
+};
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cmake --build tests/build --target test_e2e_keystore --parallel && ctest --test-dir tests/build -R e2e_keystore --output-on-failure
+```
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add main/src/mesh/E2EKeyStore.h tests/unit/test_e2e_keystore.cpp tests/CMakeLists.txt main/project_config.h
+git commit -m "feat: E2EKeyStore — cached per-peer HKDF key derivation"
+```
+
+---
+
+### Task 6: Mesh integration — seal uplink, open at master
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.h` (member + helper decls)
+- Modify: `main/src/mesh/Mesh.cpp` (`transmitCore`, `processAdapterData`, `processRouteReport`)
+- Create: `tests/e2e/scenarios/test_e2e_aead.cpp`
+- Modify: `tests/CMakeLists.txt` (add scenario to `lattice_e2e` sources — mirror how existing scenarios are listed)
+
+**Interfaces:**
+- Consumes: `E2EKeyStore` (Task 5), `crypto::sealPayload`/`openPayload` (Task 4), `enrollment.getPrivateKey()` (`Enrollment.h:27`), `peers.find(mac)->publicKey` (`PeerRegistry.h:35`).
+- Produces: sealed-on-air uplink. Rule (both directions of the same predicate):
+  - **Seal** in `transmitCore` when: message is self-originated (`origin == deviceMacAddress`), node is not master, type is `MESH_TYPE_ADAPTER_DATA` or `MESH_TYPE_ROUTE_REPORT`, and master keys are available.
+  - **Open** on local delivery when: node is master and frame is a self-targeted `ADAPTER_DATA`/`ROUTE_REPORT`. Failure → `LOG_WARN` + drop.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Create `tests/e2e/scenarios/test_e2e_aead.cpp`. Follow the exact setup idiom of `tests/e2e/scenarios/test_pir_dataflow_e2e.cpp` (bus/node/hub construction, enrollment approval, cycle-stepping helpers) — copy its fixture and adapt. The scenario content:
+
+```cpp
+// Test 1: SealedUplinkDeliversPlaintextToHub
+//  - master + leaf linked on VirtualBus; enroll leaf via FakeHub approval (existing idiom)
+//  - leaf sends PIR adapter data (same trigger as test_pir_dataflow_e2e)
+//  - capture the frame ON THE BUS: assert its data[] differs from the known
+//    plaintext opcode layout (i.e. data[0] != OP_PIR_* expected byte) — proves sealed in transit
+//  - run cycles; assert FakeHub received the decoded adapter data with the
+//    ORIGINAL plaintext opcode — proves master opened before serial delivery
+
+// Test 2: TamperedFrameIsDropped
+//  - same setup; intercept the in-flight frame via the VirtualBus pending queue
+//    (add a test-only mutator to VirtualBus if none exists: e.g.
+//    `mesh_message* lastPending()` #ifdef-free — harness code, not firmware)
+//  - flip one byte of msg.data, deliver
+//  - assert FakeHub receives nothing and master logs/drops (no externalRecvCallback delivery)
+
+// Test 3: ForgedFrameWithoutValidTagIsDropped
+//  - construct a raw mesh_message impersonating the leaf (correct MACs/epoch/seq,
+//    garbage auth_tag), inject via bus toward master
+//  - assert FakeHub receives nothing
+```
+
+Write these as real GoogleTest cases against the harness API (read `tests/e2e/harness/VirtualBus.h`, `FakeHub.h`, `SimNode.h` first; reuse their existing accessors — only add a harness mutator if none exists).
+
+- [ ] **Step 2: Run to verify the right failure**
+
+```bash
+cmake --build tests/build --target lattice_e2e --parallel && ctest --test-dir tests/build -R e2e_aead --output-on-failure
+```
+
+Expected: Test 1 FAILS at the "differs from plaintext" assertion (payload is still plaintext on the bus — feature not implemented). Tests 2–3 may incidentally pass or fail; only Test 1's failure mode matters here.
+
+- [ ] **Step 3: Implement sealing in `transmitCore`**
+
+In `main/src/mesh/Mesh.h`: add includes for `E2EKeyStore.h`; add private members and helpers:
+
+```cpp
+E2EKeyStore e2eKeys;
+// Returns k_up/k_down for the current master (leaf side); false if not enrolled
+// or master pubkey unknown.
+bool masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown);
+// Returns keys for an enrolled origin peer (master side); false if unknown peer.
+bool peerE2EKeys(const uint8_t* originMac, const uint8_t** kUp, const uint8_t** kDown);
+static bool isSealedType(uint8_t messageType);
+```
+
+In `main/src/mesh/Mesh.cpp`:
+
+```cpp
+bool Mesh::isSealedType(uint8_t messageType) {
+  return messageType == MESH_TYPE_ADAPTER_DATA || messageType == MESH_TYPE_ROUTE_REPORT;
+}
+
+bool Mesh::masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown) {
+  if (!enrollment.hasMasterMac)
+    return false;
+  PeerInfo* master = peers.find(currentMaster.mac);
+  if (!master)
+    return false;
+  return e2eKeys.getKeys(master->mac, enrollment.getPrivateKey(), master->publicKey, kUp, kDown);
+}
+
+bool Mesh::peerE2EKeys(const uint8_t* originMac, const uint8_t** kUp, const uint8_t** kDown) {
+  PeerInfo* peer = peers.find(originMac);
+  if (!peer)
+    return false;
+  return e2eKeys.getKeys(peer->mac, enrollment.getPrivateKey(), peer->publicKey, kUp, kDown);
+}
+```
+
+In `transmitCore` (`Mesh.cpp:315-346`), after the target override block (line 328) and BEFORE the routing lookup, insert:
+
+```cpp
+  // E2E seal (spec §1/§2): self-originated uplink payloads only. Relayed frames
+  // (msgOverride with foreign origin) are already sealed — forward untouched.
+  bool selfOriginated = (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0);
+  if (!isMaster && selfOriginated && isSealedType(msg.message_type)) {
+    const uint8_t *kUp, *kDown;
+    if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kUp, msg)) {
+      Logger::logln("MESH", "E2E seal unavailable — uplink dropped", LogLevel::LOG_WARN);
+      return;
+    }
+  }
+```
+
+**Sealing must happen after the final `target_mac_address` is set** — target is AAD-bound.
+
+- [ ] **Step 4: Implement opening at the master**
+
+In `processAdapterData` (`Mesh.cpp:592-638`): at the top of the local-delivery section (right after the relay branches return, before the `isConfigOpcode` check at line 619), insert:
+
+```cpp
+  // E2E open (spec §2): master unseals self-targeted uplink before local delivery.
+  mesh_message opened = msg;
+  bool needsOpen = isMaster && addressedToSelf && isSealedType(msg.message_type);
+  if (needsOpen) {
+    const uint8_t *kUp, *kDown;
+    if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
+        !lattice::mesh::crypto::openPayload(kUp, opened)) {
+      Logger::logln("MESH", "E2E open failed — frame dropped", LogLevel::LOG_WARN);
+      return;
+    }
+  }
+```
+
+and switch the remainder of the local-delivery block (`isConfigOpcode` check, `externalRecvCallback` call) to use `opened` instead of `msg`. The broadcast-relay tail (`relayDownlink(msg)` at line 636) keeps using the original `msg`.
+
+In `processRouteReport` (`Mesh.cpp:806-840`):
+- Master branch: open the payload the same way (reuse the exact pattern above) before parsing `data[1]`/path bytes; drop on failure.
+- Relay branch: **stop appending MACs to `msg.data`** — forward the frame unmodified except `hop_count`/`last_hop` (payload is sealed; path accumulation moves to the header `route_path` field in Phase 3 — spec §4). Leave a one-line comment citing the spec section.
+
+- [ ] **Step 5: Run the new scenario + full suite**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: ALL PASS, including all pre-existing e2e scenarios (enrollment, PIR dataflow, route report, replay, dual-master, hotswap, master-health, serial-robustness). The route-report e2e must still pass — direct-range reports carry an empty path (`data[1] = 0`), unaffected by the relay-append removal. If `test_route_report_e2e` asserts on relay path accumulation, update that assertion to expect an empty path and reference spec §4 (header accumulation lands in Phase 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add main/src/mesh/Mesh.h main/src/mesh/Mesh.cpp tests/e2e/scenarios/test_e2e_aead.cpp tests/CMakeLists.txt
+git commit -m "feat: seal uplink payloads E2E; master opens before delivery"
+```
+
+---
+
+### Task 7: seq-wrap epoch bump
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.cpp` (`buildMessage`, `Mesh.cpp:93-111`)
+- Modify: `main/src/mesh/Mesh.h` (`#ifdef UNIT_TEST` hook)
+- Create: `tests/e2e/scenarios/test_seq_wrap.cpp` (add to `lattice_e2e` sources)
+
+**Interfaces:**
+- Consumes: `replay.nextSeq()` (`ReplayCache.h:34`, wraps `0xFFFF → 0`), `EepromManager::{load,save}BootEpoch` (`EepromManager.h:144-145`).
+- Produces: nonce uniqueness across seq wrap — `seq_num == 0` never goes on air; epoch increments and persists instead.
+
+- [ ] **Step 1: Add the UNIT_TEST hook**
+
+In `main/src/mesh/Mesh.h`, alongside the existing `#ifdef UNIT_TEST` hooks (grep `UNIT_TEST` in the header and match placement):
+
+```cpp
+#ifdef UNIT_TEST
+  ReplayCache& testReplay() { return replay; }
+#endif
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/e2e/scenarios/test_seq_wrap.cpp` (same fixture idiom as Task 6's scenario):
+
+```cpp
+// SeqWrapBumpsEpochAndKeepsSealing
+//  - enroll leaf with master (standard fixture)
+//  - leaf.mesh().testReplay().txSeqNum = 0xFFFE;
+//  - uint32_t epochBefore = leaf.mesh().testReplay().bootEpoch;
+//  - trigger three uplink sends (PIR events), stepping cycles between each
+//  - assert leaf.mesh().testReplay().bootEpoch == epochBefore + 1  (wrapped once)
+//  - assert FakeHub received all three payloads decrypted (post-wrap frames still open —
+//    proves master used the frame's epoch_num, and no frame went out with seq 0)
+//  - assert the leaf's EEPROM mock persisted the bumped epoch
+//    (leaf.ctx() exposes the EEPROM mock — read BOOT_EPOCH via EepromManager or ctx state)
+```
+
+Write as a real GoogleTest case. Run:
+
+```bash
+cmake --build tests/build --target lattice_e2e --parallel && ctest --test-dir tests/build -R seq_wrap --output-on-failure
+```
+
+Expected: FAIL — epoch unchanged (no wrap handling) and/or a frame with `seq_num == 0` reused a nonce.
+
+- [ ] **Step 3: Implement the bump**
+
+In `buildMessage` (`Mesh.cpp:93-111`), replace lines 108-109 with:
+
+```cpp
+  msg.seq_num = replay.nextSeq();
+  if (msg.seq_num == 0) {
+    // seq wrapped (spec §2): a reused (epoch, seq) pair would reuse an AEAD nonce.
+    // Advance the persisted epoch and restart the sequence.
+    uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
+    EepromManager::getInstance().saveBootEpoch(epoch);
+    replay.bootEpoch = epoch;
+    msg.seq_num = replay.nextSeq();
+  }
+  msg.epoch_num = replay.bootEpoch;
+```
+
+(Note: `epoch_num` assignment moves AFTER the wrap check so the frame carries the bumped epoch.)
+
+- [ ] **Step 4: Run test + full suite**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/src/mesh/Mesh.h main/src/mesh/Mesh.cpp tests/e2e/scenarios/test_seq_wrap.cpp tests/CMakeLists.txt
+git commit -m "fix: bump persisted epoch on seq wrap to prevent AEAD nonce reuse"
+```
+
+---
+
+### Task 8: Remove per-peer LMK encryption
+
+**Files:**
+- Modify: `main/src/mesh/MeshCrypto.h` (delete `derivePeerLMK`; simplify `registerPeerWithEspNow`)
+- Modify: callers if any pass key args that are now unused (grep `registerPeerWithEspNow` — `Mesh.cpp:718-760` area)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `crypto::registerPeerWithEspNow(const uint8_t mac[6])` — all ESP-NOW peers registered unencrypted (spec §2: E2E AEAD is the security boundary; unencrypted slots raise the peer cap from ~6 to 20). `generateKeypair` and the PMK (`esp_now_set_pmk`, `Mesh.cpp:182`) remain.
+
+- [ ] **Step 1: Simplify registerPeerWithEspNow**
+
+In `main/src/mesh/MeshCrypto.h`: delete `derivePeerLMK` entirely (lines 17-119) and replace `registerPeerWithEspNow` (lines 121-150) with:
+
+```cpp
+// Register an ESP-NOW peer WITHOUT link-layer encryption (spec §2, proto v3):
+// payload confidentiality/integrity is end-to-end (E2ECrypto.h), and unencrypted
+// slots raise the ESP-NOW peer cap from ~6 to 20. The shared PMK stays set.
+inline void registerPeerWithEspNow(const uint8_t mac[6]) {
+  if (esp_now_is_peer_exist(mac))
+    return;
+  esp_now_peer_info_t info = {};
+  memcpy(info.peer_addr, mac, 6);
+  info.channel = 0;
+  info.encrypt = false;
+  lattice::err::checkEsp(esp_now_add_peer(&info), lattice::utils::ErrorType::COMMUNICATION_FAIL,
+                         "registerPeerWithEspNow: add_peer failed");
+}
+```
+
+Remove the now-unused includes from `MeshCrypto.h` if nothing else in the header uses them (`generateKeypair` still needs ecp/entropy/ctr_drbg — keep those; `mbedtls/ecdh.h` and `mbedtls/sha256.h` likely become removable).
+
+- [ ] **Step 2: Fix call sites**
+
+```bash
+grep -rn "registerPeerWithEspNow" main/ tests/
+```
+
+Update every call to the new single-arg signature (expected: `Mesh.cpp` in `registerPeerWithKey`, possibly harness/test code). The peer's public key stays in `PeerRegistry` (feeds E2E derivation) — only the ESP-NOW-layer usage is deleted.
+
+- [ ] **Step 3: Build + full suite**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/src/mesh/MeshCrypto.h main/src/mesh/Mesh.cpp
+git commit -m "refactor: drop per-peer LMK link encryption — E2E AEAD is the security boundary"
+```
+
+---
+
+### Task 9: Finish — full verification + PRs
+
+**Files:**
+- Modify: `docs/design-gaps/multihop-data-uplink.md` (status note only)
+
+- [ ] **Step 1: Full clean-build verification**
+
+```bash
+rm -rf tests/build && cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: ALL PASS from scratch.
+
+- [ ] **Step 2: Note Phase 1 in the gap doc**
+
+In `docs/design-gaps/multihop-data-uplink.md`, under **Status**, append one line:
+
+```markdown
+**Update 2026-07-16:** Phase 1 (protocol v3 + E2E payload AEAD, spec
+`docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md`) landed —
+keying groundwork done; the routing gap itself closes in Phase 2.
+```
+
+Commit:
+
+```bash
+git add docs/design-gaps/multihop-data-uplink.md
+git commit -m "docs: note Phase 1 (proto v3 + E2E AEAD) in gap doc"
+```
+
+- [ ] **Step 3: Open PRs**
+
+Use the superpowers:finishing-a-development-branch skill. Two PRs, lattice-protocol first:
+
+1. `../lattice-protocol` `feat/proto-v3-e2e-aead` → main; after merge, tag per repo convention (v0.x.0 series).
+2. `lattice-nodes` `feat/phase1-proto-v3-e2e-aead` → main; before opening, re-point the submodule at the MERGED lattice-protocol commit (`cd main/lib/lattice-protocol && git fetch && git checkout <merged-sha>`), re-run the suite, amend the bump commit (same pattern as PR #30).
+
+---
+
+## Deferred (explicitly NOT in Phase 1)
+
+- nanopb regen (`main/src/mesh/serialization/mesh.pb.*`): new proto fields don't cross the serial link yet; nanopb skips unknown fields on decode. Regenerate in Phase 3 (route path to server) / Phase 4 (secondary keys from server) with nanopb-0.4.9.1.
+- Downlink sealing (`SERIAL_CMD_BROADCAST`, `relayDownlink` paths) — Phase 3, needs source routing to make downlink unicast.
+- Header `route_path` accumulation for route reports — Phase 3 (relay-side payload append removed in Task 6 with a spec-§4 comment).
+- Multi-hop uplink (NeighborTable) — Phase 2. The two `DISABLED_` e2e tests stay disabled after Phase 1.

--- a/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
+++ b/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
@@ -32,7 +32,8 @@ Header stays plaintext (relays need it to forward):
 ```
 proto_version=3 | message_type | origin_mac(6) | target_mac(6) | last_hop_mac(6)
 | hop_count(u8) | epoch_num(u32) | seq_num(u16)
-| route_len(u8) + route_path[route_len × 6B]    // NEW; downlink only, 0 on uplink
+| route_len(u8) + route_path[route_len × 6B]    // NEW; downlink source route,
+                                                 //      or uplink path accumulator
 | payload ciphertext + 16B Poly1305 tag          // NEW; sealed
 ```
 
@@ -62,6 +63,10 @@ proto_version=3 | message_type | origin_mac(6) | target_mac(6) | last_hop_mac(6)
   layer. Per-peer LMK encryption is **dropped for the data path** — E2E AEAD
   is the security boundary. Data frames travel as unencrypted ESP-NOW
   unicast to auto-added forwarding neighbors (20-peer cap, LRU-evicted).
+  The per-peer LMK derivation path (`MeshCrypto::derivePeerLMK`,
+  `registerPeerWithEspNow` encrypt branch) becomes dead code and is removed
+  in Phase 1; the ECDH keypair and pubkey exchange remain — they now feed
+  HKDF instead.
 - **Trust split:**
   - `PeerRegistry` — identity + key material. The enrollment-only add rule
     (`PeerRegistry.cpp:67`) is **unchanged**.
@@ -94,9 +99,17 @@ Replaces the single `currentMaster.nextHop` as route source.
 
 ## 4. Downlink — source routing, stateless relays
 
-- Nodes send route reports (existing `OP_ROUTE_REPORT`; path accumulates
-  relay MACs in flight) periodically **and on next-hop change**. Route
-  reports are AEAD-sealed like all payloads.
+- Nodes send route reports (existing `OP_ROUTE_REPORT`) periodically **and
+  on next-hop change**. The report's payload (opcode etc.) is AEAD-sealed
+  like all payloads; the relay path accumulates in the plaintext
+  `route_path` header field (relays append their MAC in flight — possible
+  precisely because that field is mutable and excluded from AAD). The
+  current in-payload path encoding (`[opcode][path_len][MACs…]`,
+  `Mesh.cpp:806-840`) migrates to the header field.
+- Consequence: the path a master learns is relay-asserted, not
+  E2E-authenticated. A malicious relay could falsify it — yielding at worst
+  misrouted downlinks (DoS-equivalent, same class as the accepted blackhole
+  risk in Section 2). Uplink data integrity is unaffected.
 - Master keeps a route table: node MAC → latest path. RAM-only, rebuilt
   from reports. Size: compile-time `LATTICE_ROUTE_TABLE_MAX` (default 32;
   raise for large deployments — master is hub-side with headroom).

--- a/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
+++ b/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
@@ -1,0 +1,152 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Design: Multi-Hop Routing with End-to-End Payload Crypto (Protocol v3)
+
+**Status:** Approved 2026-07-16.
+**Closes:** Design gaps #7 (multi-hop data uplink) and #8 (dual-master data
+failover) — see `docs/design-gaps/multihop-data-uplink.md`.
+**Executable specs:** the two `DISABLED_` tests in
+`tests/e2e/scenarios/test_multihop_e2e.cpp` and
+`tests/e2e/scenarios/test_dual_master_e2e.cpp` become enabled as their phases
+land.
+
+## Decisions (from brainstorm)
+
+| Question | Decision |
+|---|---|
+| Threat model | **High** — end-to-end payload crypto; relays forward ciphertext they cannot read |
+| Scope | Full routing overhaul: uplink (#7), downlink commands, dual-master data failover (#8) |
+| Compatibility | Flag-day reflash; protocol v3, no mixed-version support. v3 nodes drop `proto_version != 3` (existing check, `Mesh.cpp:247`) |
+| Scale | Configurable at compile time; deployments may be large. Relays must stay stateless |
+| Approach | **A** — E2E AEAD + source-routed downlink (per-hop link crypto rejected: ESP-NOW caps encrypted peers at ~6–7; group key rejected: no compromise containment) |
+
+Hardware fact underpinning the approach: ESP-NOW supports ~6–7 **encrypted**
+peers but 20 unencrypted peers per node, and broadcast needs no peer entry.
+E2E payload crypto makes hop encryption unnecessary, so forwarding can use
+unencrypted peer slots and scale.
+
+## 1. Protocol v3 wire format
+
+Header stays plaintext (relays need it to forward):
+
+```
+proto_version=3 | message_type | origin_mac(6) | target_mac(6) | last_hop_mac(6)
+| hop_count(u8) | epoch_num(u32) | seq_num(u16)
+| route_len(u8) + route_path[route_len × 6B]    // NEW; downlink only, 0 on uplink
+| payload ciphertext + 16B Poly1305 tag          // NEW; sealed
+```
+
+- Payload (adapter data, commands, route reports) is ChaCha20-Poly1305
+  (mbedtls) ciphertext.
+- **AAD** = immutable header fields: version, type, origin, target, epoch,
+  seq. Mutable-in-flight fields (last_hop, hop_count, route_path) are
+  excluded — relays legally rewrite them. Tampering with excluded fields
+  yields at worst misrouting/drop (DoS equivalent to jamming), never payload
+  disclosure or forgery.
+- Beacons, enrollment requests, and JOIN_ACK remain plaintext broadcast as
+  today; the TOFU + enrollment-pubkey model is unchanged.
+
+## 2. Keying and crypto
+
+- **E2E keys per (node, master) pair:** HKDF-SHA256 over the existing
+  Curve25519 ECDH shared secret (pubkeys already exchanged at enrollment)
+  derives **two** 32-byte keys, `k_up` and `k_down`, with distinct HKDF
+  labels. Direction-split keys eliminate cross-direction nonce collisions.
+- **Nonce (12B):** `epoch(4) || seq(2) || origin_mac(6)`.
+  - Epoch is the EEPROM-persisted boot counter (`Mesh.cpp:120-122`);
+    seq is per-boot. Unique per origin per key.
+  - **Mandatory guard — seq wrap:** u16 seq overflows after 65,535 messages
+    in one boot. On wrap: increment and persist epoch, reset seq to 0.
+    Without this, a long-lived node reuses nonces (fatal for AEAD).
+- **ESP-NOW layer:** shared PMK (`DEFAULT_MESH_KEY`) kept as cheap outer
+  layer. Per-peer LMK encryption is **dropped for the data path** — E2E AEAD
+  is the security boundary. Data frames travel as unencrypted ESP-NOW
+  unicast to auto-added forwarding neighbors (20-peer cap, LRU-evicted).
+- **Trust split:**
+  - `PeerRegistry` — identity + key material. The enrollment-only add rule
+    (`PeerRegistry.cpp:67`) is **unchanged**.
+  - `NeighborTable` (new) — unauthenticated forwarding candidates learned
+    from beacons. Routing only; never holds or implies key material.
+  - Accepted risk: a spoofed beacon can attract (blackhole) traffic — a
+    local-attacker DoS comparable to RF jamming. It cannot read or forge
+    payloads. Documented, not mitigated in this cycle.
+
+## 3. Uplink routing — NeighborTable
+
+Replaces the single `currentMaster.nextHop` as route source.
+
+- Entry: `mac(6) | masterDistance(u8) | lastSeenMillis`. Populated from
+  overheard master beacons: relayed beacon's `hop_count + 1` = that
+  neighbor's distance to master.
+- Size: compile-time `LATTICE_NEIGHBOR_MAX` (default 8).
+- Next hop = freshest neighbor with **min distance strictly less than own
+  distance** (strict inequality prevents two equal-distance siblings
+  ping-ponging a frame).
+- Eviction: stale first (reuse `STALE_PEER_THRESHOLD_MS` = 8s semantics),
+  then largest distance.
+- `findNextHopToMaster()` reads the NeighborTable. The chosen neighbor is
+  auto-added as an **unencrypted** ESP-NOW peer on first forward.
+- Route repair is emergent: a dead relay stops beaconing, its entry goes
+  stale, the next-best neighbor is selected. No new protocol messages.
+- Data relay generalizes the existing enrollment relay logic
+  (`Mesh.cpp:653-672`): bump hop_count, forward toward own next hop,
+  ReplayCache dedup, `MAX_HOPS` bound.
+
+## 4. Downlink — source routing, stateless relays
+
+- Nodes send route reports (existing `OP_ROUTE_REPORT`; path accumulates
+  relay MACs in flight) periodically **and on next-hop change**. Route
+  reports are AEAD-sealed like all payloads.
+- Master keeps a route table: node MAC → latest path. RAM-only, rebuilt
+  from reports. Size: compile-time `LATTICE_ROUTE_TABLE_MAX` (default 32;
+  raise for large deployments — master is hub-side with headroom).
+- Downlink frames carry the reversed path in `route_path[]`. A relay finds
+  its own MAC at index *i* and forwards to index *i+1*. Relays hold zero
+  routing state — this is the property that scales.
+- **Parse bounds:** `route_len ≤ MAX_HOPS`, all path indexing bounds-checked
+  (same defect class as the OOB ack-buffer fix in PR #31; fuzz-tested).
+- Stale route ⇒ downlink lost ⇒ next route report heals it. The JOIN_ACK
+  broadcast workaround remains only as the enrollment-time fallback.
+
+## 5. Dual-master data failover (#8)
+
+- JOIN_ACK gains `secondary_master_mac(6) + secondary_public_key(32)`. The
+  server (which manages both masters) supplies these via the primary.
+- At enrollment the leaf derives a second `k_up`/`k_down` pair for the
+  secondary and persists the secondary pubkey in EEPROM (secondary-MAC slot
+  already exists at `EepromManager.h:497`; a pubkey slot is added).
+- Failover behavior (TOFU-adopt secondary when primary goes silent) is
+  already implemented and tested; after this change the post-failover
+  uplink is encrypted with the secondary's keys and is decryptable.
+- The secondary master obtains each leaf's pubkey via server sync over its
+  serial link. **Confirmed assumption:** both masters are hub/server-connected.
+
+## 6. Error handling and repair
+
+- AEAD decrypt/tag failure → quiet drop + error counter (matches the
+  finding-#9 pattern; no `err::fail` loops).
+- No neighbor with smaller distance → quiet drop; wait for next beacon
+  (existing behavior).
+- seq wrap → epoch bump + persist (Section 2).
+- Replay protection: existing ReplayCache unchanged; (origin, epoch, seq)
+  remains the dedup key.
+
+## 7. Testing
+
+- Enable both `DISABLED_` e2e tests — they are the executable specs for
+  #7 and #8.
+- New e2e scenarios (PR #28 sim suite): 3-hop chain uplink; downlink source
+  route delivery; route repair (kill relay mid-test); ciphertext tamper
+  (bit-flip → drop); replay reinjection; equal-distance sibling ping-pong
+  guard.
+- Unit tests: AEAD known-answer vectors; nonce construction including seq
+  wrap; NeighborTable eviction ordering; `route_path` parse bounds/fuzz.
+
+## 8. Phasing (each phase = its own plan + PR)
+
+1. **Protocol v3 + E2E AEAD**, direct-range only — crypto core, flag day.
+2. **NeighborTable + multi-hop data uplink** — closes gap #7.
+3. **Source-routed downlink** — master route table + path forwarding.
+4. **Dual-master keying + data failover** — closes gap #8.
+
+Phases 2–4 each end by enabling their corresponding e2e tests.

--- a/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
+++ b/docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md
@@ -155,7 +155,29 @@ Replaces the single `currentMaster.nextHop` as route source.
 - Unit tests: AEAD known-answer vectors; nonce construction including seq
   wrap; NeighborTable eviction ordering; `route_path` parse bounds/fuzz.
 
-## 8. Phasing (each phase = its own plan + PR)
+## 8. Cross-repo changes — lattice-protocol
+
+The wire format lives in the `lattice-protocol` repo (worked on at
+`../lattice-protocol`, vendored here as the `main/lib/lattice-protocol`
+submodule). Protocol v3 changes land there first, then the submodule is
+bumped here.
+
+- `c/mesh_message.h`: v3 header — `route_len` + `route_path[MAX_HOPS × 6]`,
+  AEAD tag/ciphertext payload layout, `PROTO_VERSION = 3`.
+- `c/mesh_message.h` (JOIN_ACK): `secondary_master_mac(6)` +
+  `secondary_public_key(32)` fields (Section 5).
+- `c/opcodes.h`: unchanged opcodes, but route-report path encoding moves
+  from payload to header (Section 4) — payload doc/comments updated.
+- Go side (`message/`, `proto/`): v3 struct fields, route-path parsing, and
+  whatever the hub needs for enrolled-peer sync to both masters
+  (Section 5). AEAD encrypt/decrypt happens on master firmware, not the
+  server, so no crypto lands in Go beyond field pass-through — but the
+  server composes JOIN_ACK content including the secondary master's pubkey.
+- Each firmware phase that changes wire format (1, 3, 4) pairs with a
+  lattice-protocol release + submodule bump PR here (same pattern as
+  PR #30).
+
+## 9. Phasing (each phase = its own plan + PR)
 
 1. **Protocol v3 + E2E AEAD**, direct-range only — crypto core, flag day.
 2. **NeighborTable + multi-hop data uplink** — closes gap #7.

--- a/main/project_config.h
+++ b/main/project_config.h
@@ -111,6 +111,9 @@ constexpr TxPowerPreset DEFAULT_TX_POWER_PRESET = TxPowerPreset::OUTDOOR;
 // =====================
 // 9. Global Limits (Tiger Style)
 // =====================
+// E2E AEAD derived-key cache entries (spec §2). One entry per (peer, master) pair;
+// masters need one per enrolled node, leaves need one per master. Default: MAX_PEERS.
+inline constexpr size_t LATTICE_E2E_KEYCACHE_MAX = 10; // = MAX_PEERS
 // Maximum allowed routing hops in the mesh network
 constexpr uint8_t MAX_HOPS = 10;
 // Maximum relay hops in a route report path; bounded by data[2..61] = 60 bytes / 6 bytes per MAC

--- a/main/src/mesh/E2ECrypto.h
+++ b/main/src/mesh/E2ECrypto.h
@@ -60,8 +60,8 @@ inline void computeSharedSecret(const uint8_t* ownPrivateKey32, const uint8_t* p
                         "MESH: computeSharedSecret — mpi_lset (Qp.Z) failed");
   }
   size_t outLen = 0;
-  ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, secret32Out, 32, mbedtls_ctr_drbg_random,
-                                 &ctr_drbg);
+  ret =
+      mbedtls_ecdh_calc_secret(&ecdh, &outLen, secret32Out, 32, mbedtls_ctr_drbg_random, &ctr_drbg);
   if (ret != 0) {
     lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 25,
                         "MESH: computeSharedSecret — ecdh_calc_secret failed");
@@ -86,8 +86,8 @@ inline void deriveE2EKeys(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
   static const uint8_t downLabel[] = "lattice-e2e-down-v3";
   int ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, upLabel, sizeof(upLabel) - 1, kUp32Out, 32);
   if (ret == 0) {
-    ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, downLabel, sizeof(downLabel) - 1, kDown32Out,
-                       32);
+    ret =
+        mbedtls_hkdf(md, nullptr, 0, secret, 32, downLabel, sizeof(downLabel) - 1, kDown32Out, 32);
   }
   memset(secret, 0, sizeof(secret));
   if (ret != 0) {

--- a/main/src/mesh/E2ECrypto.h
+++ b/main/src/mesh/E2ECrypto.h
@@ -1,0 +1,95 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/hkdf.h>
+#include <mbedtls/md.h>
+#include "src/error/Error.h"
+#include "src/error/ErrorCore.h"
+
+namespace lattice {
+namespace mesh {
+namespace crypto {
+
+// X25519 ECDH shared secret. Same mbedtls flow as derivePeerLMK (MeshCrypto.h),
+// without the LMK KDF step. err::fatal digits 20-25 (LMK path uses 10-19).
+inline void computeSharedSecret(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
+                                uint8_t* secret32Out) {
+  mbedtls_ecdh_context ecdh;
+  mbedtls_entropy_context entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_ecdh_init(&ecdh);
+  mbedtls_entropy_init(&entropy);
+  mbedtls_ctr_drbg_init(&ctr_drbg);
+
+  const char* pers = "lattice_ecdh_e2e";
+  int ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                  reinterpret_cast<const uint8_t*>(pers), strlen(pers));
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 20,
+                        "MESH: computeSharedSecret — ctr_drbg_seed failed");
+  }
+  ret = mbedtls_ecdh_setup(&ecdh, MBEDTLS_ECP_DP_CURVE25519);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 21,
+                        "MESH: computeSharedSecret — ecdh_setup failed");
+  }
+  ret = mbedtls_mpi_read_binary(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(d), ownPrivateKey32,
+      32);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 22,
+                        "MESH: computeSharedSecret — mpi_read_binary (private key) failed");
+  }
+  ret = mbedtls_mpi_read_binary(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X),
+      peerPublicKey32, 32);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 23,
+                        "MESH: computeSharedSecret — mpi_read_binary (peer public key) failed");
+  }
+  ret = mbedtls_mpi_lset(
+      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z),
+      1);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 24,
+                        "MESH: computeSharedSecret — mpi_lset (Qp.Z) failed");
+  }
+  size_t outLen = 0;
+  ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, secret32Out, 32, mbedtls_ctr_drbg_random,
+                                 &ctr_drbg);
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 25,
+                        "MESH: computeSharedSecret — ecdh_calc_secret failed");
+  }
+  mbedtls_ecdh_free(&ecdh);
+  mbedtls_ctr_drbg_free(&ctr_drbg);
+  mbedtls_entropy_free(&entropy);
+}
+
+// Direction-split E2E keys (spec §2): HKDF-SHA256 over the ECDH secret.
+// k_up seals node→master payloads, k_down master→node.
+inline void deriveE2EKeys(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
+                          uint8_t* kUp32Out, uint8_t* kDown32Out) {
+  uint8_t secret[32];
+  computeSharedSecret(ownPrivateKey32, peerPublicKey32, secret);
+  const mbedtls_md_info_t* md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  static const uint8_t upLabel[] = "lattice-e2e-up-v3";
+  static const uint8_t downLabel[] = "lattice-e2e-down-v3";
+  int ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, upLabel, sizeof(upLabel) - 1, kUp32Out, 32);
+  if (ret == 0) {
+    ret = mbedtls_hkdf(md, nullptr, 0, secret, 32, downLabel, sizeof(downLabel) - 1, kDown32Out,
+                       32);
+  }
+  memset(secret, 0, sizeof(secret));
+  if (ret != 0) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 26,
+                        "MESH: deriveE2EKeys — hkdf failed");
+  }
+}
+
+} // namespace crypto
+} // namespace mesh
+} // namespace lattice

--- a/main/src/mesh/E2ECrypto.h
+++ b/main/src/mesh/E2ECrypto.h
@@ -6,8 +6,10 @@
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/hkdf.h>
 #include <mbedtls/md.h>
+#include <mbedtls/chachapoly.h>
 #include "src/error/Error.h"
 #include "src/error/ErrorCore.h"
+#include "../../lib/lattice-protocol/c/mesh_message.h"
 
 namespace lattice {
 namespace mesh {
@@ -88,6 +90,73 @@ inline void deriveE2EKeys(const uint8_t* ownPrivateKey32, const uint8_t* peerPub
     lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 26,
                         "MESH: deriveE2EKeys — hkdf failed");
   }
+}
+
+// AEAD framing (spec §1/§2).
+// Nonce (12B): epoch(4 LE) || seq(2 LE) || origin_mac(6) — unique per key given the
+// boot-epoch counter and the seq-wrap epoch bump.
+// AAD (24B): version, type, data_type, origin, target, epoch, seq — immutable fields only.
+constexpr size_t E2E_AAD_LEN = 24;
+constexpr size_t E2E_NONCE_LEN = 12;
+
+inline void buildNonce(const mesh_message& msg, uint8_t nonce[E2E_NONCE_LEN]) {
+  nonce[0] = static_cast<uint8_t>(msg.epoch_num);
+  nonce[1] = static_cast<uint8_t>(msg.epoch_num >> 8);
+  nonce[2] = static_cast<uint8_t>(msg.epoch_num >> 16);
+  nonce[3] = static_cast<uint8_t>(msg.epoch_num >> 24);
+  nonce[4] = static_cast<uint8_t>(msg.seq_num);
+  nonce[5] = static_cast<uint8_t>(msg.seq_num >> 8);
+  memcpy(nonce + 6, msg.origin_mac_address, 6);
+}
+
+inline void buildAad(const mesh_message& msg, uint8_t aad[E2E_AAD_LEN]) {
+  aad[0] = msg.proto_version;
+  aad[1] = msg.message_type;
+  aad[2] = static_cast<uint8_t>(msg.data_type);
+  aad[3] = static_cast<uint8_t>(msg.data_type >> 8);
+  aad[4] = static_cast<uint8_t>(msg.data_type >> 16);
+  aad[5] = static_cast<uint8_t>(msg.data_type >> 24);
+  memcpy(aad + 6, msg.origin_mac_address, 6);
+  memcpy(aad + 12, msg.target_mac_address, 6);
+  aad[18] = static_cast<uint8_t>(msg.epoch_num);
+  aad[19] = static_cast<uint8_t>(msg.epoch_num >> 8);
+  aad[20] = static_cast<uint8_t>(msg.epoch_num >> 16);
+  aad[21] = static_cast<uint8_t>(msg.epoch_num >> 24);
+  aad[22] = static_cast<uint8_t>(msg.seq_num);
+  aad[23] = static_cast<uint8_t>(msg.seq_num >> 8);
+}
+
+// Encrypts msg.data in place and writes msg.auth_tag. Returns false on mbedtls error.
+inline bool sealPayload(const uint8_t* key32, mesh_message& msg) {
+  uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
+  buildNonce(msg, nonce);
+  buildAad(msg, aad);
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  if (ret == 0) {
+    ret = mbedtls_chachapoly_encrypt_and_tag(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+                                             msg.data, msg.data, msg.auth_tag);
+  }
+  mbedtls_chachapoly_free(&ctx);
+  return ret == 0;
+}
+
+// Decrypts msg.data in place, verifying msg.auth_tag. Returns false on tag mismatch
+// or mbedtls error — callers drop the frame quietly (finding-#9 pattern).
+inline bool openPayload(const uint8_t* key32, mesh_message& msg) {
+  uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
+  buildNonce(msg, nonce);
+  buildAad(msg, aad);
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  if (ret == 0) {
+    ret = mbedtls_chachapoly_auth_decrypt(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+                                          msg.auth_tag, msg.data, msg.data);
+  }
+  mbedtls_chachapoly_free(&ctx);
+  return ret == 0;
 }
 
 } // namespace crypto

--- a/main/src/mesh/E2ECrypto.h
+++ b/main/src/mesh/E2ECrypto.h
@@ -66,6 +66,10 @@ inline void computeSharedSecret(const uint8_t* ownPrivateKey32, const uint8_t* p
     lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 25,
                         "MESH: computeSharedSecret — ecdh_calc_secret failed");
   }
+  if (outLen != 32) {
+    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 27,
+                        "MESH: computeSharedSecret — unexpected shared-secret length");
+  }
   mbedtls_ecdh_free(&ecdh);
   mbedtls_ctr_drbg_free(&ctr_drbg);
   mbedtls_entropy_free(&entropy);

--- a/main/src/mesh/E2EKeyStore.h
+++ b/main/src/mesh/E2EKeyStore.h
@@ -28,7 +28,7 @@ public:
   // change, so a move is no riskier than an eviction.
   E2EKeyStore(E2EKeyStore&&) = default;
   E2EKeyStore& operator=(E2EKeyStore&&) = default;
-  bool getKeys(const uint8_t mac[6], const uint8_t* ownPriv32, const uint8_t* peerPub32,
+  bool getKeys(const uint8_t* mac, const uint8_t* ownPriv32, const uint8_t* peerPub32,
                const uint8_t** kUpOut, const uint8_t** kDownOut) {
     for (size_t i = 0; i < config::LATTICE_E2E_KEYCACHE_MAX; ++i) {
       if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0) {

--- a/main/src/mesh/E2EKeyStore.h
+++ b/main/src/mesh/E2EKeyStore.h
@@ -20,6 +20,14 @@ public:
   E2EKeyStore() = default;
   E2EKeyStore(const E2EKeyStore&) = delete;
   E2EKeyStore& operator=(const E2EKeyStore&) = delete;
+  // Move is fine (and needed so composing types — e.g. Mesh, which now holds
+  // one of these — stay returnable-by-value/relocatable, notably in test
+  // factory helpers). The cache holds no pointers or owned resources, only
+  // fixed-size POD entries; any raw pointer a caller obtained from getKeys()
+  // is already documented above as invalidated by any subsequent structural
+  // change, so a move is no riskier than an eviction.
+  E2EKeyStore(E2EKeyStore&&) = default;
+  E2EKeyStore& operator=(E2EKeyStore&&) = default;
   bool getKeys(const uint8_t mac[6], const uint8_t* ownPriv32, const uint8_t* peerPub32,
                const uint8_t** kUpOut, const uint8_t** kDownOut) {
     for (size_t i = 0; i < config::LATTICE_E2E_KEYCACHE_MAX; ++i) {

--- a/main/src/mesh/E2EKeyStore.h
+++ b/main/src/mesh/E2EKeyStore.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "E2ECrypto.h"
+#include "../../project_config.h"
+
+namespace lattice {
+namespace mesh {
+
+// RAM-only cache of derived E2E key pairs, one entry per peer MAC (spec §2).
+// Derivation costs an X25519 exchange (~ms on ESP32) — cache so the periodic
+// uplink path never re-derives. Round-robin overwrite when full; wrong evictions
+// only cost a re-derivation.
+class E2EKeyStore {
+public:
+  bool getKeys(const uint8_t mac[6], const uint8_t* ownPriv32, const uint8_t* peerPub32,
+               const uint8_t** kUpOut, const uint8_t** kDownOut) {
+    for (size_t i = 0; i < config::LATTICE_E2E_KEYCACHE_MAX; ++i) {
+      if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0) {
+        *kUpOut = entries[i].kUp;
+        *kDownOut = entries[i].kDown;
+        return true;
+      }
+    }
+    if (!peerPub32)
+      return false;
+    bool allZero = true;
+    for (int i = 0; i < 32; ++i) {
+      if (peerPub32[i] != 0) {
+        allZero = false;
+        break;
+      }
+    }
+    if (allZero)
+      return false;
+    Entry& e = entries[nextSlot];
+    nextSlot = (nextSlot + 1) % config::LATTICE_E2E_KEYCACHE_MAX;
+    crypto::deriveE2EKeys(ownPriv32, peerPub32, e.kUp, e.kDown);
+    memcpy(e.mac, mac, 6);
+    e.valid = true;
+    *kUpOut = e.kUp;
+    *kDownOut = e.kDown;
+    return true;
+  }
+
+  void clear() {
+    memset(entries, 0, sizeof(entries));
+    nextSlot = 0;
+  }
+
+private:
+  struct Entry {
+    uint8_t mac[6];
+    bool valid;
+    uint8_t kUp[32];
+    uint8_t kDown[32];
+  };
+  Entry entries[config::LATTICE_E2E_KEYCACHE_MAX]{};
+  size_t nextSlot{0};
+};
+
+} // namespace mesh
+} // namespace lattice

--- a/main/src/mesh/E2EKeyStore.h
+++ b/main/src/mesh/E2EKeyStore.h
@@ -11,8 +11,15 @@ namespace mesh {
 // Derivation costs an X25519 exchange (~ms on ESP32) — cache so the periodic
 // uplink path never re-derives. Round-robin overwrite when full; wrong evictions
 // only cost a re-derivation.
+//
+// IMPORTANT: Pointers returned via kUpOut/kDownOut are invalidated by any
+// subsequent getKeys() call that causes an eviction. Callers must use them
+// immediately and must NOT cache them across getKeys() calls.
 class E2EKeyStore {
 public:
+  E2EKeyStore() = default;
+  E2EKeyStore(const E2EKeyStore&) = delete;
+  E2EKeyStore& operator=(const E2EKeyStore&) = delete;
   bool getKeys(const uint8_t mac[6], const uint8_t* ownPriv32, const uint8_t* peerPub32,
                const uint8_t** kUpOut, const uint8_t** kDownOut) {
     for (size_t i = 0; i < config::LATTICE_E2E_KEYCACHE_MAX; ++i) {

--- a/main/src/mesh/Enrollment.cpp
+++ b/main/src/mesh/Enrollment.cpp
@@ -138,7 +138,7 @@ void Enrollment::enrollPeer(const uint8_t* mac, const uint8_t* pubKey32, Registe
   if (esp_now_is_peer_exist(mac)) {
     esp_now_del_peer(mac);
   }
-  crypto::registerPeerWithEspNow(mac, devicePrivateKey, pubKey32);
+  crypto::registerPeerWithEspNow(mac);
   if (registerFn)
     registerFn(mac, pubKey32);
 }

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -253,8 +253,13 @@ void Mesh::drainRecvQueue() {
 
     const mesh_message& msg = entry.msg;
 
-    // Proto version check
-    if (msg.proto_version != 0 && msg.proto_version != PROTO_VERSION) {
+    // Proto version check: drop anything that isn't exactly the current wire
+    // version. There is no legitimate proto_version==0 case — buildMessage(),
+    // Enrollment::sendRequest(), and the JOIN_ACK path all stamp PROTO_VERSION
+    // unconditionally — so a zero value only ever means a forged/malformed
+    // frame that would otherwise bypass both this flag-day drop and the replay
+    // gate below (which is itself keyed on proto_version == PROTO_VERSION).
+    if (msg.proto_version != PROTO_VERSION) {
       Logger::logln("MESH", "Unsupported proto version, dropping", LogLevel::LOG_WARN);
       continue;
     }
@@ -662,6 +667,21 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     return;
   }
 
+  // Security gate: at the master, a sealed-type frame (ADAPTER_DATA/ROUTE_REPORT)
+  // that is NOT addressed to self must never reach local delivery unopened. No
+  // leaf ever originates a broadcast-target (FF:FF:FF:FF:FF:FF) sealed uplink —
+  // only the master's own downlink broadcast (broadcastAdapterData, which delivers
+  // locally directly and never re-enters this function) and beacons use FF:FF. So
+  // a broadcast-target (or otherwise not-self-addressed) sealed frame arriving here
+  // over the air at the master is either a stale self-echo or a forgery — drop it
+  // rather than deliver it to externalRecvCallback without E2E authentication.
+  if (isMaster && !addressedToSelf && isSealedType(msg.message_type)) {
+    Logger::logln("MESH",
+                   "Master: sealed-type frame not addressed to self rejected (unauthenticated)",
+                   LogLevel::LOG_WARN);
+    return;
+  }
+
   // Local delivery
   // E2E open (spec §2): master unseals self-targeted uplink before local delivery.
   mesh_message opened = msg;
@@ -683,10 +703,9 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     Logger::logln("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
     return;
   }
-  // Warn if master receives adapter data not addressed to itself — unexpected topology
-  if (isMaster && !addressedToSelf && !isBroadcastTarget) {
-    Logger::logln("MESH", "Master received ADAPTER_DATA not addressed to self", LogLevel::LOG_WARN);
-  }
+  // Note: the "master received ADAPTER_DATA not addressed to self" case is now
+  // handled (and rejected) by the security gate above — ADAPTER_DATA is always a
+  // sealed type, so isMaster && !addressedToSelf never reaches this point.
   if (externalRecvCallback)
     externalRecvCallback(opened);
 

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -213,8 +213,7 @@ bool Mesh::setupEspNow() {
   }
 
   for (size_t i = 0; i < peers.peerCount; ++i) {
-    lattice::mesh::crypto::registerPeerWithEspNow(peers.peerMacs[i].mac, enrollment.getPrivateKey(),
-                                                  peers.peerMacs[i].publicKey);
+    lattice::mesh::crypto::registerPeerWithEspNow(peers.peerMacs[i].mac);
   }
   esp_now_register_send_cb(onDataSentCallback);
   esp_now_register_recv_cb(Mesh::dataRecvTrampoline);
@@ -769,9 +768,7 @@ void Mesh::addPeer(const uint8_t* mac) {
   size_t before = peers.peerCount;
   peers.addAndPersist(mac);
   if (peers.peerCount > before) {
-    lattice::mesh::crypto::registerPeerWithEspNow(peers.peerMacs[peers.peerCount - 1].mac,
-                                                  enrollment.getPrivateKey(),
-                                                  peers.peerMacs[peers.peerCount - 1].publicKey);
+    lattice::mesh::crypto::registerPeerWithEspNow(peers.peerMacs[peers.peerCount - 1].mac);
   }
 }
 

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -49,7 +49,9 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t(&mac)[6]) { return lattice::utils::MacAddress(mac).toString(); };
+  auto macToStr = [](const uint8_t (&mac)[6]) {
+    return lattice::utils::MacAddress(mac).toString();
+  };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);
@@ -677,8 +679,8 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   // rather than deliver it to externalRecvCallback without E2E authentication.
   if (isMaster && !addressedToSelf && isSealedType(msg.message_type)) {
     Logger::logln("MESH",
-                   "Master: sealed-type frame not addressed to self rejected (unauthenticated)",
-                   LogLevel::LOG_WARN);
+                  "Master: sealed-type frame not addressed to self rejected (unauthenticated)",
+                  LogLevel::LOG_WARN);
     return;
   }
 

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -106,8 +106,16 @@ mesh_message Mesh::buildMessage(adapter_types type, const uint8_t* data, MeshMes
   if (data)
     memcpy(msg.data, data, sizeof(msg.data));
   msg.hop_count = 0;
-  msg.epoch_num = replay.bootEpoch;
   msg.seq_num = replay.nextSeq();
+  if (msg.seq_num == 0) {
+    // seq wrapped (spec §2): a reused (epoch, seq) pair would reuse an AEAD nonce.
+    // Advance the persisted epoch and restart the sequence.
+    uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
+    EepromManager::getInstance().saveBootEpoch(epoch);
+    replay.bootEpoch = epoch;
+    msg.seq_num = replay.nextSeq();
+  }
+  msg.epoch_num = replay.bootEpoch;
   return msg;
 }
 

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -10,6 +10,7 @@
 #include "../../project_config.h"
 #include "lib/lattice-protocol/c/opcodes.h"
 #include "MeshCrypto.h"
+#include "E2ECrypto.h"
 
 namespace lattice {
 namespace mesh {
@@ -312,6 +313,26 @@ void Mesh::broadcastToAllPeers(const mesh_message& msg) {
   }
 }
 
+bool Mesh::isSealedType(uint8_t messageType) {
+  return messageType == MESH_TYPE_ADAPTER_DATA || messageType == MESH_TYPE_ROUTE_REPORT;
+}
+
+bool Mesh::masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown) {
+  if (!enrollment.hasMasterMac)
+    return false;
+  PeerInfo* master = peers.find(currentMaster.mac);
+  if (!master)
+    return false;
+  return e2eKeys.getKeys(master->mac, enrollment.getPrivateKey(), master->publicKey, kUp, kDown);
+}
+
+bool Mesh::peerE2EKeys(const uint8_t* originMac, const uint8_t** kUp, const uint8_t** kDown) {
+  PeerInfo* peer = peers.find(originMac);
+  if (!peer)
+    return false;
+  return e2eKeys.getKeys(peer->mac, enrollment.getPrivateKey(), peer->publicKey, kUp, kDown);
+}
+
 void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessageType msgType,
                         const mesh_message* msgOverride) {
   mesh_message msg;
@@ -325,6 +346,17 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
   if (msgType == MESH_TYPE_ADAPTER_DATA) {
     memcpy(msg.target_mac_address, currentMaster.mac,
            6); // authoritative: overrides relay's original target
+  }
+
+  // E2E seal (spec §1/§2): self-originated uplink payloads only. Relayed frames
+  // (msgOverride with foreign origin) are already sealed — forward untouched.
+  bool selfOriginated = (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0);
+  if (!isMaster && selfOriginated && isSealedType(msg.message_type)) {
+    const uint8_t *kUp, *kDown;
+    if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kUp, msg)) {
+      Logger::logln("MESH", "E2E seal unavailable — uplink dropped", LogLevel::LOG_WARN);
+      return;
+    }
   }
 
   // Routing: always use next hop if possible
@@ -616,11 +648,23 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   }
 
   // Local delivery
+  // E2E open (spec §2): master unseals self-targeted uplink before local delivery.
+  mesh_message opened = msg;
+  bool needsOpen = isMaster && addressedToSelf && isSealedType(msg.message_type);
+  if (needsOpen) {
+    const uint8_t *kUp, *kDown;
+    if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
+        !lattice::mesh::crypto::openPayload(kUp, opened)) {
+      Logger::logln("MESH", "E2E open failed — frame dropped", LogLevel::LOG_WARN);
+      return;
+    }
+  }
+
   bool isConfigOpcode =
-      (msg.data_type == adapter_types::SERIAL_ADAPTER && msg.data[0] == OP_CONFIG_SET);
+      (opened.data_type == adapter_types::SERIAL_ADAPTER && opened.data[0] == OP_CONFIG_SET);
   // TODO(dual-master): also allow secondary master MAC for CONFIG_SET
   if (isConfigOpcode && enrollment.hasMasterMac &&
-      memcmp(msg.origin_mac_address, enrollment.knownMasterMac, 6) != 0) {
+      memcmp(opened.origin_mac_address, enrollment.knownMasterMac, 6) != 0) {
     Logger::logln("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
     return;
   }
@@ -629,7 +673,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     Logger::logln("MESH", "Master received ADAPTER_DATA not addressed to self", LogLevel::LOG_WARN);
   }
   if (externalRecvCallback)
-    externalRecvCallback(msg);
+    externalRecvCallback(opened);
 
   // Broadcast: also relay so multi-hop nodes receive it (Task 3 test covers this)
   if (isBroadcastTarget && !isMaster) {
@@ -798,42 +842,44 @@ bool Mesh::sendRouteReport() {
     return false;
   uint8_t data[64] = {};
   data[0] = OP_ROUTE_REPORT;
-  data[1] = 0; // path_len — incremented by each relay hop
+  data[1] = 0; // path_len — reserved; relays no longer accumulate here (spec §4)
   transmitCore(adapter_types::UNKNOWN_ADAPTER, data, MESH_TYPE_ROUTE_REPORT);
   return true;
 }
 
 void Mesh::processRouteReport(const mesh_message& msg) {
-  // Verify opcode
-  if (msg.data[0] != OP_ROUTE_REPORT) {
-    Logger::logln("MESH", "processRouteReport: bad opcode, dropping", LogLevel::LOG_WARN);
-    return;
-  }
-
   if (isMaster) {
+    // E2E open (spec §2): master unseals self-targeted uplink before parsing
+    // the opcode/path bytes — the payload is ciphertext until opened.
+    mesh_message opened = msg;
+    const uint8_t *kUp, *kDown;
+    if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
+        !lattice::mesh::crypto::openPayload(kUp, opened)) {
+      Logger::logln("MESH", "E2E open failed — route report dropped", LogLevel::LOG_WARN);
+      return;
+    }
+    if (opened.data[0] != OP_ROUTE_REPORT) {
+      Logger::logln("MESH", "processRouteReport: bad opcode, dropping", LogLevel::LOG_WARN);
+      return;
+    }
     // Terminal endpoint — deliver to server via external callback
     if (externalRecvCallback)
-      externalRecvCallback(msg);
+      externalRecvCallback(opened);
     return;
   }
 
-  // Relay node: append own MAC to path and forward toward master
-  uint8_t path_len = msg.data[1];
-  if (path_len >= lattice::config::MAX_ROUTE_PATH_LEN) {
-    Logger::logln("MESH", "processRouteReport: path full, dropping", LogLevel::LOG_WARN);
+  // Relay node (spec §4): the payload is E2E-sealed end-to-end (origin -> master)
+  // so a relay cannot read or mutate msg.data — path accumulation via data[] is
+  // removed; it moves to the header route_path field in a future phase. Forward
+  // the frame unmodified except routing metadata (hop_count/last_hop).
+  if (msg.hop_count >= lattice::config::MAX_HOPS) {
+    Logger::logln("MESH", "processRouteReport: hop limit reached, dropping", LogLevel::LOG_WARN);
     return;
   }
 
   mesh_message relay = msg;
-  memcpy(&relay.data[2 + path_len * 6], deviceMacAddress, 6);
-  relay.data[1]++;
   relay.hop_count++;
   memcpy(relay.last_hop_mac_address, deviceMacAddress, 6);
-
-  if (relay.hop_count >= lattice::config::MAX_HOPS) {
-    Logger::logln("MESH", "processRouteReport: hop limit reached, dropping", LogLevel::LOG_WARN);
-    return;
-  }
 
   transmitCore(static_cast<adapter_types>(relay.data_type), relay.data, MESH_TYPE_ROUTE_REPORT,
                &relay);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -91,6 +91,22 @@ PeerInfo* Mesh::findNextHopToMaster() {
   return nullptr;
 }
 
+uint16_t Mesh::nextSeqGuarded() {
+  uint16_t seq = replay.nextSeq();
+  if (seq == 0) {
+    // seq wrapped (spec §2): a reused (epoch, seq) pair would reuse an AEAD nonce.
+    // Advance the persisted epoch and restart the sequence. replay.bootEpoch is
+    // already the currently active epoch (kept in sync with EEPROM by init()
+    // and by this method), so bump from it directly rather than re-reading
+    // EEPROM.
+    uint32_t epoch = replay.bootEpoch + 1;
+    EepromManager::getInstance().saveBootEpoch(epoch);
+    replay.bootEpoch = epoch;
+    seq = replay.nextSeq();
+  }
+  return seq;
+}
+
 mesh_message Mesh::buildMessage(adapter_types type, const uint8_t* data, MeshMessageType msgType) {
   mesh_message msg = {};
   msg.proto_version = PROTO_VERSION;
@@ -106,15 +122,7 @@ mesh_message Mesh::buildMessage(adapter_types type, const uint8_t* data, MeshMes
   if (data)
     memcpy(msg.data, data, sizeof(msg.data));
   msg.hop_count = 0;
-  msg.seq_num = replay.nextSeq();
-  if (msg.seq_num == 0) {
-    // seq wrapped (spec §2): a reused (epoch, seq) pair would reuse an AEAD nonce.
-    // Advance the persisted epoch and restart the sequence.
-    uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
-    EepromManager::getInstance().saveBootEpoch(epoch);
-    replay.bootEpoch = epoch;
-    msg.seq_num = replay.nextSeq();
-  }
+  msg.seq_num = nextSeqGuarded();
   msg.epoch_num = replay.bootEpoch;
   return msg;
 }
@@ -822,8 +830,11 @@ void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32) {
   // given JOIN_ACK at most once (the reflected copy is dropped by isReplay before
   // processJoinAck), preventing combinatorial broadcast amplification.
   ack.proto_version = PROTO_VERSION;
+  // Draw seq via the guarded choke point FIRST — it may bump replay.bootEpoch
+  // on wrap — then stamp epoch_num from the (possibly just-bumped) value so
+  // the ACK's epoch always matches the epoch its seq_num was drawn under.
+  ack.seq_num = nextSeqGuarded();
   ack.epoch_num = replay.bootEpoch;
-  ack.seq_num = replay.nextSeq();
   ack.message_type = MESH_TYPE_JOIN_ACK;
   ack.data_type = adapter_types::UNKNOWN_ADAPTER;
   memcpy(ack.origin_mac_address, deviceMacAddress, 6);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -49,9 +49,7 @@ void Mesh::readMacAddress() {
 }
 
 void Mesh::printMeshMessage(const mesh_message& msg) {
-  auto macToStr = [](const uint8_t (&mac)[6]) {
-    return lattice::utils::MacAddress(mac).toString();
-  };
+  auto macToStr = [](const uint8_t(&mac)[6]) { return lattice::utils::MacAddress(mac).toString(); };
 
   Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
   Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -16,6 +16,7 @@
 #include "ReplayCache.h"
 #include "PeerRegistry.h"
 #include "Enrollment.h"
+#include "E2EKeyStore.h"
 
 #ifdef UNIT_TEST
 // Forward declarations for test fixture classes (global namespace) so that
@@ -151,6 +152,15 @@ private:
 
   // Enrollment state (composed — mbedtls-heavy methods stubbed in test builds)
   Enrollment enrollment;
+
+  // E2E AEAD (spec §1/§2): per-peer derived key cache + lookup helpers.
+  E2EKeyStore e2eKeys;
+  // Returns k_up/k_down for the current master (leaf side); false if not enrolled
+  // or master pubkey unknown.
+  bool masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown);
+  // Returns keys for an enrolled origin peer (master side); false if unknown peer.
+  bool peerE2EKeys(const uint8_t* originMac, const uint8_t** kUp, const uint8_t** kDown);
+  static bool isSealedType(uint8_t messageType);
 
 public:
   Mesh();

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -31,7 +31,7 @@ using ::mesh_message;
 using ::MeshMessageType;
 using lattice::adapter::adapter_types;
 
-static constexpr uint8_t PROTO_VERSION = 2;
+static constexpr uint8_t PROTO_VERSION = 3;
 
 class Mesh {
 #ifdef UNIT_TEST

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -123,6 +123,10 @@ private:
   // Replay protection (composed)
   ReplayCache replay;
 
+#ifdef UNIT_TEST
+  ReplayCache& testReplay() { return replay; }
+#endif
+
   // Relay jitter: deferred relay pending fields (Task 3)
   mesh_message relayPendingMsg;
   uint32_t relayPendingAt;

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -123,6 +123,14 @@ private:
   // Replay protection (composed)
   ReplayCache replay;
 
+  // Single choke point for drawing a tx sequence number from replay.txSeqNum.
+  // ALL sites that need a fresh (epoch, seq) pair for a message we originate
+  // MUST go through this — it is the only place that guards against the
+  // 0xFFFF -> 0 wrap (spec §2): a reused (epoch, seq) pair after a silent
+  // wrap would reuse an AEAD nonce. On wrap, bumps + persists the boot epoch
+  // before redrawing so the new sequence starts under a fresh epoch.
+  uint16_t nextSeqGuarded();
+
 #ifdef UNIT_TEST
   ReplayCache& testReplay() { return replay; }
 #endif
@@ -233,7 +241,13 @@ public:
   void sendEnrollmentRequest() {
     // Pass proto_version + a fresh (epoch, seq) so ReplayCache can dedup relayed
     // copies of this request while still allowing the deliberate 10s retry.
-    enrollment.sendRequest(deviceMacAddress, PROTO_VERSION, replay.bootEpoch, replay.nextSeq());
+    // Draw seq via the guarded choke point FIRST (it may bump replay.bootEpoch
+    // on wrap), then read bootEpoch — reading it as a separate statement after
+    // the draw (rather than in the same call as replay.nextSeq()) avoids
+    // depending on unspecified argument evaluation order for a possibly-mutated
+    // member.
+    uint16_t seq = nextSeqGuarded();
+    enrollment.sendRequest(deviceMacAddress, PROTO_VERSION, replay.bootEpoch, seq);
   }
   bool isEnrolled() const { return enrollment.isEnrolled(); }
   void enrollPeer(const uint8_t* mac, const uint8_t* publicKey32);

--- a/main/src/mesh/MeshCrypto.h
+++ b/main/src/mesh/MeshCrypto.h
@@ -5,7 +5,6 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/ecp.h>
-#include <mbedtls/sha256.h>
 #include <esp_now.h>
 #include "src/error/Error.h"
 #include "src/error/ErrorCore.h"

--- a/main/src/mesh/MeshCrypto.h
+++ b/main/src/mesh/MeshCrypto.h
@@ -14,137 +14,16 @@ namespace lattice {
 namespace mesh {
 namespace crypto {
 
-// Derive a 16-byte LMK for a peer using ECDH + SHA256.
-// LMK = SHA256(ECDH_shared_secret || "lattice-lmk")[0:16]
-inline void derivePeerLMK(const uint8_t* ownPrivateKey32, const uint8_t* peerPublicKey32,
-                          uint8_t* lmk16Out) {
-  mbedtls_ecdh_context ecdh;
-  mbedtls_entropy_context entropy;
-  mbedtls_ctr_drbg_context ctr_drbg;
-  mbedtls_ecdh_init(&ecdh);
-  mbedtls_entropy_init(&entropy);
-  mbedtls_ctr_drbg_init(&ctr_drbg);
-
-  int ret = 0;
-
-  const char* pers = "lattice_ecdh";
-  ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
-                              reinterpret_cast<const uint8_t*>(pers), strlen(pers));
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 10,
-                        "MESH: derivePeerLMK — ctr_drbg_seed failed");
-  }
-
-  ret = mbedtls_ecdh_setup(&ecdh, MBEDTLS_ECP_DP_CURVE25519);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 11,
-                        "MESH: derivePeerLMK — ecdh_setup failed");
-  }
-
-  // Load own private key and peer public key (X coordinate only for Curve25519)
-  ret = mbedtls_mpi_read_binary(
-      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(d), ownPrivateKey32,
-      32);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 12,
-                        "MESH: derivePeerLMK — mpi_read_binary (private key) failed");
-  }
-
-  ret = mbedtls_mpi_read_binary(
-      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(X),
-      peerPublicKey32, 32);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 13,
-                        "MESH: derivePeerLMK — mpi_read_binary (peer public key) failed");
-  }
-
-  ret = mbedtls_mpi_lset(
-      &ecdh.MBEDTLS_PRIVATE(ctx).MBEDTLS_PRIVATE(mbed_ecdh).MBEDTLS_PRIVATE(Qp).MBEDTLS_PRIVATE(Z),
-      1);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 14,
-                        "MESH: derivePeerLMK — mpi_lset (Qp.Z) failed");
-  }
-
-  uint8_t sharedSecret[32] = {};
-  size_t outLen = 0;
-  ret = mbedtls_ecdh_calc_secret(&ecdh, &outLen, sharedSecret, sizeof(sharedSecret),
-                                 mbedtls_ctr_drbg_random, &ctr_drbg);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 15,
-                        "MESH: derivePeerLMK — ecdh_calc_secret failed");
-  }
-
-  mbedtls_ecdh_free(&ecdh);
-  mbedtls_ctr_drbg_free(&ctr_drbg);
-  mbedtls_entropy_free(&entropy);
-
-  // KDF: SHA256(sharedSecret || "lattice-lmk"), take first 16 bytes
-  mbedtls_sha256_context sha;
-  mbedtls_sha256_init(&sha);
-
-  ret = mbedtls_sha256_starts(&sha, 0); // 0 = SHA-256, not SHA-224
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 16,
-                        "MESH: derivePeerLMK — sha256_starts failed");
-  }
-
-  ret = mbedtls_sha256_update(&sha, sharedSecret, 32);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 17,
-                        "MESH: derivePeerLMK — sha256_update (secret) failed");
-  }
-
-  const uint8_t label[] = "lattice-lmk";
-  ret = mbedtls_sha256_update(&sha, label, sizeof(label) - 1);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 18,
-                        "MESH: derivePeerLMK — sha256_update (label) failed");
-  }
-
-  uint8_t digest[32];
-  ret = mbedtls_sha256_finish(&sha, digest);
-  if (ret != 0) {
-    lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 19,
-                        "MESH: derivePeerLMK — sha256_finish failed");
-  }
-
-  mbedtls_sha256_free(&sha);
-
-  memcpy(lmk16Out, digest, 16);
-
-  // Zero sensitive buffers after use (Fix 2)
-  memset(sharedSecret, 0, sizeof(sharedSecret));
-  memset(digest, 0, sizeof(digest));
-}
-
-inline void registerPeerWithEspNow(const uint8_t mac[6], const uint8_t* ownPrivateKey32,
-                                   const uint8_t* peerPublicKey32) {
+// Register an ESP-NOW peer WITHOUT link-layer encryption (spec §2, proto v3):
+// payload confidentiality/integrity is end-to-end (E2ECrypto.h), and unencrypted
+// slots raise the ESP-NOW peer cap from ~6 to 20. The shared PMK stays set.
+inline void registerPeerWithEspNow(const uint8_t mac[6]) {
   if (esp_now_is_peer_exist(mac))
     return;
-  uint8_t lmk[16];
-  bool hasPublicKey = false;
-  if (peerPublicKey32) {
-    // Check that public key is not all-zero (unset)
-    for (int i = 0; i < 32; ++i) {
-      if (peerPublicKey32[i] != 0x00) {
-        hasPublicKey = true;
-        break;
-      }
-    }
-  }
-  if (hasPublicKey && ownPrivateKey32) {
-    derivePeerLMK(ownPrivateKey32, peerPublicKey32, lmk);
-  } else {
-    // Peer public key not yet known (pre-enrollment) — no encryption
-    memset(lmk, 0, 16);
-  }
   esp_now_peer_info_t info = {};
   memcpy(info.peer_addr, mac, 6);
   info.channel = 0;
-  info.encrypt = hasPublicKey;
-  if (hasPublicKey)
-    memcpy(info.lmk, lmk, 16);
+  info.encrypt = false;
   lattice::err::checkEsp(esp_now_add_peer(&info), lattice::utils::ErrorType::COMMUNICATION_FAIL,
                          "registerPeerWithEspNow: add_peer failed");
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ add_executable(lattice_e2e
   e2e/scenarios/test_hotswap_e2e.cpp
   e2e/scenarios/test_pir_health_e2e.cpp
   e2e/scenarios/test_serial_robustness_e2e.cpp
+  e2e/scenarios/test_e2e_aead.cpp
   e2e/harness/NodeContext.cpp
   e2e/harness/SimNode.cpp
   e2e/harness/VirtualBus.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_unit_test(test_mesh_logic         unit/test_mesh_logic.cpp)
 add_unit_test(test_pir_adapter        unit/test_pir_adapter.cpp)
 add_unit_test(test_route_report       unit/test_route_report.cpp)
 add_unit_test(test_mocks              unit/test_mocks.cpp)
+add_unit_test(test_e2e_crypto         unit/test_e2e_crypto.cpp)
 
 # ---- E2E simulation target — SIMULATE_MODE recompiles all firmware sources ----
 add_executable(lattice_e2e

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_unit_test(test_pir_adapter        unit/test_pir_adapter.cpp)
 add_unit_test(test_route_report       unit/test_route_report.cpp)
 add_unit_test(test_mocks              unit/test_mocks.cpp)
 add_unit_test(test_e2e_crypto         unit/test_e2e_crypto.cpp)
+add_unit_test(test_e2e_keystore       unit/test_e2e_keystore.cpp)
 
 # ---- E2E simulation target — SIMULATE_MODE recompiles all firmware sources ----
 add_executable(lattice_e2e

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(lattice_e2e
   e2e/scenarios/test_pir_health_e2e.cpp
   e2e/scenarios/test_serial_robustness_e2e.cpp
   e2e/scenarios/test_e2e_aead.cpp
+  e2e/scenarios/test_seq_wrap.cpp
   e2e/harness/NodeContext.cpp
   e2e/harness/SimNode.cpp
   e2e/harness/VirtualBus.cpp

--- a/tests/e2e/harness/VirtualBus.cpp
+++ b/tests/e2e/harness/VirtualBus.cpp
@@ -36,6 +36,17 @@ size_t VirtualBus::framesInFlight() const {
   return pending_.size();
 }
 
+mesh_message* VirtualBus::lastPendingOfType(MeshMessageType type) {
+  for (auto it = pending_.rbegin(); it != pending_.rend(); ++it) {
+    if (it->data.size() != sizeof(mesh_message))
+      continue;
+    auto* msg = reinterpret_cast<mesh_message*>(it->data.data());
+    if (msg->message_type == type)
+      return msg;
+  }
+  return nullptr;
+}
+
 SimNode* VirtualBus::findByMac(const uint8_t* mac) const {
   for (SimNode* n : nodes_) {
     if (memcmp(n->mac(), mac, 6) == 0) return n;

--- a/tests/e2e/harness/VirtualBus.h
+++ b/tests/e2e/harness/VirtualBus.h
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 #include "SimNode.h"
+#include "lib/lattice-protocol/c/mesh_message.h"
+#include "lib/lattice-protocol/c/message_types.h"
 
 namespace sim {
 
@@ -23,6 +25,15 @@ public:
   // (from the PREVIOUS step) into target nodes' recv callbacks.
   void deliver();
   size_t framesInFlight() const;
+
+  // Test-only accessor (harness code, not firmware): a frame sent during step
+  // N sits in `pending_` from the moment step N's deliver() call returns until
+  // step N+1's deliver() call delivers it. This lets an e2e test inspect or
+  // tamper an in-flight, already-sealed frame in that one-step window (e.g.
+  // Task 6's E2E AEAD tamper/forgery scenarios). Returns a pointer to the raw
+  // bytes of the most recently enqueued pending frame of the given type, or
+  // nullptr if none is currently pending.
+  mesh_message* lastPendingOfType(MeshMessageType type);
 
 private:
   struct Pending {

--- a/tests/e2e/scenarios/test_e2e_aead.cpp
+++ b/tests/e2e/scenarios/test_e2e_aead.cpp
@@ -1,0 +1,100 @@
+// Task 6: E2E AEAD integration — seal on uplink (Mesh::transmitCore), open at
+// the master's local-delivery path (Mesh::processAdapterData /
+// Mesh::processRouteReport). See harness/MeshSimTest.h for the shared
+// fixture/enroll() helper this reuses verbatim.
+//
+// "On the bus" capture technique: a frame sent during simulation step N sits
+// in VirtualBus's pending queue from the moment step N's deliver() call
+// returns until step N+1's deliver() call actually delivers it (see
+// VirtualBus::lastPendingOfType's doc comment in VirtualBus.h for why). That
+// one-step window is where these scenarios inspect (Test 1) or tamper
+// (Test 2) an in-flight, already-sealed frame before it reaches the master.
+//
+// PirAdapter::loop() detects an armed motion event and sends within the SAME
+// loop() call (see PirAdapter.cpp), so a single world.step() after
+// simulatePirMotion() is enough to get the sealed frame into flight.
+#include "harness/MeshSimTest.h"
+
+TEST_F(MeshSimTest, SealedUplinkDeliversPlaintextToHub) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  enroll(sensor);
+
+  sensor->simulatePirMotion();
+  world.step(1); // sends this step; now in flight, not yet delivered
+
+  mesh_message* onWire = world.bus.lastPendingOfType(MESH_TYPE_ADAPTER_DATA);
+  ASSERT_NE(onWire, nullptr) << "sensor must have a sealed ADAPTER_DATA uplink frame in flight";
+  // PirAdapter's motion frame is data[64] = {1} (no named OP_PIR_* opcode
+  // constant exists in opcodes.h — PIR uses a bare literal). Once sealed,
+  // ChaCha20-Poly1305 ciphertext occupying data[0] must not coincide with
+  // that plaintext byte.
+  EXPECT_NE(onWire->data[0], 1)
+      << "the plaintext motion byte (data[0]==1) must not appear on the wire — "
+         "the payload must be sealed in transit";
+
+  runPolled(2000);
+
+  auto frames = hub->adapterDataFromOrigin(sensor->mac());
+  ASSERT_GE(frames.size(), 1u)
+      << "the motion frame must still reach the hub once opened by the master";
+  EXPECT_EQ(frames.back().data[0], 1)
+      << "the hub must see the ORIGINAL plaintext opcode — the master must open the "
+         "payload before local/serial delivery";
+}
+
+TEST_F(MeshSimTest, TamperedFrameIsDropped) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  enroll(sensor);
+
+  size_t before = hub->adapterDataFromOrigin(sensor->mac()).size();
+
+  sensor->simulatePirMotion();
+  world.step(1);
+
+  mesh_message* onWire = world.bus.lastPendingOfType(MESH_TYPE_ADAPTER_DATA);
+  ASSERT_NE(onWire, nullptr) << "sensor must have a sealed ADAPTER_DATA uplink frame in flight";
+  onWire->data[0] ^= 0xFF; // flip a byte of the sealed ciphertext while in flight
+
+  runPolled(2000);
+
+  EXPECT_EQ(hub->adapterDataFromOrigin(sensor->mac()).size(), before)
+      << "a frame tampered in flight must fail AEAD auth at the master and never reach the hub";
+}
+
+TEST_F(MeshSimTest, ForgedFrameWithoutValidTagIsDropped) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  enroll(sensor);
+
+  sensor->simulatePirMotion();
+  world.step(1);
+  mesh_message* onWire = world.bus.lastPendingOfType(MESH_TYPE_ADAPTER_DATA);
+  ASSERT_NE(onWire, nullptr) << "sensor must have a sealed ADAPTER_DATA uplink frame in flight";
+  // Correct header fields (origin/target MACs, proto_version, epoch, seq) —
+  // exactly what an attacker could observe/replay off the air.
+  mesh_message legit = *onWire;
+
+  runPolled(2000);
+  size_t before = hub->adapterDataFromOrigin(sensor->mac()).size();
+  ASSERT_GT(before, 0u) << "the legit frame must be delivered first (baseline for the check below)";
+
+  // Forge: same origin/target/epoch, a FRESH seq (so ReplayCache dedup can't
+  // be the reason it's dropped), garbage auth tag the attacker never derived.
+  mesh_message forged = legit;
+  forged.seq_num = static_cast<uint16_t>(legit.seq_num + 1000);
+  for (auto& b : forged.auth_tag)
+    b = 0xAA;
+
+  sim::swapIn(master->ctx());
+  simulateReceive(sensor->mac(), reinterpret_cast<const uint8_t*>(&forged), sizeof(forged));
+  sim::swapOut(master->ctx());
+  runPolled(1000);
+
+  EXPECT_EQ(hub->adapterDataFromOrigin(sensor->mac()).size(), before)
+      << "a forged frame with an invalid auth tag must be dropped, not delivered to the hub";
+}

--- a/tests/e2e/scenarios/test_e2e_aead.cpp
+++ b/tests/e2e/scenarios/test_e2e_aead.cpp
@@ -98,3 +98,55 @@ TEST_F(MeshSimTest, ForgedFrameWithoutValidTagIsDropped) {
   EXPECT_EQ(hub->adapterDataFromOrigin(sensor->mac()).size(), before)
       << "a forged frame with an invalid auth tag must be dropped, not delivered to the hub";
 }
+
+// Final-review fix: a broadcast-target (FF:FF:FF:FF:FF:FF) ADAPTER_DATA frame
+// delivered at the master over the air must NOT reach the hub. No leaf ever
+// originates a broadcast-target ADAPTER_DATA uplink — only the master's own
+// downlink broadcast (Mesh::broadcastAdapterData, which delivers locally
+// directly and never round-trips through processAdapterData) and beacons use
+// FF:FF. Because addressedToSelf is false for a broadcast target, the old code
+// skipped E2E open (needsOpen required addressedToSelf) and delivered the raw,
+// unauthenticated frame straight to the serial/hub path — an RF attacker could
+// forge arbitrary "sensor data" to the hub without ever enrolling or knowing
+// any key material. Mirrors ForgedFrameWithoutValidTagIsDropped above, but
+// targets FF:FF instead of the master's own MAC, uses a fresh seq, and plain
+// (unsealed) attacker-controlled bytes with no valid auth tag at all.
+TEST_F(MeshSimTest, ForgedBroadcastTargetFrameNeverReachesHub) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  enroll(sensor);
+
+  sensor->simulatePirMotion();
+  world.step(1);
+  mesh_message* onWire = world.bus.lastPendingOfType(MESH_TYPE_ADAPTER_DATA);
+  ASSERT_NE(onWire, nullptr) << "sensor must have a sealed ADAPTER_DATA uplink frame in flight";
+  // Correct/plausible header fields (origin MAC, proto_version, epoch) — exactly
+  // what an attacker could observe/replay off the air.
+  mesh_message legit = *onWire;
+
+  runPolled(2000);
+  size_t before = hub->received.size();
+  ASSERT_GT(hub->adapterDataFromOrigin(sensor->mac()).size(), 0u)
+      << "the legit frame must be delivered first (baseline for the check below)";
+
+  // Forge: same origin/epoch, broadcast target instead of the master's MAC, a
+  // FRESH seq (so ReplayCache dedup can't be the reason it's dropped),
+  // arbitrary attacker-chosen plaintext, and no valid auth tag whatsoever.
+  mesh_message forged = legit;
+  memset(forged.target_mac_address, 0xFF, 6);
+  forged.seq_num = static_cast<uint16_t>(legit.seq_num + 2000);
+  for (auto& b : forged.data)
+    b = 0x41; // arbitrary forged "sensor data"
+  for (auto& b : forged.auth_tag)
+    b = 0xAA;
+
+  sim::swapIn(master->ctx());
+  simulateReceive(sensor->mac(), reinterpret_cast<const uint8_t*>(&forged), sizeof(forged));
+  sim::swapOut(master->ctx());
+  runPolled(1000);
+
+  EXPECT_EQ(hub->received.size(), before)
+      << "a broadcast-target frame arriving at the master over the air must be dropped "
+         "entirely — the hub must receive nothing new from it";
+}

--- a/tests/e2e/scenarios/test_multihop_e2e.cpp
+++ b/tests/e2e/scenarios/test_multihop_e2e.cpp
@@ -70,10 +70,12 @@ TEST_F(MeshSimTest, EnrollmentRequestNotDuplicatedToHubViaRelayPath) {
 // Mesh::findNextHopToMaster() can only route through a peer that is in the
 // PeerRegistry AND fresh, but a node only ever registers the MASTER as a peer
 // (via JOIN_ACK), never its intermediate next-hop relay. PeerRegistry deliberately
-// refuses to auto-add senders ("Enrollment is the only path for new peers"), and
-// there is no pairwise key with the relay (LMK is per-peer ECDH, no shared mesh
-// key), so the leaf cannot unicast-encrypt to the relay. The leaf therefore has
-// no uplink route and Mesh::transmitCore() calls err::fail (COMM/MESH/8). Enabling
+// refuses to auto-add senders ("Enrollment is the only path for new peers"), so
+// even though the relay could now be added as an unencrypted ESP-NOW peer
+// (per-peer LMK derivation was removed in Task 8 — link-layer confidentiality
+// is no longer pairwise-key-gated), the leaf still has no PeerRegistry entry
+// for the relay to route through. The leaf therefore has no uplink route and
+// Mesh::transmitCore() calls err::fail (COMM/MESH/8). Enabling
 // this needs adjacent-hop key establishment / next-hop peer registration — a
 // separate feature, not a minimal bug fix. Assertions are preserved verbatim as
 // the spec for that future work. Re-enable (drop the DISABLED_ prefix) once the

--- a/tests/e2e/scenarios/test_replay_e2e.cpp
+++ b/tests/e2e/scenarios/test_replay_e2e.cpp
@@ -14,6 +14,7 @@
 // the master. That is precisely the tuple ReplayCache recorded on first
 // delivery, so it is the correct replay to test.
 #include "harness/MeshSimTest.h"
+#include "mesh/Mesh.h"
 #include <cstring>
 
 TEST_F(MeshSimTest, ReplayedFrameIsDropped) {
@@ -23,31 +24,50 @@ TEST_F(MeshSimTest, ReplayedFrameIsDropped) {
   enroll(sensor);
 
   sensor->simulatePirMotion();
+  // One step: PirAdapter::loop() detects the armed motion and sends. The bus's
+  // deliver() call inside this step moves the send into VirtualBus's pending
+  // queue but does NOT yet deliver it (delivery happens on the NEXT step) —
+  // this is the one-step window where the sealed, in-flight frame can be
+  // captured. See VirtualBus::lastPendingOfType's comment for why.
+  world.step(1);
+
+  // Task 6 (E2E AEAD): capture the SEALED frame exactly as it sits in flight
+  // so replaying it preserves a valid auth tag. Reconstructing from the hub's
+  // already-OPENED/plaintext copy (the old approach) would carry a stale tag
+  // bound to the original ciphertext and fail auth for an unrelated reason,
+  // making the "replay dropped" assertion below vacuous.
+  mesh_message* pendingSealed = world.bus.lastPendingOfType(MESH_TYPE_ADAPTER_DATA);
+  ASSERT_NE(pendingSealed, nullptr) << "sensor must have a sealed ADAPTER_DATA uplink frame in flight";
+  mesh_message sealed = *pendingSealed;
+
   runPolled(2000);
 
   auto legitFrames = hub->adapterDataFromOrigin(sensor->mac());
   ASSERT_GE(legitFrames.size(), 1u) << "the genuine motion frame must reach the hub first";
   size_t legit = legitFrames.size();
 
-  // Reconstruct the raw frame the master already processed (same origin/epoch/seq)
-  // and replay it directly at the master.
-  mesh_message replayed = legitFrames.back();
+  // Replay the exact sealed bytes the master already processed (same origin/epoch/seq)
+  // directly at the master.
   sim::swapIn(master->ctx());
-  simulateReceive(sensor->mac(), reinterpret_cast<const uint8_t*>(&replayed), sizeof(replayed));
+  simulateReceive(sensor->mac(), reinterpret_cast<const uint8_t*>(&sealed), sizeof(sealed));
   sim::swapOut(master->ctx());
   runPolled(2000);
 
   EXPECT_EQ(hub->adapterDataFromOrigin(sensor->mac()).size(), legit)
       << "replayed (origin,epoch,seq) must be dropped by ReplayCache, not re-forwarded";
 
-  // Positive control (guards against a vacuous pass): the SAME injection path
-  // with a fresh seq must be forwarded — proving the replay above was dropped
-  // by dedup specifically, not silently ignored for some unrelated reason.
-  mesh_message fresh = replayed;
-  fresh.seq_num = static_cast<uint16_t>(replayed.seq_num + 1);
-  sim::swapIn(master->ctx());
-  simulateReceive(sensor->mac(), reinterpret_cast<const uint8_t*>(&fresh), sizeof(fresh));
-  sim::swapOut(master->ctx());
+  // Positive control (guards against a vacuous pass): a genuinely fresh uplink
+  // (new seq, freshly sealed) from the sensor must be forwarded — proving the
+  // replay above was dropped by dedup specifically, not silently ignored for
+  // some unrelated reason (e.g. a broken AEAD open). Drives the real Mesh
+  // uplink path directly (buildMessage -> seal -> send), bypassing only
+  // PirAdapter's cooldown gate, which is an adapter-layer concern unrelated to
+  // mesh replay protection.
+  sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    uint8_t data[64] = {1};
+    mesh.transmitCore(lattice::adapter::PIR_ADAPTER, data, MESH_TYPE_ADAPTER_DATA);
+    return 0;
+  });
   runPolled(2000);
 
   EXPECT_EQ(hub->adapterDataFromOrigin(sensor->mac()).size(), legit + 1)

--- a/tests/e2e/scenarios/test_route_report_e2e.cpp
+++ b/tests/e2e/scenarios/test_route_report_e2e.cpp
@@ -47,8 +47,16 @@ TEST_F(MeshSimTest, DirectNodeRouteReportReachesHub) {
 // distance >= 2 — sendRouteReport() returns false because findNextHopToMaster()
 // is null when the next hop (the relay) is not a registered, in-range peer.
 // Same root cause as the multi-hop data-uplink gap documented in
-// docs/design-gaps/multihop-data-uplink.md. Assertions below are the intended
-// behavior; drop the DISABLED_ prefix once that gap is closed.
+// docs/design-gaps/multihop-data-uplink.md.
+//
+// Task 6 (E2E AEAD) note: even once multi-hop uplink lands, the path-chain
+// assertions below are now STALE — the payload is E2E-sealed origin->master,
+// so a relay can no longer read/append to msg.data (Mesh::processRouteReport's
+// relay branch just forwards the sealed frame unmodified). Path accumulation
+// moves to the header route_path field in a future phase (spec §4); until
+// then the hub-side expectation is path_len == 0 (empty path) regardless of
+// hop count. Assertions below are stale pre-AEAD intent, kept for history —
+// rewrite them (pathLen == 0, no relay-MAC check) before dropping DISABLED_.
 TEST_F(MeshSimTest, DISABLED_RouteReportCarriesHopChain) {
   addMaster();
   auto* relay = addSensor(MAC_NODE_A);

--- a/tests/e2e/scenarios/test_seq_wrap.cpp
+++ b/tests/e2e/scenarios/test_seq_wrap.cpp
@@ -73,3 +73,66 @@ TEST_F(MeshSimTest, SeqWrapBumpsEpochAndKeepsSealing) {
       << "the bumped epoch must be persisted to EEPROM, not just held in RAM — "
          "otherwise a reboot right after the wrap would replay the old epoch's seq range";
 }
+
+// Regression for the finding that the seq-wrap guard originally lived ONLY in
+// Mesh::buildMessage — sendEnrollmentRequest() and enrollPeer() (JOIN_ACK) draw
+// from the very same ReplayCache::txSeqNum via a raw replay.nextSeq() call, so
+// a wrap landing on either of those un-sealed paths would silently resume
+// seq 1,2,3... under the OLD (un-bumped) epoch; any later sealed buildMessage
+// frame in the same boot would then reuse an AEAD nonce already used by
+// pre-wrap traffic. Both call sites now route through the same
+// Mesh::nextSeqGuarded() choke point as buildMessage(); this proves the
+// enrollment-request path specifically.
+//
+// NOTE: the master's serial relay of an ENROLLMENT frame to the hub
+// (SerialAdapter::relayEnrollmentToServer) rebuilds a brand-new message
+// carrying only (mac, pubKey) — it does not forward the leaf's original
+// seq_num/epoch_num — so hub->enrollmentFrom() can't observe the value this
+// test cares about. Instead, inspect the raw over-the-air broadcast directly
+// via VirtualBus::lastPendingOfType(), the same technique test_replay_e2e.cpp
+// uses to capture an in-flight sealed frame before it's delivered.
+TEST_F(MeshSimTest, EnrollmentRequestSeqWrapBumpsEpoch) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+
+  // Force the very next draw from the leaf's txSeqNum to wrap: unlike the
+  // buildMessage scenario above (which needs 0xFFFE -> two draws), a single
+  // nextSeq() call against 0xFFFF wraps immediately, so the node's first
+  // periodic ENROLLMENT broadcast (not yet approved -- still unenrolled) is
+  // the one that must observe and apply the guard.
+  sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    mesh.testReplay().txSeqNum = 0xFFFF;
+    return 0;
+  });
+  uint32_t epochBefore = sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    return mesh.testReplay().bootEpoch;
+  });
+
+  ASSERT_FALSE(sensor->isEnrolled());
+
+  // Single-ms steps (mirrors main.ino's `millis() - lastEnrollmentBroadcast >
+  // 10000` gate) so we can catch the ENROLLMENT broadcast in VirtualBus's
+  // one-step in-flight window and read its seq_num before the next step
+  // delivers and clears it.
+  uint16_t sentSeq = 0;
+  bool sawRequest = false;
+  for (uint32_t t = 0; t < 10500 && !sawRequest; ++t) {
+    world.step(1);
+    if (const mesh_message* pending = world.bus.lastPendingOfType(MESH_TYPE_ENROLLMENT)) {
+      sentSeq = pending->seq_num;
+      sawRequest = true;
+    }
+  }
+  ASSERT_TRUE(sawRequest) << "enrollment request never sent within the retry window";
+  EXPECT_NE(sentSeq, 0)
+      << "the wrapped seq_num (0) must never reach the wire — sendEnrollmentRequest() "
+         "must draw through the same guarded choke point as buildMessage()";
+
+  uint32_t epochAfter = sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    return mesh.testReplay().bootEpoch;
+  });
+  EXPECT_EQ(epochAfter, epochBefore + 1)
+      << "the boot epoch must bump exactly once when the enrollment-request path "
+         "hits the seq wrap, same as the sealed buildMessage() path";
+}

--- a/tests/e2e/scenarios/test_seq_wrap.cpp
+++ b/tests/e2e/scenarios/test_seq_wrap.cpp
@@ -1,0 +1,75 @@
+// Task 7 (spec §2): a u16 seq_num wrap within a single boot must not reuse an
+// AEAD nonce (nonce = epoch_num || seq_num || origin_mac). buildMessage()
+// bumps and persists the boot epoch the instant nextSeq() wraps 0xFFFF -> 0,
+// so seq_num == 0 never actually goes on the air and every (epoch, seq) pair
+// stays unique for the life of the device.
+//
+// This scenario forces the wrap by hand (setting the leaf's in-memory
+// txSeqNum to 0xFFFE via the UNIT_TEST-only testReplay() hook — no real
+// device would send 65 thousand frames in a test's lifetime) and then drives
+// three real uplinks through the actual buildMessage()/seal/send path via
+// simulatePirMotion(). PirAdapter enforces a 3s post-trigger cooldown before
+// it re-arms (see PirAdapter.cpp), so each trigger is followed by a
+// runPolled() window comfortably longer than that before the next.
+#include "harness/MeshSimTest.h"
+#include "src/mesh/Mesh.h"
+#include "src/persistence/EepromManager.h"
+
+TEST_F(MeshSimTest, SeqWrapBumpsEpochAndKeepsSealing) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  enroll(sensor);
+
+  // Force the leaf to the brink of a seq wrap.
+  sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    mesh.testReplay().txSeqNum = 0xFFFE;
+    return 0;
+  });
+  uint32_t epochBefore = sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    return mesh.testReplay().bootEpoch;
+  });
+
+  // Three uplinks: #1 -> seq 0xFFFF (no wrap yet). #2 -> nextSeq() wraps to 0,
+  // buildMessage bumps+persists the epoch and re-draws a fresh seq (1) before
+  // the frame is sealed/sent, so seq_num==0 never reaches the wire. #3 ->
+  // seq 2, same (bumped) epoch. Net effect across all three: exactly one bump.
+  sensor->simulatePirMotion();
+  runPolled(4000); // > 3s PIR cooldown: re-arms before the next trigger
+  sensor->simulatePirMotion();
+  runPolled(4000);
+  sensor->simulatePirMotion();
+  runPolled(4000);
+
+  uint32_t epochAfter = sensor->with([](lattice::mesh::Mesh& mesh, lattice::adapter::Adapter*) {
+    return mesh.testReplay().bootEpoch;
+  });
+  EXPECT_EQ(epochAfter, epochBefore + 1)
+      << "the in-memory boot epoch must bump exactly once across the wrap";
+
+  // Post-wrap frames (#2, #3) still opened cleanly at the master — see below —
+  // which only happens if the master's ReplayCache/AEAD-open path trusts each
+  // frame's OWN epoch_num field rather than some stale/cached value, proving
+  // the leaf actually stamped the bumped epoch onto the frame before sealing.
+  auto frames = hub->adapterDataFromOrigin(sensor->mac());
+  ASSERT_GE(frames.size(), 3u) << "all three uplinks must reach the hub decrypted, "
+                                   "including the two sent after the epoch bump";
+  for (size_t i = frames.size() - 3; i < frames.size(); ++i) {
+    EXPECT_EQ(frames[i].data[0], 1)
+        << "frame " << i
+        << " must carry the original plaintext motion opcode — the master must have "
+           "opened it successfully using the frame's own (possibly bumped) epoch_num";
+  }
+
+  // The bumped epoch must be durable, not just an in-RAM field: EepromManager
+  // is a per-node singleton whose byte image lives in this leaf's NodeContext,
+  // so with() (which swaps that context in/out around fn) is what makes this
+  // read reflect the leaf's own persisted BOOT_EPOCH rather than whichever
+  // node's state happened to be live globally beforehand.
+  uint32_t persistedEpoch = sensor->with([](lattice::mesh::Mesh&, lattice::adapter::Adapter*) {
+    return lattice::utils::EepromManager::getInstance().loadBootEpoch();
+  });
+  EXPECT_EQ(persistedEpoch, epochBefore + 1)
+      << "the bumped epoch must be persisted to EEPROM, not just held in RAM — "
+         "otherwise a reboot right after the wrap would replay the old epoch's seq range";
+}

--- a/tests/unit/test_e2e_crypto.cpp
+++ b/tests/unit/test_e2e_crypto.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/MeshCrypto.h"
+#include "src/mesh/E2ECrypto.h"
+
+using namespace lattice::mesh::crypto;
+
+TEST(E2ECrypto, SharedSecretIsSymmetric) {
+  uint8_t privA[32], pubA[32], privB[32], pubB[32];
+  generateKeypair(privA, pubA);
+  generateKeypair(privB, pubB);
+  uint8_t sAB[32], sBA[32];
+  computeSharedSecret(privA, pubB, sAB);
+  computeSharedSecret(privB, pubA, sBA);
+  EXPECT_EQ(0, memcmp(sAB, sBA, 32));
+  // Sanity: secret is not all-zero
+  uint8_t zero[32] = {};
+  EXPECT_NE(0, memcmp(sAB, zero, 32));
+}
+
+TEST(E2ECrypto, DerivedKeysAreSymmetricAndDirectionSplit) {
+  uint8_t privA[32], pubA[32], privB[32], pubB[32];
+  generateKeypair(privA, pubA);
+  generateKeypair(privB, pubB);
+  uint8_t upA[32], downA[32], upB[32], downB[32];
+  deriveE2EKeys(privA, pubB, upA, downA);
+  deriveE2EKeys(privB, pubA, upB, downB);
+  EXPECT_EQ(0, memcmp(upA, upB, 32));     // both sides agree on k_up
+  EXPECT_EQ(0, memcmp(downA, downB, 32)); // and on k_down
+  EXPECT_NE(0, memcmp(upA, downA, 32));   // directions differ
+}
+
+TEST(E2ECrypto, DifferentPeersDifferentKeys) {
+  uint8_t priv[32], pub[32], privB[32], pubB[32], privC[32], pubC[32];
+  generateKeypair(priv, pub);
+  generateKeypair(privB, pubB);
+  generateKeypair(privC, pubC);
+  uint8_t upB[32], downB[32], upC[32], downC[32];
+  deriveE2EKeys(priv, pubB, upB, downB);
+  deriveE2EKeys(priv, pubC, upC, downC);
+  EXPECT_NE(0, memcmp(upB, upC, 32));
+}

--- a/tests/unit/test_e2e_crypto.cpp
+++ b/tests/unit/test_e2e_crypto.cpp
@@ -2,6 +2,8 @@
 #include <cstring>
 #include "src/mesh/MeshCrypto.h"
 #include "src/mesh/E2ECrypto.h"
+#include "lattice-protocol/c/mesh_message.h"
+#include <mbedtls/chachapoly.h>
 
 using namespace lattice::mesh::crypto;
 
@@ -39,4 +41,91 @@ TEST(E2ECrypto, DifferentPeersDifferentKeys) {
   deriveE2EKeys(priv, pubB, upB, downB);
   deriveE2EKeys(priv, pubC, upC, downC);
   EXPECT_NE(0, memcmp(upB, upC, 32));
+}
+
+// AEAD tests (6 new tests for ChaCha20-Poly1305 seal/open)
+
+static mesh_message makeMsg() {
+  mesh_message m = {};
+  m.proto_version = 3;
+  m.message_type = 0; // MESH_TYPE_ADAPTER_DATA
+  m.data_type = 1;
+  const uint8_t origin[6] = {0x02, 0, 0, 0, 0, 0x01};
+  const uint8_t target[6] = {0x02, 0, 0, 0, 0, 0xAA};
+  memcpy(m.origin_mac_address, origin, 6);
+  memcpy(m.target_mac_address, target, 6);
+  m.epoch_num = 7;
+  m.seq_num = 42;
+  for (int i = 0; i < 64; ++i) m.data[i] = static_cast<uint8_t>(i);
+  return m;
+}
+
+TEST(E2EAead, SealOpenRoundtrip) {
+  uint8_t key[32];
+  for (int i = 0; i < 32; ++i) key[i] = static_cast<uint8_t>(0xA0 + i);
+  mesh_message m = makeMsg();
+  mesh_message orig = m;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  EXPECT_NE(0, memcmp(m.data, orig.data, 64)); // actually encrypted
+  ASSERT_TRUE(lattice::mesh::crypto::openPayload(key, m));
+  EXPECT_EQ(0, memcmp(m.data, orig.data, 64));
+}
+
+TEST(E2EAead, TamperedCiphertextFailsOpen) {
+  uint8_t key[32] = {1};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.data[10] ^= 0x01;
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+TEST(E2EAead, TamperedAadFieldFailsOpen) {
+  uint8_t key[32] = {2};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.data_type = 99; // AAD-bound field
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+TEST(E2EAead, MutableFieldsNotBound) {
+  uint8_t key[32] = {3};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  m.hop_count = 5;                              // relays rewrite these
+  memset(m.last_hop_mac_address, 0xBB, 6);
+  m.route_len = 2;
+  EXPECT_TRUE(lattice::mesh::crypto::openPayload(key, m));
+}
+
+// RFC 8439 §2.8.2 known-answer vector, exercised against the same mbedtls
+// primitive sealPayload uses (spec §7: AEAD KAT). Guards against a broken or
+// misconfigured chachapoly build on either host or target toolchains.
+TEST(E2EAead, Rfc8439KnownAnswer) {
+  const uint8_t key[32] = {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a,
+                           0x8b, 0x8c, 0x8d, 0x8e, 0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95,
+                           0x96, 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f};
+  const uint8_t nonce[12] = {0x07, 0x00, 0x00, 0x00, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47};
+  const uint8_t aad[12] = {0x50, 0x51, 0x52, 0x53, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7};
+  const char* plaintext =
+      "Ladies and Gentlemen of the class of '99: If I could offer you "
+      "only one tip for the future, sunscreen would be it.";
+  const uint8_t expectedTag[16] = {0x1a, 0xe1, 0x0b, 0x59, 0x4f, 0x09, 0xe2, 0x6a,
+                                   0x7e, 0x90, 0x2e, 0xcb, 0xd0, 0x60, 0x06, 0x91};
+  uint8_t ct[114], tag[16];
+  mbedtls_chachapoly_context ctx;
+  mbedtls_chachapoly_init(&ctx);
+  ASSERT_EQ(0, mbedtls_chachapoly_setkey(&ctx, key));
+  ASSERT_EQ(0, mbedtls_chachapoly_encrypt_and_tag(
+                   &ctx, 114, nonce, aad, sizeof(aad),
+                   reinterpret_cast<const uint8_t*>(plaintext), ct, tag));
+  mbedtls_chachapoly_free(&ctx);
+  EXPECT_EQ(0, memcmp(tag, expectedTag, 16));
+  EXPECT_EQ(0xd3, ct[0]); // first ciphertext byte per RFC 8439 §2.8.2
+}
+
+TEST(E2EAead, WrongKeyFailsOpen) {
+  uint8_t key[32] = {4}, wrong[32] = {5};
+  mesh_message m = makeMsg();
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(key, m));
+  EXPECT_FALSE(lattice::mesh::crypto::openPayload(wrong, m));
 }

--- a/tests/unit/test_e2e_keystore.cpp
+++ b/tests/unit/test_e2e_keystore.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/MeshCrypto.h"
+#include "src/mesh/E2EKeyStore.h"
+
+using namespace lattice::mesh;
+
+TEST(E2EKeyStore, DerivesAndCaches) {
+  uint8_t priv[32], pub[32], peerPriv[32], peerPub[32];
+  crypto::generateKeypair(priv, pub);
+  crypto::generateKeypair(peerPriv, peerPub);
+  const uint8_t mac[6] = {2, 0, 0, 0, 0, 1};
+  E2EKeyStore store;
+  const uint8_t *up1, *down1, *up2, *down2;
+  ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up1, &down1));
+  ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up2, &down2));
+  EXPECT_EQ(up1, up2); // cache hit: same storage, no re-derivation
+  EXPECT_EQ(0, memcmp(down1, down2, 32));
+}
+
+TEST(E2EKeyStore, RejectsZeroPubkey) {
+  uint8_t priv[32], pub[32];
+  crypto::generateKeypair(priv, pub);
+  const uint8_t mac[6] = {2, 0, 0, 0, 0, 2};
+  uint8_t zeroPub[32] = {};
+  E2EKeyStore store;
+  const uint8_t *up, *down;
+  EXPECT_FALSE(store.getKeys(mac, priv, zeroPub, &up, &down));
+  EXPECT_FALSE(store.getKeys(mac, priv, nullptr, &up, &down));
+}
+
+TEST(E2EKeyStore, OverwritesWhenFullAndClearWorks) {
+  uint8_t priv[32], pub[32], peerPriv[32], peerPub[32];
+  crypto::generateKeypair(priv, pub);
+  crypto::generateKeypair(peerPriv, peerPub);
+  E2EKeyStore store;
+  const uint8_t *up, *down;
+  // Fill beyond capacity — must not crash, oldest entries overwritten
+  for (int i = 0; i < static_cast<int>(lattice::config::LATTICE_E2E_KEYCACHE_MAX) + 3; ++i) {
+    uint8_t mac[6] = {2, 0, 0, 0, 0, static_cast<uint8_t>(i)};
+    ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up, &down));
+  }
+  store.clear();
+  const uint8_t mac0[6] = {2, 0, 0, 0, 0, 0};
+  ASSERT_TRUE(store.getKeys(mac0, priv, peerPub, &up, &down)); // re-derives after clear
+}

--- a/tests/unit/test_e2e_keystore.cpp
+++ b/tests/unit/test_e2e_keystore.cpp
@@ -35,12 +35,35 @@ TEST(E2EKeyStore, OverwritesWhenFullAndClearWorks) {
   crypto::generateKeypair(peerPriv, peerPub);
   E2EKeyStore store;
   const uint8_t *up, *down;
+
   // Fill beyond capacity — must not crash, oldest entries overwritten
   for (int i = 0; i < static_cast<int>(lattice::config::LATTICE_E2E_KEYCACHE_MAX) + 3; ++i) {
     uint8_t mac[6] = {2, 0, 0, 0, 0, static_cast<uint8_t>(i)};
     ASSERT_TRUE(store.getKeys(mac, priv, peerPub, &up, &down));
   }
+
+  // Before clear: pick the last inserted mac (still resident), assert cache hit
+  const int lastIdx = lattice::config::LATTICE_E2E_KEYCACHE_MAX + 2;
+  const uint8_t lastMac[6] = {2, 0, 0, 0, 0, static_cast<uint8_t>(lastIdx)};
+  const uint8_t *upBefore, *downBefore;
+  ASSERT_TRUE(store.getKeys(lastMac, priv, peerPub, &upBefore, &downBefore)); // cache hit
+
+  // Capture kUp pointer bytes to verify cache effect
+  uint8_t kUpCached[32];
+  memcpy(kUpCached, upBefore, 32);
+
+  // Clear the cache
   store.clear();
+
+  // After clear: immediately test with nullptr pubkey — should fail (cache is empty)
+  const uint8_t *upNull, *downNull;
+  ASSERT_FALSE(store.getKeys(lastMac, priv, nullptr, &upNull, &downNull));
+
+  // Now re-derive: same mac with pubkey should succeed (refills cache after clear)
+  const uint8_t *upAfter, *downAfter;
+  ASSERT_TRUE(store.getKeys(lastMac, priv, peerPub, &upAfter, &downAfter)); // re-derives
+
+  // Keep existing assertion: verify we can still add fresh entries after clear
   const uint8_t mac0[6] = {2, 0, 0, 0, 0, 0};
   ASSERT_TRUE(store.getKeys(mac0, priv, peerPub, &up, &down)); // re-derives after clear
 }

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -647,8 +647,10 @@ TEST_F(JoinAckRelayTest, JoinAckAddressedToSelf_RegistersMasterAsRoutablePeer) {
   Mesh mesh = makeIntermediateNode();
   ASSERT_EQ(mesh.peers.find(kMasterMac), nullptr) << "precondition: master not yet a peer";
 
-  // Real Curve25519 keypairs: registration derives an ESP-NOW LMK via ECDH,
-  // which rejects a zeroed private key / arbitrary public-key bytes.
+  // Real Curve25519 keypairs: ESP-NOW peer registration no longer derives a
+  // per-peer LMK (Task 8 — link layer is unencrypted; E2E AEAD is the security
+  // boundary), but the stored public key still feeds E2E key derivation
+  // elsewhere, so keep using real (non-zeroed) keys here.
   uint8_t nodePriv[32], nodePub[32], masterPriv[32], masterKey[32];
   lattice::mesh::crypto::generateKeypair(nodePriv, nodePub);
   lattice::mesh::crypto::generateKeypair(masterPriv, masterKey);

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include "mesh/Mesh.h"
 #include "mesh/MeshCrypto.h"
+#include "mesh/E2ECrypto.h"
 #include "esp_now_mock.h"
 #include "time_mock.h"
 #include "EEPROM.h"
@@ -384,11 +385,30 @@ TEST_F(AdapterDataRelayTest, Master_DoesNotRelayUplink_DeliversLocally) {
   Mesh mesh = makeIntermediateNode();
   mesh.isMaster = true;
 
+  // Task 6 (E2E AEAD): the master now opens sealed ADAPTER_DATA before local
+  // delivery, so the test frame must be genuinely sealed with keys the master
+  // can actually derive (peerE2EKeys uses the master's own priv + the
+  // registered origin peer's pubkey; ECDH is symmetric, so sealing with the
+  // sensor's priv + the master's pubkey yields the same k_up).
+  uint8_t masterPriv[32], masterPub[32], sensorPriv[32], sensorPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(sensorPriv, sensorPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo sensorPeer{};
+  memcpy(sensorPeer.mac, kSensorMac, 6);
+  memcpy(sensorPeer.publicKey, sensorPub, 32);
+  sensorPeer.lastSeenMillis = 0;
+  mesh.peers.append(sensorPeer);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(sensorPriv, masterPub, kUp, kDown);
+
   bool callbackFired = false;
   mesh.linkDataRecvCallback([&](const mesh_message&) { callbackFired = true; });
 
   auto msg = makeUplinkMsg(1, 1);
   memcpy(msg.target_mac_address, mesh.deviceMacAddress, 6); // addressed to self (master)
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg)); // seal after target is final
 
   size_t before = espNowSentPackets.size();
   mesh.processAdapterData(msg);
@@ -804,6 +824,22 @@ TEST_F(DrainRecvQueueTest, DropsReplayedAdapterData) {
   Mesh mesh;
   memcpy(mesh.deviceMacAddress, kMyMac, 6);
   mesh.isMaster = true; // master: delivers locally, no relay — clean baseline
+
+  // Task 6 (E2E AEAD): master opens sealed ADAPTER_DATA before dispatch, so
+  // this frame must be sealed with keys the master can actually derive.
+  uint8_t masterPriv[32], masterPub[32], originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo origin{};
+  memcpy(origin.mac, kOriginMac, 6);
+  memcpy(origin.publicKey, originPub, 32);
+  origin.lastSeenMillis = 0;
+  mesh.peers.append(origin);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
+
   int deliveredCount = 0;
   mesh.linkDataRecvCallback([&](const mesh_message&) { ++deliveredCount; });
 
@@ -815,6 +851,7 @@ TEST_F(DrainRecvQueueTest, DropsReplayedAdapterData) {
   memcpy(msg.target_mac_address, kMyMac, 6);
   msg.epoch_num = 1;
   msg.seq_num = 42;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
 
   injectAndDrain(mesh, msg); // first: not replay — delivered
   EXPECT_EQ(deliveredCount, 1);

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -862,6 +862,46 @@ TEST_F(DrainRecvQueueTest, DropsReplayedAdapterData) {
   EXPECT_EQ(deliveredCount, 1); // callback not invoked again
 }
 
+// Final-review fix: proto_version == 0 must not bypass the flag-day version
+// drop, and (since the replay gate is keyed on proto_version == PROTO_VERSION)
+// must also not bypass replay dedup. Everything else about this frame is
+// otherwise valid (properly sealed, addressed to self, fresh epoch/seq) so the
+// only reason it can be rejected is the version check itself.
+TEST_F(DrainRecvQueueTest, DropsProtoVersionZeroAdapterData) {
+  Mesh mesh;
+  memcpy(mesh.deviceMacAddress, kMyMac, 6);
+  mesh.isMaster = true;
+
+  uint8_t masterPriv[32], masterPub[32], originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo origin{};
+  memcpy(origin.mac, kOriginMac, 6);
+  memcpy(origin.publicKey, originPub, 32);
+  origin.lastSeenMillis = 0;
+  mesh.peers.append(origin);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
+
+  int deliveredCount = 0;
+  mesh.linkDataRecvCallback([&](const mesh_message&) { ++deliveredCount; });
+
+  mesh_message msg{};
+  msg.proto_version = 0; // forged/malformed — must be dropped, not delivered
+  msg.message_type = MESH_TYPE_ADAPTER_DATA;
+  msg.data_type = adapter_types::PIR_ADAPTER;
+  memcpy(msg.origin_mac_address, kOriginMac, 6);
+  memcpy(msg.target_mac_address, kMyMac, 6);
+  msg.epoch_num = 1;
+  msg.seq_num = 99;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
+
+  injectAndDrain(mesh, msg);
+  EXPECT_EQ(deliveredCount, 0); // dropped by the version check, never reaches dispatch
+}
+
 // Task 9c R1: an enrollment request seen twice within one drain window (e.g. the
 // direct broadcast plus a neighbour's relayed copy, same origin/epoch/seq) must
 // be forwarded to the server only once — the master enqueues one pending relay.

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -808,7 +808,7 @@ TEST_F(DrainRecvQueueTest, DropsReplayedAdapterData) {
   mesh.linkDataRecvCallback([&](const mesh_message&) { ++deliveredCount; });
 
   mesh_message msg{};
-  msg.proto_version = 2;
+  msg.proto_version = PROTO_VERSION;
   msg.message_type = MESH_TYPE_ADAPTER_DATA;
   msg.data_type = adapter_types::PIR_ADAPTER;
   memcpy(msg.origin_mac_address, kOriginMac, 6);

--- a/tests/unit/test_route_report.cpp
+++ b/tests/unit/test_route_report.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include "mesh/Mesh.h"
+#include "mesh/MeshCrypto.h"
+#include "mesh/E2ECrypto.h"
 #include "esp_now_mock.h"
 #include "time_mock.h"
 #include "EEPROM.h"
@@ -13,9 +15,18 @@ protected:
     EEPROM.reset();
     resetMillis();
     resetEspNowMock();
+    // Task 6 (E2E AEAD): self-originated ADAPTER_DATA/ROUTE_REPORT uplinks are
+    // now sealed in transmitCore(), which requires a real (non-zero) master
+    // pubkey to derive a key with — generate real Curve25519 keypairs once per
+    // test so setupRelayNode() below can register a properly keyed master peer.
+    lattice::mesh::crypto::generateKeypair(myPriv, myPub);
+    lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
   }
 
-  // Set up mesh as non-master with a reachable master peer
+  uint8_t myPriv[32], myPub[32];
+  uint8_t masterPriv[32], masterPub[32];
+
+  // Set up mesh as non-master with a reachable, E2E-keyed master peer.
   void setupRelayNode(Mesh& mesh, const uint8_t masterMac[6]) {
     static const uint8_t myMac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01};
     memcpy(mesh.deviceMacAddress, myMac, 6);
@@ -25,10 +36,14 @@ protected:
     memcpy(mesh.currentMaster.mac, masterMac, 6);
     mesh.currentMaster.distance = 1;
     memcpy(mesh.currentMaster.nextHop, masterMac, 6);
+    memcpy(mesh.enrollment.devicePrivateKey, myPriv, 32);
+    memcpy(mesh.enrollment.devicePublicKey, myPub, 32);
 
-    // Register master as a live peer so findNextHopToMaster() returns it
+    // Register master as a live, keyed peer so findNextHopToMaster() AND E2E
+    // sealing (Mesh::masterE2EKeys) both succeed.
     PeerInfo peer{};
     memcpy(peer.mac, masterMac, 6);
+    memcpy(peer.publicKey, masterPub, 32);
     peer.lastSeenMillis = millis();
     mesh.peers.append(peer);
   }
@@ -39,6 +54,15 @@ protected:
       return {};
     }
     return *reinterpret_cast<const mesh_message*>(espNowSentPackets.back().data.data());
+  }
+
+  // The k_up this node uses to seal uplinks to the master set up by
+  // setupRelayNode() — ECDH is symmetric, so deriving from our own priv + the
+  // master's pubkey matches what the master derives from its priv + our pubkey
+  // (mirrors Mesh::masterE2EKeys).
+  void deriveUpKey(uint8_t kUpOut[32]) {
+    uint8_t kDown[32];
+    lattice::mesh::crypto::deriveE2EKeys(myPriv, masterPub, kUpOut, kDown);
   }
 };
 
@@ -62,7 +86,14 @@ TEST_F(RouteReportTest, SendRouteReport_PayloadStructure) {
 
   mesh.sendRouteReport();
 
+  // The wire payload is now E2E-sealed (Task 6) — open it with the same k_up
+  // the master would derive before asserting on its plaintext structure.
   mesh_message sent = lastSentMsg();
+  uint8_t kUp[32];
+  deriveUpKey(kUp);
+  ASSERT_TRUE(lattice::mesh::crypto::openPayload(kUp, sent))
+      << "sent frame must open with the k_up derived the same way the master would";
+
   EXPECT_EQ(sent.data[0], OP_ROUTE_REPORT);  // 0xB3
   EXPECT_EQ(sent.data[1], 0);                // path_len = 0 on origin
   // data[2..63] should be zeroed
@@ -83,7 +114,14 @@ TEST_F(RouteReportTest, SendRouteReport_NotSentByMaster) {
   EXPECT_EQ(espNowSentPackets.size(), before);
 }
 
-TEST_F(RouteReportTest, ProcessRouteReport_RelayAppendsMAC) {
+// Task 6 (spec §4): the payload is E2E-sealed end-to-end (origin -> master),
+// so an intermediate relay can no longer read or mutate it — path
+// accumulation via msg.data is removed (it moves to the header route_path
+// field in a future phase). A relay now forwards the sealed frame
+// byte-for-byte, only updating routing metadata (hop_count/last_hop).
+// Replaces the old ProcessRouteReport_RelayAppendsMAC, which asserted the
+// pre-AEAD path-accumulation behavior this task intentionally removes.
+TEST_F(RouteReportTest, ProcessRouteReport_RelayForwardsSealedFrameUnmodified) {
   const uint8_t masterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
   const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   const uint8_t myMac[6]     = {0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01};
@@ -91,17 +129,17 @@ TEST_F(RouteReportTest, ProcessRouteReport_RelayAppendsMAC) {
   setupRelayNode(mesh, masterMac);
   memcpy(mesh.deviceMacAddress, myMac, 6); // set after setupRelayNode (which overwrites it)
 
-  // Build a route report with path_len=1 (one relay MAC already written)
+  // Foreign origin (not this relay) standing in for an already-sealed frame —
+  // a relay never re-seals, only forwards. The bytes are opaque on purpose:
+  // a relay must not need to interpret them.
   mesh_message msg{};
   msg.proto_version = PROTO_VERSION;
   msg.message_type = MESH_TYPE_ROUTE_REPORT;
   msg.data_type = 0;
   msg.hop_count = 1;
   memcpy(msg.origin_mac_address, originMac, 6);
-  msg.data[0] = OP_ROUTE_REPORT;
-  msg.data[1] = 1; // one relay already written
-  // data[2..7] = some relay MAC
-  memset(&msg.data[2], 0xAB, 6);
+  for (int i = 0; i < 64; ++i)
+    msg.data[i] = static_cast<uint8_t>(0xC0 + i);
 
   size_t before = espNowSentPackets.size();
   mesh.processRouteReport(msg);
@@ -109,16 +147,31 @@ TEST_F(RouteReportTest, ProcessRouteReport_RelayAppendsMAC) {
   ASSERT_EQ(espNowSentPackets.size(), before + 1);
   mesh_message sent = lastSentMsg();
   EXPECT_EQ(sent.message_type, MESH_TYPE_ROUTE_REPORT);
-  EXPECT_EQ(sent.data[1], 2); // path_len incremented to 2
-
-  // Our device MAC should be at data[8..13] (index 1 = second relay slot)
-  EXPECT_EQ(memcmp(&sent.data[8], myMac, 6), 0);
+  EXPECT_EQ(memcmp(sent.data, msg.data, sizeof(sent.data)), 0)
+      << "relay must forward the sealed payload byte-for-byte, unmodified (spec §4)";
+  EXPECT_EQ(memcmp(sent.last_hop_mac_address, myMac, 6), 0);
   EXPECT_EQ(sent.hop_count, 2);
 }
 
 TEST_F(RouteReportTest, ProcessRouteReport_MasterDeliversToCallback) {
+  const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   Mesh mesh;
   mesh.isMaster = true;
+
+  // Task 6 (E2E AEAD): master opens the sealed payload before delivering to
+  // the callback — register the origin as a keyed peer and seal accordingly.
+  uint8_t originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo origin{};
+  memcpy(origin.mac, originMac, 6);
+  memcpy(origin.publicKey, originPub, 32);
+  origin.lastSeenMillis = 0;
+  mesh.peers.append(origin);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
 
   bool callbackFired = false;
   mesh_message received{};
@@ -130,8 +183,10 @@ TEST_F(RouteReportTest, ProcessRouteReport_MasterDeliversToCallback) {
   mesh_message msg{};
   msg.proto_version = PROTO_VERSION;
   msg.message_type = MESH_TYPE_ROUTE_REPORT;
+  memcpy(msg.origin_mac_address, originMac, 6);
   msg.data[0] = OP_ROUTE_REPORT;
   msg.data[1] = 1;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
 
   mesh.processRouteReport(msg);
 
@@ -139,38 +194,65 @@ TEST_F(RouteReportTest, ProcessRouteReport_MasterDeliversToCallback) {
   EXPECT_EQ(received.data[0], OP_ROUTE_REPORT);
 }
 
-TEST_F(RouteReportTest, ProcessRouteReport_PathFullDropsMessage) {
+// Replaces the old ProcessRouteReport_PathFullDropsMessage: the path-length
+// guard was part of the relay-side path-accumulation feature this task
+// removes (spec §4 — a relay can no longer read msg.data at all). The
+// remaining relay-side guard is the pre-existing hop-count limit.
+TEST_F(RouteReportTest, ProcessRouteReport_HopLimitDropsMessage) {
   const uint8_t masterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   Mesh mesh;
   setupRelayNode(mesh, masterMac);
 
   mesh_message msg{};
   msg.proto_version = PROTO_VERSION;
   msg.message_type = MESH_TYPE_ROUTE_REPORT;
-  msg.data[0] = OP_ROUTE_REPORT;
-  msg.data[1] = 10; // path full — max 10 relay MACs
+  msg.hop_count = lattice::config::MAX_HOPS; // at limit — relay must not forward further
+  memcpy(msg.origin_mac_address, originMac, 6);
+  for (int i = 0; i < 64; ++i) // opaque payload — relay never reads it
+    msg.data[i] = 0xAB;
 
   size_t before = espNowSentPackets.size();
   mesh.processRouteReport(msg);
 
-  EXPECT_EQ(espNowSentPackets.size(), before); // no message sent
+  EXPECT_EQ(espNowSentPackets.size(), before); // no message sent — hop limit reached
 }
 
-TEST_F(RouteReportTest, ProcessRouteReport_MalformedOpcodeDropsMessage) {
-  const uint8_t masterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+// Replaces the old ProcessRouteReport_MalformedOpcodeDropsMessage: opcode
+// validation is no longer possible at a relay (payload is ciphertext to it).
+// It now happens only at the master, after a successful AEAD open.
+TEST_F(RouteReportTest, ProcessRouteReport_MasterDropsOnBadOpcodeAfterOpen) {
+  const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   Mesh mesh;
-  setupRelayNode(mesh, masterMac);
+  mesh.isMaster = true;
+
+  uint8_t originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo origin{};
+  memcpy(origin.mac, originMac, 6);
+  memcpy(origin.publicKey, originPub, 32);
+  origin.lastSeenMillis = 0;
+  mesh.peers.append(origin);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
+
+  bool callbackFired = false;
+  mesh.linkDataRecvCallback([&](const mesh_message&) { callbackFired = true; });
 
   mesh_message msg{};
   msg.proto_version = PROTO_VERSION;
   msg.message_type = MESH_TYPE_ROUTE_REPORT;
-  msg.data[0] = 0xFF; // wrong opcode
-  msg.data[1] = 0;
+  memcpy(msg.origin_mac_address, originMac, 6);
+  msg.data[0] = 0xFF; // wrong opcode (plaintext) — sealed correctly, auth succeeds
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
 
-  size_t before = espNowSentPackets.size();
   mesh.processRouteReport(msg);
 
-  EXPECT_EQ(espNowSentPackets.size(), before); // no message sent
+  EXPECT_FALSE(callbackFired)
+      << "master must drop a validly-sealed frame carrying an unexpected opcode";
 }
 
 TEST_F(RouteReportTest, DrainRecvQueue_DispatchesRouteReport) {


### PR DESCRIPTION
## What

Phase 1 of the multi-hop routing + E2E crypto design. Establishes the keying and wire-format groundwork; closes no design gap on its own (gap #7/#8 close in Phase 2/4) but is the foundation for them.

- **Protocol v3** submodule bump; `PROTO_VERSION = 3`, flag day (drops `proto_version != 3`).
- **E2E AEAD**: self-originated uplink (`ADAPTER_DATA`, `ROUTE_REPORT`) sealed with ChaCha20-Poly1305; the master opens before delivering to the hub. Relays forward ciphertext they cannot read.
- **Keys**: HKDF-SHA256 over the existing Curve25519 ECDH secret → direction-split `k_up`/`k_down`; cached per peer (`E2EKeyStore`).
- **Nonce**: `epoch(4) ‖ seq(2) ‖ origin_mac(6)`; seq-wrap bumps + persists the boot epoch (all seq draws centralized through one guard) to prevent AEAD nonce reuse.
- **AAD** binds every immutable header field (version, type, data_type, origin, target, epoch, seq); mutable routing fields excluded so relays can rewrite them.
- **LMK removal**: per-peer ESP-NOW link encryption dropped — E2E AEAD is now the security boundary; ESP-NOW peers are unencrypted (raises the peer cap ~6→20). PMK retained.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md`
- Plan: `docs/superpowers/plans/2026-07-16-phase1-proto-v3-e2e-aead.md`

## Depends on — MERGE ORDER

Requires **lattice-protocol PR superbrobenji/lattice-protocol#25** to merge **and be cut as a new release/tag** first. Before merging this PR, the submodule must be re-pointed from the branch SHA to that released tag, then the suite re-run. Do not merge against the floating branch SHA.

## Security notes

- Whole-branch review closed a broadcast-target auth-bypass (forged `FF:FF` `ADAPTER_DATA` reaching the hub unauthenticated) and a `proto_version==0` version/replay-check bypass. Both fixed with regression tests.
- **Known, spec-accepted window until Phase 3**: downlink commands (`CONFIG_SET`) are plaintext and authenticated by sender-MAC only; unicast is now unencrypted, so an RF attacker can spoof a downlink command (integrity-class). Downlink sealing closes this in Phase 3.

## Test

145 → 147 tests pass (2 disabled = multi-hop chain + route-report chain, both need Phase 2 routing). Clean-from-scratch build verified.

The 2 `DISABLED_` tests remain the executable specs for gaps #7/#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)