### PR TITLE
feat: Phase 3 — downlink source routing + k_down sealing (closes command-injection window)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-phase3-downlink-source-routing.md
+++ b/docs/superpowers/plans/2026-07-21-phase3-downlink-source-routing.md
@@ -1,0 +1,737 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Phase 3: Downlink Source Routing + k_down Sealing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The master delivers commands to a multi-hop node by source-routing a sealed downlink frame along the reversed path it learned from that node's route reports; relays forward statelessly; downlink payloads are E2E-sealed with `k_down`, closing the Phase-1 command-injection window.
+
+**Architecture:** Route reports accumulate the relay chain in the plaintext `route_path[]` header field (relays append their own MAC in flight — legal because `route_path`/`route_len` are excluded from the AEAD AAD). The master records each node's path in a RAM `RouteTable` (node MAC → path). To send a downlink, the master reverses that path into `route_path[]`, sets `target_mac_address` to the destination, seals the payload with the destination's `k_down`, and unicasts to the first hop; each relay finds its own MAC in `route_path[]` and forwards to the next index (or to `target_mac` when it is the last relay). If no route is known, it falls back to the existing broadcast flood (still sealed). The destination node opens the payload with its `k_down`.
+
+**Tech Stack:** C++ (ESP32 firmware, host-tested), GoogleTest + `tests/e2e` sim harness. `main/lib/lattice-protocol` submodule at v0.4.0 (proto v3, unchanged — `route_len`/`route_path[60]`/`auth_tag[16]` already exist).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md` §1 (wire format), §2 (keying, direction-split), §4 (downlink source routing).
+- **`route_path` orientation (uplink accumulation):** a route report leaves the origin with `route_len = 0`. Each relay appends its own 6-byte MAC at `route_path[route_len*6 .. +6)` and increments `route_len`, BEFORE forwarding onward. The master therefore receives the relay chain in **origin-to-master forward order**: `[R_nearest_origin, …, R_nearest_master]`.
+- **`route_path` orientation (downlink):** the master sends with `route_path[]` = the **reversed** learned path (`[R_nearest_master, …, R_nearest_origin]`) and `target_mac_address` = the destination node. A relay finds its own MAC at index `i` in `route_path[0..route_len)`; it forwards to `route_path[i+1]` if `i+1 < route_len`, else to `target_mac_address`. Relays hold **zero** routing state.
+- **Bounds (parse-safety, every access):** `route_len <= MAX_HOPS` (10); reject/drop any frame with `route_len > MAX_HOPS`. Never index `route_path` beyond `route_len*6`; `route_path` is 60 bytes = 10 × 6, exactly `MAX_HOPS` MACs. Same defect class as the OOB ack-buffer fix (PR #31) — treat every `route_len`/index as attacker-controlled and bounds-check before use.
+- **AAD exclusion:** `route_len`, `route_path`, `hop_count`, `last_hop_mac_address`, `auth_tag` are NOT in the AEAD AAD (verified: `E2ECrypto.h buildAad` binds only proto_version, message_type, data_type, origin, target, epoch, seq). Relays may rewrite `route_path`/`hop_count`/`last_hop` without breaking the tag. **`target_mac_address` IS AAD-bound** — the master sets it to the destination before sealing and no relay may change it.
+- **Keying (spec §2):** downlink is sealed with `k_down`, derived per `(node, master)` pair. The master seals with the **destination node's** `k_down` (`peerE2EKeys(destMac)` → use `kDown`); the destination opens with its own `k_down` (`masterE2EKeys()` → use `kDown`). Both sides derive the same `k_down` from the same ECDH secret. Uplink continues to use `k_up` (unchanged).
+- **Downlink nonce:** `epoch(4) || seq(2) || origin_mac(6)` with origin = the master's MAC and the master's own `nextSeqGuarded()`/`bootEpoch`. Unique per master message; reusing the same nonce across different destinations is safe because each destination uses a different `k_down` key.
+- **What is sealed:** master-originated `MESH_TYPE_ADAPTER_DATA` addressed to a specific node (`target_mac_address != FF:FF:FF:FF:FF:FF`). Broadcast frames (beacons, enrollment, JOIN_ACK, any `FF:FF` adapter data) stay plaintext as today.
+- **Fallback preserved:** if the master has no route-table entry for the destination, it still seals the payload but delivers via the existing broadcast flood (`broadcastToAllPeers`/`relayDownlink`) with `target_mac = destination` (not `FF:FF`). Only the destination opens it. This is the enrollment-time / unknown-route fallback (spec §4).
+- **`LATTICE_ROUTE_TABLE_MAX`** (new, `lattice::config`, default **32**) bounds the master route table; **`LATTICE_NEIGHBOR_MAX`** = 8, **`MAX_HOPS`** = 10 (existing).
+- PeerRegistry enrollment-only rule and the NeighborTable (Phase 2) are unchanged.
+- All firmware test hooks `#ifdef UNIT_TEST`-gated.
+- **clang-format 18** (CI `lint-format` checks `main/src` only — not `tests/`). Install once `python3 -m pip install 'clang-format==18.1.8'`; before each commit: `CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")` then `"$CF" --style=file --dry-run --Werror <changed main/src files>`. Only reformat lines you changed. The local `ctest` loop does NOT run clang-format.
+- **CodeQL:** function params take `const uint8_t*`, never `const uint8_t mac[6]` (alert #300 class); bounds-check every buffer index (alert class from PR #31).
+- Verification loop: `cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release` (once), then `cmake --build tests/build --parallel` and `ctest --test-dir tests/build --output-on-failure`. Baseline is **159 pass / 1 disabled** (`RouteReportCarriesHopChain`, which this phase enables). No device build in CI.
+
+## Current-state facts (verified on this branch, post-Phase-2)
+
+- `mesh_message` (v3): `route_len` (u8), `route_path[60]`, `auth_tag[16]` present; unused today. `buildMessage` (`Mesh.cpp:141-159`) does `mesh_message msg = {}` — zero-inits `route_len`/`route_path`.
+- `sendRouteReport()` (`Mesh.cpp:913-921`): non-master, requires a route to master, sends `data[0]=OP_ROUTE_REPORT, data[1]=0`, `MESH_TYPE_ROUTE_REPORT`. Does NOT touch `route_path`.
+- `processRouteReport()` (`Mesh.cpp:923-961`): master branch opens with `peerE2EKeys(origin).kUp`, checks `data[0]==OP_ROUTE_REPORT`, delivers to `externalRecvCallback`. Relay branch bumps `hop_count`/`last_hop`, forwards sealed `data` unmodified via `transmitCore(..., &relay)`. Neither branch touches `route_path`.
+- `relayDownlink()` (`Mesh.cpp:758-769`): floods to enrolled `peers.peerMacs[]` (not NeighborTable), bumps hop_count/last_hop.
+- `broadcastAdapterData()` (`Mesh.cpp:529-536`): `buildMessage`, `memset(target,0xFF,6)`, `broadcastToAllPeers`, optional local deliver. Static entry `broadcastAdapterDataStatic` is the master's serial→mesh downlink path (`SerialAdapter.cpp:279,356`).
+- `processAdapterData()` (`Mesh.cpp:684-756`): computes `addressedToSelf`/`isBroadcastTarget`/`addressedToMaster` from `target_mac_address`. Master opens uplink (`k_up`) on self-addressed sealed frames (Phase 1); the Phase-1 CRITICAL guard drops sealed-type frames at the master not addressed to self. **Nodes do NOT currently open anything** (downlink is plaintext today).
+- `Adapter::onMeshData` (`Adapter.cpp:41-72`): for `data_type==SERIAL_ADAPTER` && `data[0]==OP_CONFIG_SET`, reads `data[1..6]` as target MAC (or `FF:FF` broadcast), compares to own MAC, restarts with new adapter type. **Keep this**: the master seals the full 64-byte `data` (including the `data[1..6]` target bytes), the node opens then runs this existing check unchanged.
+- `masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown)` / `peerE2EKeys(const uint8_t* originMac, const uint8_t** kUp, const uint8_t** kDown)` (`Mesh.cpp:340-365`) — both return the pair; Phase 1 used only `kUp`. This phase uses `kDown`.
+- `crypto::sealPayload(const uint8_t* key32, mesh_message&)` / `openPayload(...)` (`E2ECrypto.h`) — seal/open `data` in place using `auth_tag`.
+- `currentMaster.nextHop` (`MasterInfo`, `PeerRegistry.h:21-25`): write-only/dead post-Phase-2 (writes at `Mesh.cpp:31,567,645`; no readers). `MAX_ROUTE_PATH_LEN` (`project_config.h:124`): stale, zero usages.
+- Disabled test `RouteReportCarriesHopChain` (`tests/e2e/scenarios/test_route_report_e2e.cpp:60-83`): asserts the OLD in-payload encoding (`m.data[1]`=pathLen, `m.data[2..]`=MAC). Its own comment says to REWRITE for the header-field design before enabling. This phase rewrites its assertions to read `route_len`/`route_path` (the payload is sealed and opaque on the wire).
+
+## File Structure
+
+- **Create** `main/src/mesh/RouteTable.h` — master-side RAM route table (node MAC → path), header-only, non-copyable, bounded + evicting (mirrors `NeighborTable.h`/`E2EKeyStore.h`).
+- **Create** `tests/unit/test_route_table.cpp` — RouteTable unit tests.
+- **Modify** `main/project_config.h` — add `LATTICE_ROUTE_TABLE_MAX`; delete stale `MAX_ROUTE_PATH_LEN`.
+- **Modify** `main/src/mesh/PeerRegistry.h` — remove dead `MasterInfo::nextHop`.
+- **Modify** `main/src/mesh/Mesh.h` / `Mesh.cpp` — route_path accumulation in route-report relay; RouteTable member + recording; source-routed sealed downlink send + stateless relay forwarding; node-side `k_down` open; remove `currentMaster.nextHop` writes.
+- **Modify** `main/src/adapter/serial/SerialAdapter.cpp` — master's CONFIG_SET/command downlink uses the new targeted-downlink API.
+- **Modify** `tests/CMakeLists.txt` — register `test_route_table`.
+- **Modify** `tests/e2e/scenarios/test_route_report_e2e.cpp` — rewrite + enable `RouteReportCarriesHopChain`.
+- **Modify** `tests/unit/test_mesh_logic.cpp`, `tests/unit/test_route_report.cpp` — update fixtures that seed the removed `currentMaster.nextHop`.
+
+---
+
+### Task 1: Config + dead-field cleanup
+
+**Files:**
+- Modify: `main/project_config.h` (add `LATTICE_ROUTE_TABLE_MAX`, delete `MAX_ROUTE_PATH_LEN`)
+- Modify: `main/src/mesh/PeerRegistry.h` (remove `MasterInfo::nextHop`)
+- Modify: `main/src/mesh/Mesh.cpp` (remove the 2 `currentMaster.nextHop` writes)
+- Modify: `tests/unit/test_mesh_logic.cpp`, `tests/unit/test_route_report.cpp` (remove `.nextHop` seed writes)
+
+**Interfaces:**
+- Produces: `lattice::config::LATTICE_ROUTE_TABLE_MAX` (`size_t`, 32). `MasterInfo` becomes `{ uint8_t mac[6]; uint8_t distance; }`.
+
+- [ ] **Step 1: Add the knob, delete the stale one**
+
+In `main/project_config.h`, after the `LATTICE_NEIGHBOR_MAX` line add:
+
+```cpp
+// Downlink source routing (spec §4): max node->path entries the master tracks.
+// Master is hub-side with RAM headroom; raise for large deployments.
+inline constexpr size_t LATTICE_ROUTE_TABLE_MAX = 32;
+```
+
+Delete the `MAX_ROUTE_PATH_LEN` line (stale, sized for the removed in-payload encoding; grep confirms zero usages — `grep -rn MAX_ROUTE_PATH_LEN main/ tests/` must return nothing after deletion).
+
+- [ ] **Step 2: Remove the dead `nextHop` field**
+
+In `main/src/mesh/PeerRegistry.h`, change `MasterInfo` to drop `nextHop`:
+
+```cpp
+struct MasterInfo {
+  uint8_t mac[6];
+  uint8_t distance; // Hops to master
+};
+```
+
+- [ ] **Step 3: Remove writers + test seeds**
+
+`grep -rn "\.nextHop\|currentMaster.nextHop\|MasterInfo" main/ tests/` and remove every write to `currentMaster.nextHop`:
+- `Mesh.cpp:31` (constructor zero-init line for nextHop), `Mesh.cpp:567` (checkMasterTimeout), `Mesh.cpp:645` (processMasterBeacon `memcpy(currentMaster.nextHop, ...)`). Delete those statements (the surrounding `mac`/`distance` handling stays).
+- `tests/unit/test_mesh_logic.cpp:339,674` and `tests/unit/test_route_report.cpp:38` — delete the lines that write `.nextHop` on a `currentMaster`/`MasterInfo` (the tests never read it; they only need `mac`/`distance`).
+
+- [ ] **Step 4: Build + full suite**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+Expected: 159 pass / 1 disabled (no behavior change — dead field removed, new constant unused so far).
+
+- [ ] **Step 5: clang-format + commit**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/project_config.h main/src/mesh/PeerRegistry.h main/src/mesh/Mesh.cpp
+git add main/project_config.h main/src/mesh/PeerRegistry.h main/src/mesh/Mesh.cpp tests/unit/test_mesh_logic.cpp tests/unit/test_route_report.cpp
+git commit -m "refactor: add LATTICE_ROUTE_TABLE_MAX; remove dead MasterInfo::nextHop and stale MAX_ROUTE_PATH_LEN"
+```
+
+---
+
+### Task 2: RouteTable (master-side, unit-tested in isolation)
+
+**Files:**
+- Create: `main/src/mesh/RouteTable.h`
+- Create: `tests/unit/test_route_table.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `lattice::config::LATTICE_ROUTE_TABLE_MAX`, `MAX_HOPS`, `STALE` — none needed at runtime beyond the max; staleness uses a caller-passed `nowMillis`.
+- Produces: `class lattice::mesh::RouteTable` with:
+  - `void record(const uint8_t* nodeMac, const uint8_t* path, uint8_t pathLen, uint32_t nowMillis)` — insert/update the node's path (`pathLen <= MAX_HOPS`; a `pathLen > MAX_HOPS` call is ignored). On a full table with no existing entry, evict the oldest (smallest `lastSeenMillis`).
+  - `bool lookup(const uint8_t* nodeMac, uint8_t* pathOut, uint8_t* pathLenOut) const` — copy the node's stored path into `pathOut` (caller supplies a `>= 60`-byte buffer) and length into `*pathLenOut`; return `true` if found, else `false`.
+  - `void clear()`; non-copyable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_route_table.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/RouteTable.h"
+
+using namespace lattice::mesh;
+
+static const uint8_t NODE[6] = {0x02, 0, 0, 0, 0, 0xEE};
+static const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+static const uint8_t R2[6] = {0x02, 0, 0, 0, 0, 0x22};
+
+TEST(RouteTable, RecordsAndLooksUpPath) {
+  RouteTable t;
+  uint8_t path[12];
+  memcpy(path, R1, 6);
+  memcpy(path + 6, R2, 6);
+  t.record(NODE, path, 2, 1000);
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(NODE, out, &outLen));
+  EXPECT_EQ(outLen, 2);
+  EXPECT_EQ(0, memcmp(out, R1, 6));
+  EXPECT_EQ(0, memcmp(out + 6, R2, 6));
+}
+
+TEST(RouteTable, LookupMissReturnsFalse) {
+  RouteTable t;
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}
+
+TEST(RouteTable, RecordUpdatesExistingNode) {
+  RouteTable t;
+  uint8_t p1[6];
+  memcpy(p1, R1, 6);
+  t.record(NODE, p1, 1, 1000); // path via R1
+  uint8_t p2[12];
+  memcpy(p2, R2, 6);
+  memcpy(p2 + 6, R1, 6);
+  t.record(NODE, p2, 2, 2000); // newer path via R2,R1
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(NODE, out, &outLen));
+  EXPECT_EQ(outLen, 2);
+  EXPECT_EQ(0, memcmp(out, R2, 6));
+}
+
+TEST(RouteTable, RejectsOverlongPath) {
+  RouteTable t;
+  uint8_t big[66] = {};
+  t.record(NODE, big, 11, 1000); // 11 > MAX_HOPS(10) → ignored
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}
+
+TEST(RouteTable, EvictsOldestWhenFull) {
+  RouteTable t;
+  uint8_t p[6] = {0x02, 0, 0, 0, 0, 0x01};
+  // Fill: node i observed at time (i+1)*100; node 0 is oldest.
+  for (size_t i = 0; i < lattice::config::LATTICE_ROUTE_TABLE_MAX; ++i) {
+    uint8_t mac[6] = {0x02, 0, 0, 0, 0, static_cast<uint8_t>(0x80 + i)};
+    t.record(mac, p, 1, static_cast<uint32_t>((i + 1) * 100));
+  }
+  uint8_t oldest[6] = {0x02, 0, 0, 0, 0, 0x80}; // observed at t=100
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(oldest, out, &outLen));
+  // Insert one more (fresh) node → oldest must be evicted.
+  t.record(NODE, p, 1, 999999);
+  EXPECT_FALSE(t.lookup(oldest, out, &outLen)) << "oldest entry evicted";
+  EXPECT_TRUE(t.lookup(NODE, out, &outLen)) << "new entry present";
+}
+
+TEST(RouteTable, ClearEmpties) {
+  RouteTable t;
+  uint8_t p[6] = {0x02, 0, 0, 0, 0, 0x01};
+  t.record(NODE, p, 1, 1000);
+  t.clear();
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}
+```
+
+Add to `tests/CMakeLists.txt` next to the other `add_unit_test` lines (mirror `test_neighbor_table`):
+
+```cmake
+add_unit_test(test_route_table unit/test_route_table.cpp)
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --target test_route_table --parallel
+```
+Expected: FAIL — `RouteTable.h: No such file or directory`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `main/src/mesh/RouteTable.h`:
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "../../project_config.h"
+
+namespace lattice {
+namespace mesh {
+
+// Master-side RAM route table (spec §4): node MAC -> the relay path from the
+// origin to the master, in origin-to-master forward order, as learned from that
+// node's most recent route report. RAM-only, rebuilt from reports. Routing only,
+// no key material. Bounded by LATTICE_ROUTE_TABLE_MAX; evicts the oldest entry.
+class RouteTable {
+public:
+  RouteTable() = default;
+  RouteTable(const RouteTable&) = delete;
+  RouteTable& operator=(const RouteTable&) = delete;
+
+  void record(const uint8_t* nodeMac, const uint8_t* path, uint8_t pathLen, uint32_t nowMillis) {
+    if (pathLen > config::MAX_HOPS)
+      return; // parse-safety: never store an overlong path
+    Entry* slot = findSlot(nodeMac);
+    if (!slot)
+      slot = allocateSlot();
+    memcpy(slot->nodeMac, nodeMac, 6);
+    slot->pathLen = pathLen;
+    if (pathLen)
+      memcpy(slot->path, path, static_cast<size_t>(pathLen) * 6);
+    slot->lastSeenMillis = nowMillis;
+    slot->valid = true;
+  }
+
+  bool lookup(const uint8_t* nodeMac, uint8_t* pathOut, uint8_t* pathLenOut) const {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i) {
+      const Entry& e = entries[i];
+      if (e.valid && memcmp(e.nodeMac, nodeMac, 6) == 0) {
+        *pathLenOut = e.pathLen;
+        if (e.pathLen)
+          memcpy(pathOut, e.path, static_cast<size_t>(e.pathLen) * 6);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void clear() {
+    memset(entries, 0, sizeof(entries));
+  }
+
+private:
+  struct Entry {
+    uint8_t nodeMac[6];
+    uint8_t pathLen;
+    bool valid;
+    uint32_t lastSeenMillis;
+    uint8_t path[config::MAX_HOPS * 6]; // 60 bytes, matches route_path[]
+  };
+  Entry entries[config::LATTICE_ROUTE_TABLE_MAX]{};
+
+  Entry* findSlot(const uint8_t* nodeMac) {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (entries[i].valid && memcmp(entries[i].nodeMac, nodeMac, 6) == 0)
+        return &entries[i];
+    return nullptr;
+  }
+
+  Entry* allocateSlot() {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (!entries[i].valid)
+        return &entries[i];
+    Entry* oldest = &entries[0];
+    for (size_t i = 1; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (entries[i].lastSeenMillis < oldest->lastSeenMillis)
+        oldest = &entries[i];
+    return oldest;
+  }
+};
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 4: Run to verify GREEN + full suite**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+Expected: 6 new tests pass; full suite 165 pass / 1 disabled.
+
+- [ ] **Step 5: clang-format + commit**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/src/mesh/RouteTable.h tests/unit/test_route_table.cpp
+git add main/src/mesh/RouteTable.h tests/unit/test_route_table.cpp tests/CMakeLists.txt
+git commit -m "feat: RouteTable — master-side node->path store for downlink source routing"
+```
+
+---
+
+### Task 3: Route reports accumulate the relay path in the header
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.cpp` (`processRouteReport` relay branch)
+- Modify: `tests/unit/test_route_report.cpp` (assert path accumulation)
+
+**Interfaces:**
+- Consumes: `route_len`/`route_path` header fields; `MAX_HOPS`.
+- Produces: a route report arriving at the master carries `route_path[0..route_len)` = the relay chain in origin-to-master order.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to `tests/unit/test_route_report.cpp` (mirror the existing relay-forward test's fixture — read how it builds a `mesh_message` route report and invokes the relay path):
+
+```cpp
+TEST_F(RouteReportRelayTest, RelayAppendsOwnMacToRoutePath) {
+  Mesh relay = makeIntermediateNode(); // non-master, has a route to master (fixture)
+  mesh_message rr = {};
+  rr.proto_version = PROTO_VERSION;
+  rr.message_type = MESH_TYPE_ROUTE_REPORT;
+  const uint8_t leafMac[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  memcpy(rr.origin_mac_address, leafMac, 6);
+  memcpy(rr.target_mac_address, relay.currentMaster.mac, 6);
+  rr.epoch_num = 5;
+  rr.seq_num = 1;
+  rr.hop_count = 0;
+  rr.route_len = 0; // origin sent an empty path
+
+  mesh_message forwarded;
+  relay.testCaptureNextSend(&forwarded); // fixture hook capturing the outgoing frame
+  relay.testProcessRouteReport(rr);       // UNIT_TEST hook onto processRouteReport
+
+  ASSERT_EQ(forwarded.route_len, 1) << "relay appended its own MAC";
+  EXPECT_EQ(0, memcmp(&forwarded.route_path[0], relay.testDeviceMac(), 6));
+}
+```
+
+Use whatever capture/dispatch hooks the fixture already exposes; if `processRouteReport` isn't directly reachable, drive it through the recv queue the way other relay tests do, and read the forwarded frame from the esp_now mock's last-sent record. Add minimal `#ifdef UNIT_TEST` hooks to `Mesh.h` only if no existing path reaches it (e.g. `void testProcessRouteReport(const mesh_message& m){ processRouteReport(m); }`, `const uint8_t* testDeviceMac(){ return deviceMacAddress; }`). Prefer the existing esp_now mock's sent-frame query over adding a bespoke capture hook.
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cmake --build tests/build --target test_route_report --parallel && ctest --test-dir tests/build -R RelayAppendsOwnMacToRoutePath --output-on-failure
+```
+Expected: FAIL — `route_len` stays 0 (relay doesn't append yet).
+
+- [ ] **Step 3: Implement path accumulation**
+
+In `main/src/mesh/Mesh.cpp` `processRouteReport` relay branch (currently bumps `hop_count`/`last_hop` then forwards), append this node's MAC to `route_path` before forwarding. Replace the relay branch body with:
+
+```cpp
+  // Relay node (spec §4): the payload is E2E-sealed origin->master and opaque to
+  // us. Accumulate the relay path in the plaintext route_path header (excluded
+  // from AAD, so this does not break the tag) so the master learns the full
+  // origin->master relay chain for downlink source routing.
+  if (msg.hop_count >= lattice::config::MAX_HOPS)
+    return;
+  if (msg.route_len >= lattice::config::MAX_HOPS) {
+    Logger::logln("MESH", "route report path full — dropping", LogLevel::LOG_WARN);
+    return;
+  }
+  mesh_message relay = msg;
+  relay.hop_count++;
+  memcpy(relay.last_hop_mac_address, deviceMacAddress, 6);
+  memcpy(&relay.route_path[static_cast<size_t>(relay.route_len) * 6], deviceMacAddress, 6);
+  relay.route_len++;
+  transmitCore(static_cast<adapter_types>(relay.data_type), relay.data, MESH_TYPE_ROUTE_REPORT,
+               &relay);
+```
+
+- [ ] **Step 4: Run to verify GREEN + full suite**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+Expected: new test passes; full suite still green (165 pass / 1 disabled — the disabled e2e test is enabled in Task 6).
+
+- [ ] **Step 5: clang-format + commit**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/src/mesh/Mesh.cpp main/src/mesh/Mesh.h
+git add main/src/mesh/Mesh.cpp main/src/mesh/Mesh.h tests/unit/test_route_report.cpp
+git commit -m "feat: route reports accumulate relay path in route_path header (spec §4)"
+```
+
+---
+
+### Task 4: Master records routes from reports
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.h` (add `RouteTable routes;` member + `#ifdef UNIT_TEST` accessor), `Mesh.cpp` (`processRouteReport` master branch)
+
+**Interfaces:**
+- Consumes: `RouteTable::record` (Task 2); the opened route report.
+- Produces: `Mesh::routes` populated with `origin_mac → route_path` on every valid route report the master receives. Adds `#ifdef UNIT_TEST RouteTable& testRoutes()`.
+
+- [ ] **Step 1: Add member + include + hook**
+
+In `Mesh.h`: `#include "RouteTable.h"`; add private `RouteTable routes;` near `NeighborTable neighbors;`; add under the `#ifdef UNIT_TEST` block: `RouteTable& testRoutes() { return routes; }`.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/unit/test_route_report.cpp` a master-side test: build a master `Mesh`, feed a route report (origin = a leaf, `route_len=2`, `route_path=[R1,R2]`) sealed with that leaf's `k_up` (reuse the fixture's key setup used by the existing master-open test), drive `processRouteReport`, then assert `master.testRoutes().lookup(leafMac, out, &len)` returns `len==2`, `out[0..6]==R1`. Mirror the existing master-branch route-report unit test for the sealing/keys setup.
+
+- [ ] **Step 3: Run RED**, then **Step 4: implement**:
+
+In `processRouteReport` master branch, after the payload opens and `opened.data[0]==OP_ROUTE_REPORT` is verified, record the route (use the RAW `msg`'s header path — `route_path` is plaintext, not part of the sealed payload):
+
+```cpp
+    // Learn the origin's relay path for downlink source routing (spec §4).
+    // route_path/route_len are plaintext header fields (accumulated by relays);
+    // bounds-checked by RouteTable::record.
+    routes.record(msg.origin_mac_address, msg.route_path, msg.route_len, millis());
+```
+
+- [ ] **Step 5: GREEN + full suite; clang-format; commit** `"feat: master records node routes from route reports"`.
+
+Expected suite after: 166 pass / 1 disabled.
+
+---
+
+### Task 5: Source-routed sealed downlink send (master) + stateless relay forwarding
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.h` / `Mesh.cpp` (new `sendDownlinkToNode`; source-route forwarding in `processAdapterData`)
+- Modify: `tests/unit/test_mesh_logic.cpp` (unit tests for send + forward)
+
+**Interfaces:**
+- Consumes: `RouteTable::lookup`, `peerE2EKeys(destMac).kDown`, `sealPayload`, `findNextHopToMaster` (not used here), `sendMessage`, `broadcastToAllPeers`.
+- Produces:
+  - `void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const uint8_t* data)` — master-only. Builds a `MESH_TYPE_ADAPTER_DATA` frame, `target_mac_address = destMac`, seals `data` with the destination's `k_down`, then: if `routes.lookup(destMac)` succeeds → reverse the path into `route_path[]`, set `route_len`, unicast to `route_path[0]` (or directly to `destMac` if `route_len==0`); else → `route_len=0` and broadcast-flood fallback (`broadcastToAllPeers`). Returns void; logs+drops if keys unavailable.
+  - Stateless downlink relay: in `processAdapterData`, a non-master node that is not the target and sees `route_len > 0` finds its own MAC in `route_path[0..route_len)` and forwards to the next hop; if not found or `route_len==0`, falls back to the existing `relayDownlink` flood.
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add to `tests/unit/test_mesh_logic.cpp`:
+
+```cpp
+// (a) Master with a known route source-routes to the first hop, target=dest, sealed.
+TEST_F(JoinAckRelayTest, DownlinkSourceRoutesViaFirstHop) {
+  Mesh master = makeMasterNode(); // fixture master with an enrolled leaf + keys
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+  const uint8_t R2[6] = {0x02, 0, 0, 0, 0, 0x22};
+  uint8_t path[12];
+  memcpy(path, R1, 6);
+  memcpy(path + 6, R2, 6); // origin->R1->R2->master
+  master.testRoutes().record(leaf, path, 2, 1000);
+
+  resetEspNowMock();
+  uint8_t cmd[64] = {};
+  cmd[0] = OP_CONFIG_SET;
+  master.sendDownlinkToNode(leaf, adapter_types::SERIAL_ADAPTER, cmd);
+
+  // Reversed path [R2,R1]; first hop = R2.
+  mesh_message sent = lastEspNowSentTo(R2); // fixture/mock query
+  ASSERT_TRUE(wasSentTo(R2));
+  EXPECT_EQ(sent.route_len, 2);
+  EXPECT_EQ(0, memcmp(&sent.route_path[0], R2, 6));
+  EXPECT_EQ(0, memcmp(&sent.route_path[6], R1, 6));
+  EXPECT_EQ(0, memcmp(sent.target_mac_address, leaf, 6));
+  // payload sealed: data[0] != plaintext opcode
+  EXPECT_NE(sent.data[0], OP_CONFIG_SET);
+  // first hop auto-registered as ESP-NOW peer (VirtualBus doesn't enforce this,
+  // so assert it explicitly — the Phase-2 lesson).
+  EXPECT_TRUE(esp_now_is_peer_exist(R2));
+}
+
+// (b) A relay in the path forwards to the next index, unchanged frame.
+TEST_F(JoinAckRelayTest, DownlinkRelayForwardsToNextIndex) {
+  Mesh r2 = makeIntermediateNodeWithMac(/*R2*/ {0x02,0,0,0,0,0x22});
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+  mesh_message dl = {};
+  dl.proto_version = PROTO_VERSION;
+  dl.message_type = MESH_TYPE_ADAPTER_DATA;
+  memcpy(dl.target_mac_address, leaf, 6);
+  dl.route_len = 2;
+  memcpy(&dl.route_path[0], /*R2*/ r2.testDeviceMac(), 6);
+  memcpy(&dl.route_path[6], R1, 6);
+  dl.epoch_num = 7; dl.seq_num = 3;
+
+  resetEspNowMock();
+  r2.testProcessAdapterData(dl); // UNIT_TEST hook
+  EXPECT_TRUE(wasSentTo(R1)) << "R2 forwards to route_path[1]=R1";
+}
+
+// (c) Last relay forwards to target_mac.
+TEST_F(JoinAckRelayTest, DownlinkLastRelayForwardsToTarget) {
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  Mesh r1 = makeIntermediateNodeWithMac({0x02,0,0,0,0,0x11}); // R1
+  mesh_message dl = {};
+  dl.proto_version = PROTO_VERSION;
+  dl.message_type = MESH_TYPE_ADAPTER_DATA;
+  memcpy(dl.target_mac_address, leaf, 6);
+  dl.route_len = 2;
+  const uint8_t R2mac[6] = {0x02, 0, 0, 0, 0, 0x22};
+  memcpy(&dl.route_path[0], R2mac, 6);
+  memcpy(&dl.route_path[6], r1.testDeviceMac(), 6); // R1 at index 1 (last)
+  dl.epoch_num = 7; dl.seq_num = 4;
+  resetEspNowMock();
+  r1.testProcessAdapterData(dl);
+  EXPECT_TRUE(wasSentTo(leaf)) << "last relay forwards to target_mac";
+}
+```
+
+Adapt the fixture helpers (`makeMasterNode`, `makeIntermediateNodeWithMac`, `lastEspNowSentTo`/`wasSentTo`, `resetEspNowMock`) to what the test file + esp_now mock actually provide — read them first; add minimal `#ifdef UNIT_TEST` `testProcessAdapterData(const mesh_message&)` hook if `processAdapterData` isn't reachable.
+
+- [ ] **Step 2: RED.** **Step 3: implement.**
+
+Add to `Mesh.h` (public): `void sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const uint8_t* data);` and, if needed, the UNIT_TEST hook.
+
+In `Mesh.cpp`:
+
+```cpp
+void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const uint8_t* data) {
+  if (!isMaster)
+    return;
+  mesh_message msg = buildMessage(type, data, MESH_TYPE_ADAPTER_DATA);
+  memcpy(msg.target_mac_address, destMac, 6); // AAD-bound destination
+
+  const uint8_t *kUp, *kDown;
+  if (!peerE2EKeys(destMac, &kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kDown, msg)) {
+    Logger::logln("MESH", "downlink seal unavailable — dropped", LogLevel::LOG_WARN);
+    return;
+  }
+
+  uint8_t path[lattice::config::MAX_HOPS * 6];
+  uint8_t pathLen = 0;
+  if (routes.lookup(destMac, path, &pathLen) && pathLen > 0) {
+    // Reverse the origin->master path into master->origin order.
+    msg.route_len = pathLen;
+    for (uint8_t i = 0; i < pathLen; ++i)
+      memcpy(&msg.route_path[static_cast<size_t>(i) * 6], &path[static_cast<size_t>(pathLen - 1 - i) * 6], 6);
+    // First hop = route_path[0]; auto-register it as an unencrypted ESP-NOW peer
+    // (idempotent) so esp_now_send can unicast to it. Command-frequency, so no
+    // dedicated bounding beyond the enrolled/forwarding peers already present.
+    lattice::mesh::crypto::registerPeerWithEspNow(msg.route_path);
+    sendMessage(msg.route_path, msg);
+    return;
+  }
+  // No known multi-hop route: fall back to broadcast flood (still sealed).
+  // Direct/adjacent nodes and unknown-route nodes are reached this way.
+  msg.route_len = 0;
+  broadcastToAllPeers(msg);
+}
+```
+
+In `processAdapterData`, the non-master downlink branch (`!isMaster && !addressedToSelf && !isBroadcastTarget && !addressedToMaster`) currently calls `relayDownlink(msg)`. Replace with source-route-then-fallback:
+
+```cpp
+    // Downlink toward a specific node. If the frame carries a source route and
+    // we are on it, forward to the next hop (stateless — spec §4); otherwise
+    // fall back to the flood.
+    if (msg.route_len > 0 && msg.route_len <= lattice::config::MAX_HOPS) {
+      for (uint8_t i = 0; i < msg.route_len; ++i) {
+        if (memcmp(&msg.route_path[static_cast<size_t>(i) * 6], deviceMacAddress, 6) == 0) {
+          if (msg.hop_count >= lattice::config::MAX_HOPS)
+            return;
+          mesh_message fwd = msg;
+          fwd.hop_count++;
+          const uint8_t* next = (i + 1 < msg.route_len)
+                                    ? &msg.route_path[static_cast<size_t>(i + 1) * 6]
+                                    : msg.target_mac_address;
+          lattice::mesh::crypto::registerPeerWithEspNow(next); // idempotent; needed to unicast
+          sendMessage(next, fwd);
+          return;
+        }
+      }
+    }
+    relayDownlink(msg); // not on the route / no route → existing flood fallback
+    return;
+```
+
+- [ ] **Step 4: GREEN + full suite; clang-format; commit** `"feat: source-routed sealed downlink send + stateless relay forwarding (spec §4)"`.
+
+Expected suite after: 169 pass / 1 disabled.
+
+---
+
+### Task 6: Node opens k_down downlink; wire master command path; enable e2e
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.cpp` (`processAdapterData` local-delivery open with `k_down`)
+- Modify: `main/src/adapter/serial/SerialAdapter.cpp` (CONFIG_SET/command → `sendDownlinkToNode`)
+- Modify: `tests/e2e/scenarios/test_route_report_e2e.cpp` (rewrite + enable `RouteReportCarriesHopChain`)
+- Create/Modify e2e: a multi-hop sealed-downlink delivery scenario.
+
+**Interfaces:**
+- Consumes: `masterE2EKeys().kDown` (node side), `openPayload`, `sendDownlinkToNode` (Task 5).
+- Produces: a distance-2 node receives, opens, and applies a master command; the gap-#7-sibling downlink path works end to end.
+
+- [ ] **Step 1: Node-side open (failing e2e first)**
+
+Write a multi-hop downlink e2e test in `tests/e2e/scenarios/` (mirror `test_multihop_e2e.cpp` chain fixture): master + relay + leaf (leaf NOT linked to master), enroll both, let route reports populate the master's table (`runPolled(ROUTE_REPORT_INTERVAL_MS + 5000)`), then have the master send a CONFIG_SET to the leaf via the serial path; assert the leaf receives and applies it (e.g. observes the adapter-type-change / restart signal the harness exposes, or the leaf's `externalRecvCallback` sees the opened CONFIG_SET with `data[0]==OP_CONFIG_SET`). Assert a relay in between never delivered it locally (only forwarded).
+
+- [ ] **Step 2: RED**, then **Step 3: implement node-side open**
+
+In `processAdapterData` local-delivery section (the `addressedToSelf` path on a non-master node), before the existing `externalRecvCallback`/config handling, open a sealed downlink:
+
+```cpp
+  // Node-side E2E open (spec §2): a self-addressed sealed ADAPTER_DATA from the
+  // master is opened with our k_down before local delivery. Mirrors the master's
+  // uplink open. Failure → drop (finding-#9 pattern).
+  mesh_message opened = msg;
+  if (!isMaster && addressedToSelf && msg.message_type == MESH_TYPE_ADAPTER_DATA) {
+    const uint8_t *kUp, *kDown;
+    if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::openPayload(kDown, opened)) {
+      Logger::logln("MESH", "downlink open failed — dropped", LogLevel::LOG_WARN);
+      return;
+    }
+  }
+```
+
+and use `opened` for the subsequent local-delivery/config checks and `externalRecvCallback` on this node path (the existing master-side and broadcast handling keeps using its own opened/raw copy as today).
+
+**Care:** confirm the existing single-hop `ServerBroadcastTest.ConfigSetReachesNodeAdapterAndPersists` path — the master must now seal single-hop targeted downlinks too, so the direct node opens them. Update the master command origination (Step 4) so BOTH single-hop and multi-hop go through `sendDownlinkToNode` (sealed). Broadcast-to-all (`FF:FF`) adapter data stays plaintext and is NOT opened (guarded by `addressedToSelf`, which is false for `FF:FF`).
+
+- [ ] **Step 4: Wire the master command path**
+
+In `main/src/adapter/serial/SerialAdapter.cpp` where the master handles a server CONFIG_SET / targeted command and currently calls `broadcastAdapterDataStatic` (lines ~279, ~356), extract the destination MAC (from the command's `data[1..6]`) and call the new targeted API instead:
+
+```cpp
+// Master → node command: source-route + seal to the specific destination.
+uint8_t destMac[6];
+memcpy(destMac, &fwdData[1], 6); // CONFIG_SET target field
+lattice::mesh::Mesh::sendDownlinkToNodeStatic(destMac, static_cast<adapter_types>(msg.data_type), fwdData);
+```
+
+Add a static forwarder `Mesh::sendDownlinkToNodeStatic` mirroring `broadcastAdapterDataStatic` (it exists as a static→instance shim; follow that pattern). If the command is a genuine broadcast (target `FF:FF`), keep the existing `broadcastAdapterDataStatic` (plaintext broadcast) — only targeted commands get sealed source routing. Read the surrounding code to place this correctly and preserve HEALTH_REQ / other opcodes.
+
+- [ ] **Step 5: Rewrite + enable `RouteReportCarriesHopChain`**
+
+In `tests/e2e/scenarios/test_route_report_e2e.cpp`, rewrite the disabled test's assertions for the header-field design and drop `DISABLED_`. The payload is sealed/opaque on the wire, so assert on the header `route_len`/`route_path`, not `data[]`:
+
+```cpp
+TEST_F(MeshSimTest, RouteReportCarriesHopChain) {
+  addMaster();
+  auto* relay = addSensor(MAC_NODE_A);
+  auto* leaf = addSensor(MAC_NODE_B);
+  world.bus.link(master, relay);
+  world.bus.link(relay, leaf);
+  enroll(relay);
+  enroll(leaf);
+  runPolled(lattice::config::ROUTE_REPORT_INTERVAL_MS + 5000);
+
+  bool sawLeafRoute = false;
+  for (const auto& m : hub->ofType(MESH_TYPE_ROUTE_REPORT)) {
+    if (memcmp(m.origin_mac_address, leaf->mac(), 6) != 0)
+      continue;
+    ASSERT_GE(m.route_len, 1);
+    EXPECT_EQ(memcmp(&m.route_path[0], relay->mac(), 6), 0)
+        << "first relay in the leaf's path is the middle node";
+    sawLeafRoute = true;
+  }
+  EXPECT_TRUE(sawLeafRoute) << "leaf's route report reaches the hub carrying its relay path";
+}
+```
+
+(If `FakeHub::ofType` surfaces the frame as received at the master, `route_path`/`route_len` are the plaintext header as the master saw it. Confirm the hub records the header fields; if it only records opened payload, read the frame via the master's recorded route table instead — `hub` exposes what the master delivered.)
+
+- [ ] **Step 6: Full suite; clang-format; commit**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/src/mesh/Mesh.cpp main/src/adapter/serial/SerialAdapter.cpp
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+git add -A
+git commit -m "feat: k_down downlink open + master command source routing; enable RouteReportCarriesHopChain (closes downlink gap + command-injection window)"
+```
+Expected: **0 disabled tests** remaining; full suite green (~171 pass / 0 disabled).
+
+---
+
+### Task 7: Finish — full verification + PR
+
+- [ ] **Step 1: Clean-from-scratch build + suite**
+
+```bash
+rm -rf tests/build && cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+Expected: all pass, **0 disabled**.
+
+- [ ] **Step 2: Whole-tree clang-format-18 gate (main/src)**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+find main/src \( -name '*.cpp' -o -name '*.h' \) ! -path '*/nanopb/*' ! -name 'mesh.pb.h' ! -name 'mesh.pb.c' | xargs "$CF" --style=file --dry-run --Werror
+```
+Expected: exit 0, no output.
+
+- [ ] **Step 3: PR via superpowers:finishing-a-development-branch**
+
+Single lattice-nodes PR (no protocol change; submodule stays v0.4.0). PR body: completes spec §4 downlink source routing + §2 downlink `k_down` sealing; closes the Phase-1 command-injection window; enables the last disabled test; `currentMaster.nextHop`/`MAX_ROUTE_PATH_LEN` cleanup. Note the gh active account must be `superbrobenji` (ADMIN) to open the PR.
+
+---
+
+## Deferred (explicitly NOT in Phase 3)
+
+- **Dual-master data failover** (gap #8, `secondary_master_mac`/`secondary_public_key` fields already in the v3 struct) — Phase 4. This is the remaining open gap.
+- **`transmitCore` AAD-bound target rewrite on relayed sealed frames** — only bites with multiple masters; Phase 4.
+- **Route-report path authenticity:** the relay-accumulated `route_path` is plaintext and relay-asserted (a malicious relay can falsify it → misrouted downlink, DoS-class, same envelope as the spec §2/§4 accepted blackhole risk; uplink data integrity unaffected). Documented, not mitigated.
+- **Sticky-low `currentMaster.distance`** (Phase-2 MINOR-2) — longer-only path repair latency; not addressed here.

--- a/main/project_config.h
+++ b/main/project_config.h
@@ -118,10 +118,11 @@ inline constexpr size_t LATTICE_E2E_KEYCACHE_MAX = 10; // = MAX_PEERS
 // Multi-hop uplink routing (spec §3): max beacon-learned forwarding neighbors
 // tracked per node. One entry per distinct upstream relay a node can hear.
 inline constexpr size_t LATTICE_NEIGHBOR_MAX = 8;
+// Downlink source routing (spec §4): max node->path entries the master tracks.
+// Master is hub-side with RAM headroom; raise for large deployments.
+inline constexpr size_t LATTICE_ROUTE_TABLE_MAX = 32;
 // Maximum allowed routing hops in the mesh network
 constexpr uint8_t MAX_HOPS = 10;
-// Maximum relay hops in a route report path; bounded by data[2..61] = 60 bytes / 6 bytes per MAC
-constexpr uint8_t MAX_ROUTE_PATH_LEN = (64 - 2) / 6;
 // Peer staleness threshold (ms) before being considered offline
 constexpr uint32_t STALE_PEER_THRESHOLD_MS = 8000UL;
 // Routing timeout used by MessageRouter (ms)

--- a/main/project_config.h
+++ b/main/project_config.h
@@ -121,6 +121,16 @@ inline constexpr size_t LATTICE_NEIGHBOR_MAX = 8;
 // Downlink source routing (spec §4): max node->path entries the master tracks.
 // Master is hub-side with RAM headroom; raise for large deployments.
 inline constexpr size_t LATTICE_ROUTE_TABLE_MAX = 32;
+// Downlink auto-registered forwarding peers (spec §2: "20-peer cap,
+// LRU-evicted"). Bounds the number of non-enrolled, non-master ESP-NOW peers a
+// node will auto-register while relaying/sending source-routed downlink
+// frames (registerDownlinkPeer, Mesh.cpp) — without this bound, an
+// RF attacker can craft ADAPTER_DATA frames with fresh distinct next-hop MACs
+// to exhaust the ~20-slot ESP-NOW peer table (no self-heal, no reboot),
+// blackholing legitimate downlink forwarding. Keep small: enrolled peers
+// (up to MAX_PEERS) + the single uplink forwardingPeer + this must stay well
+// under the ~20 cap on realistic relays.
+inline constexpr size_t LATTICE_DOWNLINK_PEER_MAX = 4;
 // Maximum allowed routing hops in the mesh network
 constexpr uint8_t MAX_HOPS = 10;
 // Peer staleness threshold (ms) before being considered offline

--- a/main/src/adapter/serial/SerialAdapter.cpp
+++ b/main/src/adapter/serial/SerialAdapter.cpp
@@ -274,11 +274,28 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
                          6, "Serial_Adapter: transmit function not set");
     }
   } else if (msg.message_type == MESH_TYPE_SERIAL_CMD_BROADCAST) {
-    Logger::logln("Serial_Adapter", "Broadcasting adapter data to all peers", LogLevel::LOG_DEBUG);
-    // Broadcast adapter data to all peers
-    lattice::mesh::Mesh::broadcastAdapterDataStatic(static_cast<adapter_types>(msg.data_type),
-                                                    msg.data);
-    Logger::logln("Serial_Adapter", "Broadcast sent successfully", LogLevel::LOG_DEBUG);
+    static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    bool isGenuineBroadcast = (memcmp(msg.target_mac_address, kBroadcastMac, 6) == 0);
+    if (isGenuineBroadcast) {
+      Logger::logln("Serial_Adapter", "Broadcasting adapter data to all peers",
+                    LogLevel::LOG_DEBUG);
+      // Broadcast adapter data to all peers (plaintext — no single destination to seal for)
+      lattice::mesh::Mesh::broadcastAdapterDataStatic(static_cast<adapter_types>(msg.data_type),
+                                                      msg.data);
+      Logger::logln("Serial_Adapter", "Broadcast sent successfully", LogLevel::LOG_DEBUG);
+    } else {
+      // Master -> node command: source-route + seal to the specific destination
+      // (spec §4), instead of flooding it in plaintext to every peer. The
+      // opcode's target field (data[1..6], e.g. CONFIG_SET/NODE_ID_SET) carries
+      // the destination MAC.
+      const uint8_t* fwdData = msg.data;
+      uint8_t destMac[6];
+      memcpy(destMac, &fwdData[1], 6); // CONFIG_SET target field
+      Logger::logln("Serial_Adapter", "Sending sealed, source-routed downlink to node",
+                    LogLevel::LOG_DEBUG);
+      lattice::mesh::Mesh::sendDownlinkToNodeStatic(
+          destMac, static_cast<adapter_types>(msg.data_type), fwdData);
+    }
   } else {
     Logger::logln("Serial_Adapter", "Unknown message type: " + String(msg.message_type),
                   LogLevel::LOG_WARN);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -575,6 +575,12 @@ void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t* data) {
     instance->broadcastAdapterData(type, data);
 }
 
+void Mesh::sendDownlinkToNodeStatic(const uint8_t* destMac, adapter_types type,
+                                    const uint8_t* data) {
+  if (instance)
+    instance->sendDownlinkToNode(destMac, type, data);
+}
+
 void Mesh::debugDumpRadio() {
   if (!EepromManager::getInstance().getDevMode())
     return;
@@ -782,6 +788,19 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
         !lattice::mesh::crypto::openPayload(kUp, opened)) {
       Logger::logln("MESH", "E2E open failed — frame dropped", LogLevel::LOG_WARN);
+      return;
+    }
+  }
+
+  // Node-side E2E open (spec §2): a self-addressed sealed ADAPTER_DATA from the
+  // master is opened with our k_down before local delivery. Mirrors the master's
+  // uplink open above. Failure → drop (finding-#9 pattern). Broadcast (FF:FF)
+  // frames are NOT opened — addressedToSelf is false for those, so this never
+  // fires for them (they stay plaintext, handled below).
+  if (!isMaster && addressedToSelf && msg.message_type == MESH_TYPE_ADAPTER_DATA) {
+    const uint8_t *kUp, *kDown;
+    if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::openPayload(kDown, opened)) {
+      Logger::logln("MESH", "downlink open failed — dropped", LogLevel::LOG_WARN);
       return;
     }
   }

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -534,6 +534,42 @@ void Mesh::broadcastAdapterData(adapter_types type, const uint8_t* data, bool de
   }
 }
 
+void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const uint8_t* data) {
+  if (!isMaster)
+    return;
+  mesh_message msg = buildMessage(type, data, MESH_TYPE_ADAPTER_DATA);
+  memcpy(msg.target_mac_address, destMac, 6); // AAD-bound destination — set before sealing
+
+  const uint8_t *kUp, *kDown;
+  if (!peerE2EKeys(destMac, &kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kDown, msg)) {
+    Logger::logln("MESH", "downlink seal unavailable — dropped", LogLevel::LOG_WARN);
+    return;
+  }
+
+  uint8_t path[lattice::config::MAX_HOPS * 6];
+  uint8_t pathLen = 0;
+  if (routes.lookup(destMac, path, &pathLen) && pathLen > 0) {
+    // RouteTable stores the path in origin->master order (as accumulated by
+    // relays on the uplink route report); reverse it into master->origin order
+    // for the downlink source route.
+    msg.route_len = pathLen;
+    for (uint8_t i = 0; i < pathLen; ++i)
+      memcpy(&msg.route_path[static_cast<size_t>(i) * 6],
+             &path[static_cast<size_t>(pathLen - 1 - i) * 6], 6);
+    // First hop = route_path[0]; auto-register it as an unencrypted ESP-NOW peer
+    // (idempotent) so esp_now_send can unicast to it — real ESP-NOW requires the
+    // peer to be registered first (VirtualBus doesn't enforce this, but the
+    // Phase-2 lesson was that skipping it here is a real-hardware bug).
+    lattice::mesh::crypto::registerPeerWithEspNow(msg.route_path);
+    sendMessage(msg.route_path, msg);
+    return;
+  }
+  // No known multi-hop route: fall back to broadcast flood (still sealed).
+  // Direct/adjacent nodes and unknown-route nodes are reached this way.
+  msg.route_len = 0;
+  broadcastToAllPeers(msg);
+}
+
 void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t* data) {
   if (instance)
     instance->broadcastAdapterData(type, data);
@@ -699,8 +735,26 @@ void Mesh::processAdapterData(const mesh_message& msg) {
                    &relay);
       return;
     }
-    // Downlink to another node: relay outward toward specific target
-    relayDownlink(msg);
+    // Downlink toward a specific node. If the frame carries a source route and
+    // we are on it, forward to the next hop (stateless — spec §4); otherwise
+    // fall back to the flood.
+    if (msg.route_len > 0 && msg.route_len <= lattice::config::MAX_HOPS) {
+      for (uint8_t i = 0; i < msg.route_len; ++i) {
+        if (memcmp(&msg.route_path[static_cast<size_t>(i) * 6], deviceMacAddress, 6) == 0) {
+          if (msg.hop_count >= lattice::config::MAX_HOPS)
+            return;
+          mesh_message fwd = msg;
+          fwd.hop_count++;
+          const uint8_t* next = (i + 1 < msg.route_len)
+                                    ? &msg.route_path[static_cast<size_t>(i + 1) * 6]
+                                    : msg.target_mac_address;
+          lattice::mesh::crypto::registerPeerWithEspNow(next); // idempotent; needed to unicast
+          sendMessage(next, fwd);
+          return;
+        }
+      }
+    }
+    relayDownlink(msg); // not on the route / no route -> existing flood fallback
     return;
   }
 

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -934,6 +934,10 @@ void Mesh::processRouteReport(const mesh_message& msg) {
       Logger::logln("MESH", "processRouteReport: bad opcode, dropping", LogLevel::LOG_WARN);
       return;
     }
+    // Learn the origin's relay path for downlink source routing (spec §4).
+    // route_path/route_len are plaintext header fields (accumulated by relays);
+    // bounds-checked by RouteTable::record.
+    routes.record(msg.origin_mac_address, msg.route_path, msg.route_len, millis());
     // Terminal endpoint — deliver to server via external callback
     if (externalRecvCallback)
       externalRecvCallback(opened);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -121,6 +121,49 @@ PeerInfo* Mesh::findNextHopToMaster() {
   return &nextHopScratch;
 }
 
+void Mesh::registerDownlinkPeer(const uint8_t* mac) {
+  // Enrolled peers and the current master are managed exclusively by their
+  // own paths (PeerRegistry / enrollment) — just register (idempotent) and
+  // never track or evict them via this LRU.
+  bool isCurrentMaster =
+      currentMaster.distance != 0xFF &&
+      lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(currentMaster.mac);
+  if (peers.find(mac) || isCurrentMaster) {
+    lattice::mesh::crypto::registerPeerWithEspNow(mac);
+    return;
+  }
+
+  // Already tracked: touch (move to front) and ensure still registered.
+  for (size_t i = 0; i < downlinkPeerLruCount; ++i) {
+    if (lattice::utils::MacAddress(downlinkPeerLru[i]) == lattice::utils::MacAddress(mac)) {
+      uint8_t touched[6];
+      memcpy(touched, downlinkPeerLru[i], 6);
+      for (size_t j = i; j > 0; --j)
+        memcpy(downlinkPeerLru[j], downlinkPeerLru[j - 1], 6);
+      memcpy(downlinkPeerLru[0], touched, 6);
+      lattice::mesh::crypto::registerPeerWithEspNow(mac);
+      return;
+    }
+  }
+
+  // Not tracked. Evict the oldest (LRU) entry from ESP-NOW first if at
+  // capacity (spec §2: "20-peer cap, LRU-evicted") — otherwise an RF attacker
+  // crafting downlink frames with fresh distinct next-hop MACs on every frame
+  // would grow this set unbounded and eventually exhaust the ESP-NOW peer
+  // table (no self-heal, no reboot).
+  if (downlinkPeerLruCount >= lattice::config::LATTICE_DOWNLINK_PEER_MAX) {
+    uint8_t* oldest = downlinkPeerLru[downlinkPeerLruCount - 1];
+    if (esp_now_is_peer_exist(oldest))
+      esp_now_del_peer(oldest);
+  } else {
+    ++downlinkPeerLruCount;
+  }
+  for (size_t j = downlinkPeerLruCount - 1; j > 0; --j)
+    memcpy(downlinkPeerLru[j], downlinkPeerLru[j - 1], 6);
+  memcpy(downlinkPeerLru[0], mac, 6);
+  lattice::mesh::crypto::registerPeerWithEspNow(mac);
+}
+
 uint16_t Mesh::nextSeqGuarded() {
   uint16_t seq = replay.nextSeq();
   if (seq == 0) {
@@ -557,10 +600,11 @@ void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const 
       memcpy(&msg.route_path[static_cast<size_t>(i) * 6],
              &path[static_cast<size_t>(pathLen - 1 - i) * 6], 6);
     // First hop = route_path[0]; auto-register it as an unencrypted ESP-NOW peer
-    // (idempotent) so esp_now_send can unicast to it — real ESP-NOW requires the
-    // peer to be registered first (VirtualBus doesn't enforce this, but the
-    // Phase-2 lesson was that skipping it here is a real-hardware bug).
-    lattice::mesh::crypto::registerPeerWithEspNow(msg.route_path);
+    // so esp_now_send can unicast to it — real ESP-NOW requires the peer to be
+    // registered first (VirtualBus doesn't enforce this, but the Phase-2 lesson
+    // was that skipping it here is a real-hardware bug). Bounded via the
+    // downlink forwarding-peer LRU (spec §2) — see registerDownlinkPeer().
+    registerDownlinkPeer(msg.route_path);
     sendMessage(msg.route_path, msg);
     return;
   }
@@ -754,7 +798,11 @@ void Mesh::processAdapterData(const mesh_message& msg) {
           const uint8_t* next = (i + 1 < msg.route_len)
                                     ? &msg.route_path[static_cast<size_t>(i + 1) * 6]
                                     : msg.target_mac_address;
-          lattice::mesh::crypto::registerPeerWithEspNow(next); // idempotent; needed to unicast
+          // Bounded via the downlink forwarding-peer LRU (spec §2) — `next` is
+          // attacker-controlled plaintext (this relay never opens the sealed
+          // frame), so an unbounded registerPeerWithEspNow here would let an RF
+          // attacker exhaust the ESP-NOW peer table one entry per crafted frame.
+          registerDownlinkPeer(next);
           sendMessage(next, fwd);
           return;
         }

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -28,7 +28,6 @@ Mesh::Mesh()
   instance = this;
   memset(currentMaster.mac, 0, 6);
   currentMaster.distance = 0xFF;
-  memset(currentMaster.nextHop, 0, 6);
   memset(lastSeenMasterMac, 0, 6);
   memset(deviceMacAddress, 0, 6);
   memset(recvQueue, 0, sizeof(recvQueue));
@@ -564,7 +563,6 @@ void Mesh::checkMasterTimeout() {
                   LogLevel::LOG_WARN);
     memset(currentMaster.mac, 0, 6);
     currentMaster.distance = 0xFF;
-    memset(currentMaster.nextHop, 0, 6);
     memset(lastSeenMasterMac, 0, 6);
     lastMasterBeaconReceivedMs = 0;
   }
@@ -642,7 +640,6 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
       newDistance < currentMaster.distance) {
     memcpy(currentMaster.mac, msg.origin_mac_address, 6);
     currentMaster.distance = newDistance;
-    memcpy(currentMaster.nextHop, msg.last_hop_mac_address, 6);
     Logger::logln("MESH", "Updated route to master. Distance: " + String(newDistance),
                   LogLevel::LOG_INFO);
   }

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -940,18 +940,24 @@ void Mesh::processRouteReport(const mesh_message& msg) {
     return;
   }
 
-  // Relay node (spec §4): the payload is E2E-sealed end-to-end (origin -> master)
-  // so a relay cannot read or mutate msg.data — path accumulation via data[] is
-  // removed; it moves to the header route_path field in a future phase. Forward
-  // the frame unmodified except routing metadata (hop_count/last_hop).
+  // Relay node (spec §4): the payload is E2E-sealed origin->master and opaque to
+  // us. Accumulate the relay path in the plaintext route_path header (excluded
+  // from AAD, so this does not break the tag) so the master learns the full
+  // origin->master relay chain for downlink source routing.
   if (msg.hop_count >= lattice::config::MAX_HOPS) {
     Logger::logln("MESH", "processRouteReport: hop limit reached, dropping", LogLevel::LOG_WARN);
+    return;
+  }
+  if (msg.route_len >= lattice::config::MAX_HOPS) {
+    Logger::logln("MESH", "route report path full — dropping", LogLevel::LOG_WARN);
     return;
   }
 
   mesh_message relay = msg;
   relay.hop_count++;
   memcpy(relay.last_hop_mac_address, deviceMacAddress, 6);
+  memcpy(&relay.route_path[static_cast<size_t>(relay.route_len) * 6], deviceMacAddress, 6);
+  relay.route_len++;
 
   transmitCore(static_cast<adapter_types>(relay.data_type), relay.data, MESH_TYPE_ROUTE_REPORT,
                &relay);

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -797,16 +797,35 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   // uplink open above. Failure → drop (finding-#9 pattern). Broadcast (FF:FF)
   // frames are NOT opened — addressedToSelf is false for those, so this never
   // fires for them (they stay plaintext, handled below).
+  bool nodeOpened = false;
   if (!isMaster && addressedToSelf && msg.message_type == MESH_TYPE_ADAPTER_DATA) {
     const uint8_t *kUp, *kDown;
     if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::openPayload(kDown, opened)) {
       Logger::logln("MESH", "downlink open failed — dropped", LogLevel::LOG_WARN);
       return;
     }
+    nodeOpened = true;
   }
 
-  bool isConfigOpcode =
-      (opened.data_type == adapter_types::SERIAL_ADAPTER && opened.data[0] == OP_CONFIG_SET);
+  bool isConfigOpcode = (opened.data_type == adapter_types::SERIAL_ADAPTER &&
+                         (opened.data[0] == OP_CONFIG_SET || opened.data[0] == OP_NODE_ID_SET));
+  // Critical fix: config opcodes (CONFIG_SET / NODE_ID_SET) are state-changing
+  // (adapter-type reconfig + restart, node-identity assignment) and must be
+  // honored ONLY via the sealed, opened path above (needsOpen on the master,
+  // nodeOpened on a node) — never via a broadcast-target or otherwise-unopened
+  // frame. Without this, a forged plaintext BROADCAST (target FF:FF)
+  // ADAPTER_DATA frame is never addressedToSelf, so it is never opened; since
+  // origin_mac is attacker-controlled and the master's real MAC is public in
+  // beacons, such a frame sailed past the origin check below too and reached
+  // externalRecvCallback fully unauthenticated (one plaintext RF frame could
+  // reboot/reconfigure any node). Legitimate non-config broadcast adapter data
+  // (e.g. OP_HEALTH_REQ, OP_TX_POWER_SET) is unaffected — this guard only
+  // fires for CONFIG_SET/NODE_ID_SET.
+  if (isConfigOpcode && !needsOpen && !nodeOpened) {
+    Logger::logln("MESH", "Config opcode via unopened/broadcast path rejected (unauthenticated)",
+                  LogLevel::LOG_WARN);
+    return;
+  }
   // TODO(dual-master): also allow secondary master MAC for CONFIG_SET
   if (isConfigOpcode && enrollment.hasMasterMac &&
       memcmp(opened.origin_mac_address, enrollment.knownMasterMac, 6) != 0) {

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -192,6 +192,35 @@ private:
   // Enrolled peers (master + sensors, held in `peers`) are NEVER tracked or
   // evicted here.
   uint8_t forwardingPeer[6]{};
+
+  // Bounded LRU of auto-registered DOWNLINK forwarding-peer MACs (spec §2:
+  // "20-peer cap, LRU-evicted"). Unlike the single uplink forwardingPeer
+  // above, a node/master may legitimately need to have MULTIPLE distinct
+  // downlink forwarding peers registered concurrently (e.g. relaying several
+  // in-flight source-routed frames toward different next hops), so this is a
+  // small fixed-capacity LRU rather than a single slot. Capacity is
+  // LATTICE_DOWNLINK_PEER_MAX (project_config.h) — kept small so enrolled
+  // peers + the uplink forwardingPeer + this stay well under the ~20 ESP-NOW
+  // cap. Entries are ordered most-recently-used first (index 0). Enrolled
+  // peers (`peers`) and the current master are NEVER tracked or evicted here
+  // — see registerDownlinkPeer().
+  uint8_t downlinkPeerLru[lattice::config::LATTICE_DOWNLINK_PEER_MAX][6]{};
+  size_t downlinkPeerLruCount{0};
+
+  // Auto-register `mac` as an unencrypted ESP-NOW peer for downlink
+  // forwarding, bounding the set of non-enrolled, non-master peers this adds
+  // via the downlinkPeerLru above (spec §2). If `mac` is an enrolled peer or
+  // the current master, this is a plain idempotent registration — those
+  // peers are managed elsewhere (PeerRegistry / enrollment) and must never be
+  // evicted by downlink forwarding churn. Otherwise `mac` is tracked in the
+  // LRU: already-tracked -> move to front (touch); not tracked and the LRU is
+  // full -> evict the oldest entry from ESP-NOW first. Replaces the plaintext
+  // `registerPeerWithEspNow` calls previously used directly by
+  // sendDownlinkToNode()/processAdapterData()'s relay-forward branch, which
+  // had no bound and let an RF attacker crafting frames with fresh distinct
+  // next-hop MACs exhaust the ESP-NOW peer table one entry per frame.
+  void registerDownlinkPeer(const uint8_t* mac);
+
   // Returns k_up/k_down for the current master (leaf side); false if not enrolled
   // or master pubkey unknown.
   bool masterE2EKeys(const uint8_t** kUp, const uint8_t** kDown);

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -138,6 +138,7 @@ private:
   NeighborTable& testNeighbors() { return neighbors; }
   RouteTable& testRoutes() { return routes; }
   uint32_t testMillisNow() { return millis(); } // exposes the node's mocked clock to tests
+  const uint8_t* testDeviceMac() const { return deviceMacAddress; }
 #endif
 
   // Relay jitter: deferred relay pending fields (Task 3)
@@ -248,6 +249,13 @@ public:
   // this node's own serial adapter — broadcastToAllPeers() explicitly skips
   // self, so without this the master could never answer for itself.
   void broadcastAdapterData(adapter_types type, const uint8_t* data, bool deliverLocally = false);
+
+  // Master-only: source-route a sealed downlink to a specific enrolled node
+  // (spec §4). Seals `data` with the destination's k_down, then unicasts via
+  // the reversed relay path recorded in RouteTable (from that node's most
+  // recent route report), or broadcast-floods if no route is known. No-op if
+  // this node is not master. See Mesh.cpp for the full rationale.
+  void sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const uint8_t* data);
 
   // Serial adapter helper (optional broadcast)
   static void broadcastAdapterDataStatic(adapter_types type, const uint8_t* data);

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -18,6 +18,7 @@
 #include "Enrollment.h"
 #include "E2EKeyStore.h"
 #include "NeighborTable.h"
+#include "RouteTable.h"
 
 #ifdef UNIT_TEST
 // Forward declarations for test fixture classes (global namespace) so that
@@ -135,6 +136,7 @@ private:
 #ifdef UNIT_TEST
   ReplayCache& testReplay() { return replay; }
   NeighborTable& testNeighbors() { return neighbors; }
+  RouteTable& testRoutes() { return routes; }
   uint32_t testMillisNow() { return millis(); } // exposes the node's mocked clock to tests
 #endif
 
@@ -173,6 +175,9 @@ private:
   // Forwarding candidates toward the master, learned from overheard master
   // beacons (spec §3). Routing only — never consulted for E2E crypto.
   NeighborTable neighbors;
+  // Master-side node -> relay path store, populated from route reports
+  // (spec §4), consulted for downlink source routing.
+  RouteTable routes;
   // Holds a NeighborTable-resolved next hop (not an enrolled peer) so
   // findNextHopToMaster() can return a stable PeerInfo* for a pure relay,
   // which is never added to `peers` (enrollment-only rule).

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -260,6 +260,12 @@ public:
   // Serial adapter helper (optional broadcast)
   static void broadcastAdapterDataStatic(adapter_types type, const uint8_t* data);
 
+  // Serial adapter helper: static shim to sendDownlinkToNode (mirrors
+  // broadcastAdapterDataStatic above) so SerialAdapter can source-route+seal a
+  // targeted server command without holding a Mesh instance itself.
+  static void sendDownlinkToNodeStatic(const uint8_t* destMac, adapter_types type,
+                                       const uint8_t* data);
+
   // Debug helper
   void debugDumpRadio();
 

--- a/main/src/mesh/PeerRegistry.h
+++ b/main/src/mesh/PeerRegistry.h
@@ -20,8 +20,7 @@ struct PeerInfo {
 // Master routing info
 struct MasterInfo {
   uint8_t mac[6];
-  uint8_t distance;   // Hops to master
-  uint8_t nextHop[6]; // Next hop MAC
+  uint8_t distance; // Hops to master
 };
 
 class PeerRegistry {

--- a/main/src/mesh/RouteTable.h
+++ b/main/src/mesh/RouteTable.h
@@ -15,6 +15,12 @@ public:
   RouteTable() = default;
   RouteTable(const RouteTable&) = delete;
   RouteTable& operator=(const RouteTable&) = delete;
+  // Move is fine (and needed so composing types — e.g. Mesh, which now holds
+  // one of these — stay returnable-by-value/relocatable, notably in test
+  // factory helpers). The table holds no pointers or owned resources, only
+  // fixed-size POD entries. Mirrors NeighborTable's rationale.
+  RouteTable(RouteTable&&) = default;
+  RouteTable& operator=(RouteTable&&) = default;
 
   void record(const uint8_t* nodeMac, const uint8_t* path, uint8_t pathLen, uint32_t nowMillis) {
     if (pathLen > config::MAX_HOPS)

--- a/main/src/mesh/RouteTable.h
+++ b/main/src/mesh/RouteTable.h
@@ -1,0 +1,78 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "../../project_config.h"
+
+namespace lattice {
+namespace mesh {
+
+// Master-side RAM route table (spec §4): node MAC -> the relay path from the
+// origin to the master, in origin-to-master forward order, as learned from that
+// node's most recent route report. RAM-only, rebuilt from reports. Routing only,
+// no key material. Bounded by LATTICE_ROUTE_TABLE_MAX; evicts the oldest entry.
+class RouteTable {
+public:
+  RouteTable() = default;
+  RouteTable(const RouteTable&) = delete;
+  RouteTable& operator=(const RouteTable&) = delete;
+
+  void record(const uint8_t* nodeMac, const uint8_t* path, uint8_t pathLen, uint32_t nowMillis) {
+    if (pathLen > config::MAX_HOPS)
+      return; // parse-safety: never store an overlong path
+    Entry* slot = findSlot(nodeMac);
+    if (!slot)
+      slot = allocateSlot();
+    memcpy(slot->nodeMac, nodeMac, 6);
+    slot->pathLen = pathLen;
+    if (pathLen)
+      memcpy(slot->path, path, static_cast<size_t>(pathLen) * 6);
+    slot->lastSeenMillis = nowMillis;
+    slot->valid = true;
+  }
+
+  bool lookup(const uint8_t* nodeMac, uint8_t* pathOut, uint8_t* pathLenOut) const {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i) {
+      const Entry& e = entries[i];
+      if (e.valid && memcmp(e.nodeMac, nodeMac, 6) == 0) {
+        *pathLenOut = e.pathLen;
+        if (e.pathLen)
+          memcpy(pathOut, e.path, static_cast<size_t>(e.pathLen) * 6);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void clear() { memset(entries, 0, sizeof(entries)); }
+
+private:
+  struct Entry {
+    uint8_t nodeMac[6];
+    uint8_t pathLen;
+    bool valid;
+    uint32_t lastSeenMillis;
+    uint8_t path[config::MAX_HOPS * 6]; // 60 bytes, matches route_path[]
+  };
+  Entry entries[config::LATTICE_ROUTE_TABLE_MAX]{};
+
+  Entry* findSlot(const uint8_t* nodeMac) {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (entries[i].valid && memcmp(entries[i].nodeMac, nodeMac, 6) == 0)
+        return &entries[i];
+    return nullptr;
+  }
+
+  Entry* allocateSlot() {
+    for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (!entries[i].valid)
+        return &entries[i];
+    Entry* oldest = &entries[0];
+    for (size_t i = 1; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
+      if (entries[i].lastSeenMillis < oldest->lastSeenMillis)
+        oldest = &entries[i];
+    return oldest;
+  }
+};
+
+} // namespace mesh
+} // namespace lattice

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ add_unit_test(test_mocks              unit/test_mocks.cpp)
 add_unit_test(test_e2e_crypto         unit/test_e2e_crypto.cpp)
 add_unit_test(test_e2e_keystore       unit/test_e2e_keystore.cpp)
 add_unit_test(test_neighbor_table     unit/test_neighbor_table.cpp)
+add_unit_test(test_route_table        unit/test_route_table.cpp)
 
 # ---- E2E simulation target — SIMULATE_MODE recompiles all firmware sources ----
 add_executable(lattice_e2e

--- a/tests/e2e/scenarios/test_harness_smoke.cpp
+++ b/tests/e2e/scenarios/test_harness_smoke.cpp
@@ -265,21 +265,18 @@ TEST(FakeHubTest, OriginMacsPreservedAndFiltersWork) {
   // this comment previously claimed full master->mesh->sensor propagation was
   // broken because Mesh::buildMessage() stamps outgoing ADAPTER_DATA frames'
   // target_mac_address from the sender's own (unset, all-zero) currentMaster.mac.
-  // That claim does not hold for this call path: SerialAdapter::handleCompleteFrame
-  // reaches the mesh via Mesh::broadcastAdapterDataStatic() -> broadcastAdapterData(),
-  // which overwrites target_mac_address to the broadcast address FF:FF:FF:FF:FF:FF
-  // right after buildMessage() runs (Mesh.cpp) -- buildMessage()'s currentMaster.mac
-  // stamp is immediately discarded, never sent. Mesh::processAdapterData() on the
-  // receiving node already special-cases that broadcast target: it delivers locally
-  // (invoking externalRecvCallback / Adapter::onMeshData) AND relays outward for
-  // multi-hop, exactly as this opcode needs. This is exercised directly by
-  // test_mesh_logic.cpp's AdapterDataRelayTest.IntermediateNode_BroadcastTarget_
-  // DeliveredAndRelayed and .BroadcastAdapterData_UsesBroadcastTargetMAC, and
-  // end-to-end (enrollment -> sendConfigSet -> sensor reboots with the new adapter
-  // type) by ServerBroadcastTest.ConfigSetReachesNodeAdapterAndPersists below.
-  // No main/src change was needed for Task 6a; this test's own assertions below
-  // were already correct (they only ever inspected the payload data[], never
-  // target_mac_address) and are left as-is.
+  // That claim does not hold for this call path.
+  //
+  // UPDATE (Task 6, spec §4): a targeted CONFIG_SET (target != FF:FF) no longer
+  // goes out via Mesh::broadcastAdapterDataStatic() at all. SerialAdapter::
+  // handleCompleteFrame now routes it through Mesh::sendDownlinkToNodeStatic(),
+  // which seals the payload with the destination's k_down before it ever hits
+  // ESP-NOW (source-routed if the master already knows a path, flood-fallback
+  // otherwise — still sealed either way) and keeps target_mac_address as the
+  // real destination MAC rather than FF:FF:FF:FF:FF:FF. The opcode is therefore
+  // NOT readable on the wire below; only the destination node's k_down-opened
+  // copy exposes data[0]==OP_CONFIG_SET, proved end-to-end by
+  // ServerBroadcastTest.ConfigSetReachesNodeAdapterAndPersists below.
   //
   // VirtualBus::deliver() collects AND clears each node's ctx().espNowSent within
   // the very same step() call that produced it, so inspecting
@@ -292,20 +289,23 @@ TEST(FakeHubTest, OriginMacsPreservedAndFiltersWork) {
   EXPECT_TRUE(master->ctx().serialRx.empty())
       << "master must have consumed the sendConfigSet frame off its (mock) serial line";
 
-  bool sawConfigSetBroadcast = false;
+  bool sawSealedConfigSetDownlink = false;
   for (const auto& pkt : pendingSends) {
     if (pkt.data.size() != sizeof(mesh_message))
       continue;
     const auto* msg = reinterpret_cast<const mesh_message*>(pkt.data.data());
-    if (msg->data_type == lattice::adapter::SERIAL_ADAPTER && msg->data[0] == OP_CONFIG_SET &&
-        memcmp(&msg->data[1], sensor->mac(), 6) == 0) {
-      sawConfigSetBroadcast = true;
+    if (msg->message_type == MESH_TYPE_ADAPTER_DATA &&
+        msg->data_type == lattice::adapter::SERIAL_ADAPTER &&
+        memcmp(msg->target_mac_address, sensor->mac(), 6) == 0) {
+      sawSealedConfigSetDownlink = true;
+      EXPECT_NE(msg->data[0], OP_CONFIG_SET)
+          << "targeted CONFIG_SET downlink payload must be sealed (ciphertext) on the "
+             "wire, not plaintext";
     }
   }
-  EXPECT_TRUE(sawConfigSetBroadcast)
-      << "master must rebroadcast the CONFIG_SET opcode (data[0]==0xC1) with the "
-         "sensor's mac embedded in the payload, even though full end-to-end "
-         "delivery into the sensor's adapter is a separate, unfixed gap";
+  EXPECT_TRUE(sawSealedConfigSetDownlink)
+      << "master must send a sealed ADAPTER_DATA frame addressed to the sensor's own "
+         "MAC (not broadcast FF:FF), even though decoding it requires the sensor's k_down";
 
   world.run(50); // let VirtualBus deliver/clear the snapshotted frame normally
 

--- a/tests/e2e/scenarios/test_harness_smoke.cpp
+++ b/tests/e2e/scenarios/test_harness_smoke.cpp
@@ -289,18 +289,29 @@ TEST(FakeHubTest, OriginMacsPreservedAndFiltersWork) {
   EXPECT_TRUE(master->ctx().serialRx.empty())
       << "master must have consumed the sendConfigSet frame off its (mock) serial line";
 
+  // NOTE: this used to also assert EXPECT_NE(msg->data[0], OP_CONFIG_SET) as a
+  // proxy for "the payload is sealed ciphertext, not plaintext" — but the
+  // sealed byte is attacker/crypto-controlled and has a ~1/256 chance of
+  // coincidentally equaling OP_CONFIG_SET (0xC1), making that a flaky
+  // assertion. The real, non-flaky signal that this frame took the sealed
+  // targeted-downlink path (rather than the plaintext broadcast path) is its
+  // target MAC: only a genuine broadcast uses FF:FF:FF:FF:FF:FF, and a
+  // targeted downlink is always addressed to the real destination MAC. Assert
+  // that directly instead of inspecting ciphertext bytes.
+  static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
   bool sawSealedConfigSetDownlink = false;
   for (const auto& pkt : pendingSends) {
     if (pkt.data.size() != sizeof(mesh_message))
       continue;
     const auto* msg = reinterpret_cast<const mesh_message*>(pkt.data.data());
     if (msg->message_type == MESH_TYPE_ADAPTER_DATA &&
-        msg->data_type == lattice::adapter::SERIAL_ADAPTER &&
-        memcmp(msg->target_mac_address, sensor->mac(), 6) == 0) {
+        msg->data_type == lattice::adapter::SERIAL_ADAPTER) {
       sawSealedConfigSetDownlink = true;
-      EXPECT_NE(msg->data[0], OP_CONFIG_SET)
-          << "targeted CONFIG_SET downlink payload must be sealed (ciphertext) on the "
-             "wire, not plaintext";
+      EXPECT_EQ(0, memcmp(msg->target_mac_address, sensor->mac(), 6))
+          << "targeted CONFIG_SET downlink must be addressed to the sensor's real MAC";
+      EXPECT_NE(0, memcmp(msg->target_mac_address, kBroadcastMac, 6))
+          << "targeted CONFIG_SET downlink must never use broadcast FF:FF:FF:FF:FF:FF as "
+             "its target — that would mean the payload left unsealed/unopened";
     }
   }
   EXPECT_TRUE(sawSealedConfigSetDownlink)

--- a/tests/e2e/scenarios/test_multihop_e2e.cpp
+++ b/tests/e2e/scenarios/test_multihop_e2e.cpp
@@ -137,3 +137,46 @@ TEST_F(MeshSimTest, RelayLearnsNeighborFromMasterBeacon) {
   });
   EXPECT_TRUE(eligible) << "relay should have learned the master as a neighbor from its beacon";
 }
+
+// Phase 3 (downlink source routing, spec §4): the downlink counterpart of
+// SensorOutOfMasterRangeRelaysThroughMiddleNode above. A leaf out of direct RF
+// range of the master (chain: master -> relay -> leaf, leaf NOT linked to
+// master) receives and applies a server-issued CONFIG_SET that the master had
+// to seal with the leaf's k_down and source-route through the relay
+// (Mesh::sendDownlinkToNode) — the relay cannot read the sealed payload, only
+// forward it one hop further per the route_path header. The master only knows
+// that route once the leaf's periodic route report (ROUTE_REPORT_INTERVAL_MS)
+// has reached it (RouteTable, Task 5), so wait that out first; before then the
+// only path is the sealed flood-fallback, which this test intentionally
+// avoids exercising.
+TEST_F(MeshSimTest, MasterSendsSealedConfigSetThroughRelayToLeaf) {
+  addMaster();
+  auto* relay = addSensor(MAC_NODE_A);
+  auto* leaf = addSensor(MAC_NODE_B);
+  world.bus.link(master, relay);
+  world.bus.link(relay, leaf);
+  enroll(relay);
+  enroll(leaf);
+
+  // Let the leaf's periodic route report reach the master so it learns the
+  // relay path (RouteTable) before the downlink is issued.
+  runPolled(lattice::config::ROUTE_REPORT_INTERVAL_MS + 5000);
+
+  auto typeOf = [](sim::SimNode* n) {
+    return n->with(
+        [](lattice::mesh::Mesh&, lattice::adapter::Adapter* a) { return a->getAdapterType(); });
+  };
+  ASSERT_EQ(typeOf(leaf), lattice::adapter::PIR_ADAPTER) << "precondition: leaf starts as PIR";
+  ASSERT_EQ(typeOf(relay), lattice::adapter::PIR_ADAPTER) << "precondition: relay starts as PIR";
+
+  hub->sendConfigSet(leaf->mac(), lattice::adapter::SERIAL_ADAPTER);
+  runPolled(5000); // master seals+source-routes -> relay forwards -> leaf opens+applies+reboots
+
+  EXPECT_EQ(typeOf(leaf), lattice::adapter::SERIAL_ADAPTER)
+      << "leaf must open the sealed downlink with its k_down and apply the CONFIG_SET despite "
+         "being 2 hops from the master";
+  EXPECT_EQ(typeOf(relay), lattice::adapter::PIR_ADAPTER)
+      << "a relay forwarding a downlink addressed to another node must not apply it itself";
+  EXPECT_FALSE(relay->restartRequested())
+      << "the relay must never locally deliver a downlink addressed to the leaf";
+}

--- a/tests/e2e/scenarios/test_route_report_e2e.cpp
+++ b/tests/e2e/scenarios/test_route_report_e2e.cpp
@@ -15,6 +15,8 @@
 #include "harness/MeshSimTest.h"
 #include "lib/lattice-protocol/c/opcodes.h"
 #include "project_config.h"
+#include "src/adapter/Adapter.h"
+#include "mesh/Mesh.h"
 
 // A directly-linked (distance-1) enrolled node's route report reaches the hub
 // with the right opcode and origin, and an empty hop chain (no relays between
@@ -39,25 +41,25 @@ TEST_F(MeshSimTest, DirectNodeRouteReportReachesHub) {
 }
 
 // Multi-hop hop-chain: leaf (distance 2) emits a route report that the relay
-// appends its MAC to before forwarding to the master, so the hub sees
-// path_len >= 1 with the relay's MAC first.
+// appends its MAC to (in the plaintext route_path header, spec §4) before
+// forwarding to the master, so the master learns a path with the relay's MAC
+// first.
 //
-// DISABLED: this requires multi-hop DATA uplink (leaf -> relay -> master for a
-// node-originated frame). The current firmware cannot route data at hop
-// distance >= 2 — sendRouteReport() returns false because findNextHopToMaster()
-// is null when the next hop (the relay) is not a registered, in-range peer.
-// Same root cause as the multi-hop data-uplink gap documented in
-// docs/design-gaps/multihop-data-uplink.md.
+// Header-field design (spec §4): the route report's opcode payload
+// (data[0]/data[1]) is E2E-sealed origin->master, so a relay can no longer
+// read/append to it (Mesh::processRouteReport's relay branch just forwards the
+// sealed frame unmodified) — that's why data[1] is a reserved constant 0 (see
+// DirectNodeRouteReportReachesHub above) regardless of hop count. Path
+// accumulation instead happens in the plaintext mesh_message header fields
+// route_len/route_path, which each relay appends to before re-transmitting.
 //
-// Task 6 (E2E AEAD) note: even once multi-hop uplink lands, the path-chain
-// assertions below are now STALE — the payload is E2E-sealed origin->master,
-// so a relay can no longer read/append to msg.data (Mesh::processRouteReport's
-// relay branch just forwards the sealed frame unmodified). Path accumulation
-// moves to the header route_path field in a future phase (spec §4); until
-// then the hub-side expectation is path_len == 0 (empty path) regardless of
-// hop count. Assertions below are stale pre-AEAD intent, kept for history —
-// rewrite them (pathLen == 0, no relay-MAC check) before dropping DISABLED_.
-TEST_F(MeshSimTest, DISABLED_RouteReportCarriesHopChain) {
+// Those header fields are mesh-internal (ESP-NOW) only, not part of the
+// serial wire protocol to the hub (SerialFraming/mesh.pb.h carry no
+// route_len/route_path field), so hub->ofType() frames can't be used to
+// inspect them — read the path the master actually recorded instead
+// (Mesh::processRouteReport -> RouteTable, Task 5's "master records node
+// routes from route reports").
+TEST_F(MeshSimTest, RouteReportCarriesHopChain) {
   addMaster();
   auto* relay = addSensor(MAC_NODE_A);
   auto* leaf = addSensor(MAC_NODE_B);
@@ -68,16 +70,23 @@ TEST_F(MeshSimTest, DISABLED_RouteReportCarriesHopChain) {
 
   runPolled(lattice::config::ROUTE_REPORT_INTERVAL_MS + 5000);
 
+  bool found = false;
+  uint8_t path[lattice::config::MAX_HOPS * 6] = {};
+  uint8_t pathLen = 0;
+  master->with([&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) {
+    found = m.testRoutes().lookup(leaf->mac(), path, &pathLen);
+    return 0;
+  });
+  ASSERT_TRUE(found) << "master must record a route to the leaf from its route reports";
+  ASSERT_GE(pathLen, 1);
+  EXPECT_EQ(memcmp(&path[0], relay->mac(), 6), 0)
+      << "first relay in the leaf's path is the middle node";
+
   bool sawLeafRoute = false;
   for (const auto& m : hub->ofType(MESH_TYPE_ROUTE_REPORT)) {
     if (memcmp(m.origin_mac_address, leaf->mac(), 6) != 0)
       continue;
-    ASSERT_EQ(m.data[0], OP_ROUTE_REPORT);
-    uint8_t pathLen = m.data[1];
-    ASSERT_GE(pathLen, 1);
-    // First hop MAC in the chain must be the relay node.
-    EXPECT_EQ(memcmp(&m.data[2], relay->mac(), 6), 0);
     sawLeafRoute = true;
   }
-  EXPECT_TRUE(sawLeafRoute) << "leaf's route report must reach the hub via the relay";
+  EXPECT_TRUE(sawLeafRoute) << "leaf's route report reaches the hub carrying its relay path";
 }

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -862,6 +862,146 @@ TEST_F(JoinAckRelayTest, DownlinkLastRelayForwardsToTarget) {
   EXPECT_TRUE(wasSentTo(leaf)) << "last relay forwards to target_mac";
 }
 
+// ─── Config-opcode injection resistance (CRITICAL finding) ──────────────────
+// Phase 3 seals+source-routes TARGETED downlink CONFIG_SET/NODE_ID_SET, and a
+// node opens a self-addressed sealed ADAPTER_DATA with its k_down before
+// honoring it (see the node-side E2E open block in processAdapterData). But a
+// forged BROADCAST (target FF:FF:FF:FF:FF:FF) ADAPTER_DATA frame is never
+// addressedToSelf, so it is never opened — it stays plaintext. Since
+// origin_mac is attacker-controlled on the wire and the master's real MAC is
+// public (broadcast in every beacon), a forged broadcast frame with
+// origin_mac spoofed to the master passes the origin check too. Without a
+// guard, this reaches externalRecvCallback (-> Adapter::onMeshData ->
+// ESP.restart()) completely unauthenticated: one plaintext RF frame reboots
+// or reconfigures any node.
+
+class ConfigOpcodeInjectionTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    EEPROM.reset();
+    resetMillis();
+    resetEspNowMock();
+    lattice::mesh::crypto::generateKeypair(nodePriv, nodePub);
+    lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  }
+
+  static constexpr uint8_t kMyMac[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  static constexpr uint8_t kMasterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  static constexpr uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+  uint8_t nodePriv[32], nodePub[32];
+  uint8_t masterPriv[32], masterPub[32];
+
+  // A non-master node enrolled under kMasterMac with real Curve25519 keys, so
+  // masterE2EKeys() can derive the same k_down the master would use to seal a
+  // legitimate targeted downlink.
+  Mesh makeEnrolledNode() {
+    Mesh mesh;
+    memcpy(mesh.deviceMacAddress, kMyMac, 6);
+    mesh.isMaster = false;
+    memcpy(mesh.enrollment.devicePrivateKey, nodePriv, 32);
+    memcpy(mesh.enrollment.devicePublicKey, nodePub, 32);
+    mesh.enrollment.hasMasterMac = true;
+    memcpy(mesh.enrollment.knownMasterMac, kMasterMac, 6);
+    memcpy(mesh.currentMaster.mac, kMasterMac, 6);
+    mesh.currentMaster.distance = 1;
+    PeerInfo master{};
+    memcpy(master.mac, kMasterMac, 6);
+    memcpy(master.publicKey, masterPub, 32);
+    master.lastSeenMillis = 0;
+    mesh.peers.append(master);
+    return mesh;
+  }
+
+  // Exactly the attack in the finding: BROADCAST target, SERIAL_ADAPTER
+  // data_type, data[0]=OP_CONFIG_SET, data[1..6]=victim's own MAC,
+  // origin_mac spoofed to the master's public MAC, NOT sealed.
+  mesh_message makeForgedBroadcastConfigSet() {
+    mesh_message m{};
+    m.proto_version = PROTO_VERSION;
+    m.message_type = MESH_TYPE_ADAPTER_DATA;
+    m.data_type = adapter_types::SERIAL_ADAPTER;
+    memcpy(m.origin_mac_address, kMasterMac, 6); // spoofed: master's public MAC
+    memcpy(m.target_mac_address, kBroadcastMac, 6); // forged: broadcast, never opened
+    memcpy(m.last_hop_mac_address, kMasterMac, 6);
+    m.epoch_num = 1;
+    m.seq_num = 1;
+    m.data[0] = OP_CONFIG_SET;
+    memcpy(&m.data[1], kMyMac, 6); // victim's own MAC as the opcode's target field
+    m.data[7] = 0x02;              // attacker-chosen adapter type
+    // NOT sealed — plaintext, exactly as an RF attacker would send it.
+    return m;
+  }
+};
+
+constexpr uint8_t ConfigOpcodeInjectionTest::kMyMac[];
+constexpr uint8_t ConfigOpcodeInjectionTest::kMasterMac[];
+constexpr uint8_t ConfigOpcodeInjectionTest::kBroadcastMac[];
+
+TEST_F(ConfigOpcodeInjectionTest, ForgedBroadcastConfigSet_NotDeliveredToExternalCallback) {
+  Mesh mesh = makeEnrolledNode();
+  bool sawConfigSet = false;
+  mesh.linkDataRecvCallback([&](const mesh_message& m) {
+    if (m.data_type == adapter_types::SERIAL_ADAPTER && m.data[0] == OP_CONFIG_SET)
+      sawConfigSet = true;
+  });
+
+  mesh.processAdapterData(makeForgedBroadcastConfigSet());
+
+  EXPECT_FALSE(sawConfigSet)
+      << "a forged plaintext BROADCAST CONFIG_SET must never reach externalRecvCallback — "
+         "it was never addressedToSelf, so it was never opened/authenticated with k_down";
+}
+
+TEST_F(ConfigOpcodeInjectionTest, ForgedBroadcastNodeIdSet_NotDeliveredToExternalCallback) {
+  Mesh mesh = makeEnrolledNode();
+  int deliveredCount = 0;
+  mesh.linkDataRecvCallback([&](const mesh_message&) { ++deliveredCount; });
+
+  mesh_message forged = makeForgedBroadcastConfigSet();
+  forged.data[0] = OP_NODE_ID_SET;
+  forged.data[7] = 0x42; // attacker-chosen node ID
+
+  mesh.processAdapterData(forged);
+
+  EXPECT_EQ(deliveredCount, 0)
+      << "a forged plaintext BROADCAST NODE_ID_SET must never reach externalRecvCallback";
+}
+
+// Legitimate counterpart: a genuinely targeted, sealed CONFIG_SET
+// (addressedToSelf, opened with k_down) must still be delivered — the guard
+// above must not overreach and break the real downlink path.
+TEST_F(ConfigOpcodeInjectionTest, TargetedSealedConfigSet_StillDelivered) {
+  Mesh mesh = makeEnrolledNode();
+  const uint8_t *kUp, *kDown;
+  ASSERT_TRUE(mesh.masterE2EKeys(&kUp, &kDown));
+
+  mesh_message msg{};
+  msg.proto_version = PROTO_VERSION;
+  msg.message_type = MESH_TYPE_ADAPTER_DATA;
+  msg.data_type = adapter_types::SERIAL_ADAPTER;
+  memcpy(msg.origin_mac_address, kMasterMac, 6);
+  memcpy(msg.target_mac_address, kMyMac, 6); // targeted, not broadcast
+  memcpy(msg.last_hop_mac_address, kMasterMac, 6);
+  msg.epoch_num = 1;
+  msg.seq_num = 1;
+  msg.data[0] = OP_CONFIG_SET;
+  memcpy(&msg.data[1], kMyMac, 6);
+  msg.data[7] = 0x02;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kDown, msg));
+
+  bool sawConfigSet = false;
+  mesh.linkDataRecvCallback([&](const mesh_message& m) {
+    if (m.data_type == adapter_types::SERIAL_ADAPTER && m.data[0] == OP_CONFIG_SET)
+      sawConfigSet = true;
+  });
+
+  mesh.processAdapterData(msg);
+
+  EXPECT_TRUE(sawConfigSet) << "a genuinely targeted, sealed CONFIG_SET (addressedToSelf, "
+                               "opened with k_down) must still be delivered";
+}
+
 // ─── JOIN_ACK forgery resistance ─────────────────────────────────────────────
 // JOIN_ACKs travel over the unencrypted broadcast peer, and everything a forger
 // needs is observable over the air: the victim's pubkey prefix (broadcast in its

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -336,7 +336,6 @@ protected:
     mesh.isMaster = false;
     // Set master route: next hop IS the master (1 hop away)
     memcpy(mesh.currentMaster.mac, kMasterMac, 6);
-    memcpy(mesh.currentMaster.nextHop, kMasterMac, 6);
     mesh.currentMaster.distance = 1;
     mesh.enrollment.hasMasterMac = true;
     memcpy(mesh.enrollment.knownMasterMac, kMasterMac, 6);
@@ -671,7 +670,6 @@ TEST_F(JoinAckRelayTest, JoinAckAddressedToSelf_RegistersMasterAsRoutablePeer) {
   // And the route must actually resolve once a beacon establishes the topology
   // (nextHop = master, one hop) — the end goal of registering the master.
   memcpy(mesh.currentMaster.mac, kMasterMac, 6);
-  memcpy(mesh.currentMaster.nextHop, kMasterMac, 6);
   mesh.currentMaster.distance = 1;
   EXPECT_NE(mesh.findNextHopToMaster(), nullptr)
       << "uplink route must resolve through the newly registered master peer";

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -862,6 +862,44 @@ TEST_F(JoinAckRelayTest, DownlinkLastRelayForwardsToTarget) {
   EXPECT_TRUE(wasSentTo(leaf)) << "last relay forwards to target_mac";
 }
 
+// Whole-branch-review finding: the downlink relay-forward branch never opens
+// the sealed frame, so route_path[i+1] is attacker-controlled plaintext. An RF
+// attacker can craft ADAPTER_DATA with this relay at route_path[i] and a fresh
+// distinct MAC at route_path[i+1] on every frame (dodging replay dedup via
+// fresh epoch/seq at the network entry point) to permanently grow the ESP-NOW
+// peer table one entry per frame — spec §2's "20-peer cap, LRU-evicted" must
+// bound this the same way Phase 2 bounded the uplink forwardingPeer.
+TEST_F(JoinAckRelayTest, DownlinkRelayForward_BoundsAutoRegisteredPeers_NeverEvictsEnrolled) {
+  Mesh mesh = makeIntermediateNode(); // kPeerMac is an ENROLLED peer — must never be evicted
+  // Mirror what setupEspNow()/addPeer() do for a real enrolled peer at boot
+  // (the fixture's peers.append() above only populates the PeerRegistry).
+  lattice::mesh::crypto::registerPeerWithEspNow(kPeerMac);
+
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  const int kFloodCount = static_cast<int>(lattice::config::LATTICE_DOWNLINK_PEER_MAX) + 6;
+  for (int i = 0; i < kFloodCount; ++i) {
+    mesh_message dl{};
+    dl.proto_version = PROTO_VERSION;
+    dl.message_type = MESH_TYPE_ADAPTER_DATA;
+    memcpy(dl.target_mac_address, leaf, 6);
+    dl.route_len = 2;
+    memcpy(&dl.route_path[0], kMyMac, 6); // this node is at route_path[0]
+    // Fresh, distinct MAC at route_path[1] on every iteration — the attack.
+    uint8_t nextMac[6] = {0x03, 0, 0, 0, static_cast<uint8_t>((i >> 8) & 0xFF),
+                          static_cast<uint8_t>(i & 0xFF)};
+    memcpy(&dl.route_path[6], nextMac, 6);
+    dl.epoch_num = 1;
+    dl.seq_num = static_cast<uint16_t>(i + 1);
+
+    mesh.processAdapterData(dl);
+  }
+
+  EXPECT_LE(espNowRegisteredPeers.size(), 1 + lattice::config::LATTICE_DOWNLINK_PEER_MAX)
+      << "auto-registered downlink forwarding peers must stay bounded by the LRU cap";
+  EXPECT_TRUE(esp_now_is_peer_exist(kPeerMac))
+      << "enrolled peer must never be evicted by downlink forwarding-peer churn";
+}
+
 // ─── Config-opcode injection resistance (CRITICAL finding) ──────────────────
 // Phase 3 seals+source-routes TARGETED downlink CONFIG_SET/NODE_ID_SET, and a
 // node opens a self-addressed sealed ADAPTER_DATA with its k_down before

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -7,6 +7,7 @@
 #include "esp_now_mock.h"
 #include "time_mock.h"
 #include "EEPROM.h"
+#include "lib/lattice-protocol/c/opcodes.h"
 
 using namespace lattice::mesh;
 
@@ -570,6 +571,36 @@ protected:
     return mesh;
   }
 
+  // A master with one enrolled leaf (real Curve25519 keys, so peerE2EKeys can
+  // actually derive k_down for sendDownlinkToNode's sealing step).
+  Mesh makeMasterNode() {
+    Mesh mesh;
+    static constexpr uint8_t kThisMasterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+    static constexpr uint8_t kLeafMac[6] = {0x02, 0, 0, 0, 0, 0x0B};
+    memcpy(mesh.deviceMacAddress, kThisMasterMac, 6);
+    mesh.isMaster = true;
+    uint8_t masterPriv[32], masterPub[32], leafPriv[32], leafPub[32];
+    lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+    lattice::mesh::crypto::generateKeypair(leafPriv, leafPub);
+    memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+    memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+    PeerInfo leaf{};
+    memcpy(leaf.mac, kLeafMac, 6);
+    memcpy(leaf.publicKey, leafPub, 32);
+    leaf.lastSeenMillis = 0;
+    mesh.peers.append(leaf);
+    return mesh;
+  }
+
+  // A bare relay node identified only by its MAC — used to exercise the
+  // stateless downlink forwarding branch of processAdapterData in isolation.
+  Mesh makeIntermediateNodeWithMac(const uint8_t mac[6]) {
+    Mesh mesh;
+    memcpy(mesh.deviceMacAddress, mac, 6);
+    mesh.isMaster = false;
+    return mesh;
+  }
+
   mesh_message makeJoinAck(const uint8_t target[6], uint8_t hopCount = 1) {
     mesh_message m{};
     m.proto_version = 1;
@@ -734,6 +765,101 @@ TEST_F(JoinAckRelayTest, MultiHopForwardingPeer_BoundToOne_EvictsStaleRelayOnSwi
   // Bound: enrolled peer (kPeerMac) + at most one auto-registered forwarding peer.
   EXPECT_EQ(espNowRegisteredPeers.size(), 2u)
       << "auto-registered forwarding peers must stay bounded to one";
+}
+
+// ─── sendDownlinkToNode / source-routed downlink relay ──────────────────────
+// Helpers to inspect captured ESP-NOW sends by destination MAC — esp_now_send
+// serializes to raw bytes, so deserialize back into a mesh_message to inspect.
+
+static bool wasSentTo(const uint8_t* mac) {
+  for (const auto& pkt : espNowSentPackets) {
+    if (!pkt.isBroadcast && memcmp(pkt.addr, mac, 6) == 0)
+      return true;
+  }
+  return false;
+}
+
+static mesh_message lastEspNowSentTo(const uint8_t* mac) {
+  for (auto it = espNowSentPackets.rbegin(); it != espNowSentPackets.rend(); ++it) {
+    if (!it->isBroadcast && memcmp(it->addr, mac, 6) == 0) {
+      mesh_message m{};
+      memcpy(&m, it->data.data(), sizeof(m));
+      return m;
+    }
+  }
+  ADD_FAILURE() << "no ESP-NOW packet was sent to the requested MAC";
+  return mesh_message{};
+}
+
+// (a) Master with a known route source-routes to the first hop, target=dest, sealed.
+TEST_F(JoinAckRelayTest, DownlinkSourceRoutesViaFirstHop) {
+  Mesh master = makeMasterNode(); // fixture master with an enrolled leaf + keys
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+  const uint8_t R2[6] = {0x02, 0, 0, 0, 0, 0x22};
+  uint8_t path[12];
+  memcpy(path, R1, 6);
+  memcpy(path + 6, R2, 6); // origin->R1->R2->master
+  master.testRoutes().record(leaf, path, 2, 1000);
+
+  resetEspNowMock();
+  uint8_t cmd[64] = {};
+  cmd[0] = OP_CONFIG_SET;
+  master.sendDownlinkToNode(leaf, adapter_types::SERIAL_ADAPTER, cmd);
+
+  // Reversed path [R2,R1]; first hop = R2.
+  ASSERT_TRUE(wasSentTo(R2));
+  mesh_message sent = lastEspNowSentTo(R2);
+  EXPECT_EQ(sent.route_len, 2);
+  EXPECT_EQ(0, memcmp(&sent.route_path[0], R2, 6));
+  EXPECT_EQ(0, memcmp(&sent.route_path[6], R1, 6));
+  EXPECT_EQ(0, memcmp(sent.target_mac_address, leaf, 6));
+  // payload sealed: data[0] != plaintext opcode
+  EXPECT_NE(sent.data[0], OP_CONFIG_SET);
+  // first hop auto-registered as ESP-NOW peer (VirtualBus doesn't enforce this,
+  // so assert it explicitly — the Phase-2 lesson).
+  EXPECT_TRUE(esp_now_is_peer_exist(R2));
+}
+
+// (b) A relay in the path forwards to the next index, unchanged frame.
+TEST_F(JoinAckRelayTest, DownlinkRelayForwardsToNextIndex) {
+  static constexpr uint8_t kR2[6] = {0x02, 0, 0, 0, 0, 0x22};
+  Mesh r2 = makeIntermediateNodeWithMac(kR2);
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+  mesh_message dl = {};
+  dl.proto_version = PROTO_VERSION;
+  dl.message_type = MESH_TYPE_ADAPTER_DATA;
+  memcpy(dl.target_mac_address, leaf, 6);
+  dl.route_len = 2;
+  memcpy(&dl.route_path[0], r2.testDeviceMac(), 6); // R2
+  memcpy(&dl.route_path[6], R1, 6);
+  dl.epoch_num = 7;
+  dl.seq_num = 3;
+
+  resetEspNowMock();
+  r2.processAdapterData(dl); // reachable directly — public under UNIT_TEST
+  EXPECT_TRUE(wasSentTo(R1)) << "R2 forwards to route_path[1]=R1";
+}
+
+// (c) Last relay forwards to target_mac.
+TEST_F(JoinAckRelayTest, DownlinkLastRelayForwardsToTarget) {
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  static constexpr uint8_t kR1[6] = {0x02, 0, 0, 0, 0, 0x11};
+  Mesh r1 = makeIntermediateNodeWithMac(kR1); // R1
+  mesh_message dl = {};
+  dl.proto_version = PROTO_VERSION;
+  dl.message_type = MESH_TYPE_ADAPTER_DATA;
+  memcpy(dl.target_mac_address, leaf, 6);
+  dl.route_len = 2;
+  const uint8_t R2mac[6] = {0x02, 0, 0, 0, 0, 0x22};
+  memcpy(&dl.route_path[0], R2mac, 6);
+  memcpy(&dl.route_path[6], r1.testDeviceMac(), 6); // R1 at index 1 (last)
+  dl.epoch_num = 7;
+  dl.seq_num = 4;
+  resetEspNowMock();
+  r1.processAdapterData(dl);
+  EXPECT_TRUE(wasSentTo(leaf)) << "last relay forwards to target_mac";
 }
 
 // ─── JOIN_ACK forgery resistance ─────────────────────────────────────────────

--- a/tests/unit/test_route_report.cpp
+++ b/tests/unit/test_route_report.cpp
@@ -35,7 +35,6 @@ protected:
     memcpy(mesh.enrollment.knownMasterMac, masterMac, 6);
     memcpy(mesh.currentMaster.mac, masterMac, 6);
     mesh.currentMaster.distance = 1;
-    memcpy(mesh.currentMaster.nextHop, masterMac, 6);
     memcpy(mesh.enrollment.devicePrivateKey, myPriv, 32);
     memcpy(mesh.enrollment.devicePublicKey, myPub, 32);
 

--- a/tests/unit/test_route_report.cpp
+++ b/tests/unit/test_route_report.cpp
@@ -249,6 +249,55 @@ TEST_F(RouteReportTest, ProcessRouteReport_MasterDeliversToCallback) {
   EXPECT_EQ(received.data[0], OP_ROUTE_REPORT);
 }
 
+// Task 4 (spec §4): the master must learn the origin's relay path from the
+// route report so it can later source-route a downlink back to that node.
+// The path is recorded from the RAW msg's plaintext route_path/route_len
+// header fields (accumulated hop-by-hop by relays), NOT from the sealed
+// payload — mirrors ProcessRouteReport_MasterDeliversToCallback above for
+// the E2E open/keying setup.
+TEST_F(RouteReportTest, ProcessRouteReport_MasterRecordsRouteFromReport) {
+  const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  const uint8_t r1[6]        = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x01};
+  const uint8_t r2[6]        = {0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0x02};
+  Mesh mesh;
+  mesh.isMaster = true;
+
+  // Task 6 (E2E AEAD): master opens the sealed payload before delivering to
+  // the callback — register the origin as a keyed peer and seal accordingly.
+  uint8_t originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(masterPriv, masterPub);
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  memcpy(mesh.enrollment.devicePrivateKey, masterPriv, 32);
+  memcpy(mesh.enrollment.devicePublicKey, masterPub, 32);
+  PeerInfo origin{};
+  memcpy(origin.mac, originMac, 6);
+  memcpy(origin.publicKey, originPub, 32);
+  origin.lastSeenMillis = 0;
+  mesh.peers.append(origin);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
+
+  mesh_message msg{};
+  msg.proto_version = PROTO_VERSION;
+  msg.message_type = MESH_TYPE_ROUTE_REPORT;
+  memcpy(msg.origin_mac_address, originMac, 6);
+  msg.route_len = 2;
+  memcpy(&msg.route_path[0], r1, 6);
+  memcpy(&msg.route_path[6], r2, 6);
+  msg.data[0] = OP_ROUTE_REPORT;
+  msg.data[1] = 2;
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
+
+  mesh.processRouteReport(msg);
+
+  uint8_t out[60];
+  uint8_t len = 0;
+  ASSERT_TRUE(mesh.testRoutes().lookup(originMac, out, &len));
+  EXPECT_EQ(len, 2);
+  EXPECT_EQ(memcmp(&out[0], r1, 6), 0);
+  EXPECT_EQ(memcmp(&out[6], r2, 6), 0);
+}
+
 // Replaces the old ProcessRouteReport_PathFullDropsMessage: the path-length
 // guard was part of the relay-side path-accumulation feature this task
 // removes (spec §4 — a relay can no longer read msg.data at all). The

--- a/tests/unit/test_route_report.cpp
+++ b/tests/unit/test_route_report.cpp
@@ -152,6 +152,62 @@ TEST_F(RouteReportTest, ProcessRouteReport_RelayForwardsSealedFrameUnmodified) {
   EXPECT_EQ(sent.hop_count, 2);
 }
 
+// Task 3 (Phase 3, spec §4): route_len/route_path are plaintext header fields
+// excluded from the AEAD AAD (E2ECrypto.h buildAad — 24 bytes: version, type,
+// data_type, origin, target, epoch, seq), so a relay can accumulate the
+// origin->master relay chain there without touching (or invalidating) the
+// E2E-sealed payload. This is the replacement for the msg.data-based path
+// accumulation that Task 6's AEAD work removed (see
+// ProcessRouteReport_RelayForwardsSealedFrameUnmodified above).
+TEST_F(RouteReportTest, RelayAppendsOwnMacToRoutePath) {
+  const uint8_t masterMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  const uint8_t myMac[6]     = {0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01};
+  Mesh mesh;
+  setupRelayNode(mesh, masterMac);
+  memcpy(mesh.deviceMacAddress, myMac, 6); // set after setupRelayNode (which overwrites it)
+
+  // Seal a real E2E payload (origin -> master) so this test also proves the
+  // route_path/route_len write does not invalidate the AEAD tag: buildAad()
+  // (E2ECrypto.h) covers only proto_version/message_type/data_type/origin/
+  // target/epoch/seq — route_len and route_path are outside the AAD.
+  uint8_t originPriv[32], originPub[32];
+  lattice::mesh::crypto::generateKeypair(originPriv, originPub);
+  uint8_t kUp[32], kDown[32];
+  lattice::mesh::crypto::deriveE2EKeys(originPriv, masterPub, kUp, kDown);
+
+  mesh_message msg{};
+  msg.proto_version = PROTO_VERSION;
+  msg.message_type = MESH_TYPE_ROUTE_REPORT;
+  msg.data_type = 0;
+  msg.hop_count = 0;
+  msg.route_len = 0; // origin sent an empty path
+  msg.epoch_num = 5;
+  msg.seq_num = 1;
+  memcpy(msg.origin_mac_address, originMac, 6);
+  memcpy(msg.target_mac_address, masterMac, 6);
+  msg.data[0] = OP_ROUTE_REPORT;
+  msg.data[1] = 0;
+  uint8_t plaintext[64];
+  memcpy(plaintext, msg.data, sizeof(plaintext));
+  ASSERT_TRUE(lattice::mesh::crypto::sealPayload(kUp, msg));
+
+  size_t before = espNowSentPackets.size();
+  mesh.processRouteReport(msg);
+
+  ASSERT_EQ(espNowSentPackets.size(), before + 1);
+  mesh_message sent = lastSentMsg();
+  ASSERT_EQ(sent.route_len, 1) << "relay appended its own MAC";
+  EXPECT_EQ(memcmp(&sent.route_path[0], myMac, 6), 0);
+
+  // Self-review (spec §4 AAD claim): the forwarded frame's sealed payload must
+  // still open with the same k_up and recover the original plaintext, proving
+  // the route_path/route_len write did not break the AEAD tag.
+  ASSERT_TRUE(lattice::mesh::crypto::openPayload(kUp, sent))
+      << "sealed payload must still open after relay writes route_path/route_len";
+  EXPECT_EQ(memcmp(sent.data, plaintext, sizeof(plaintext)), 0);
+}
+
 TEST_F(RouteReportTest, ProcessRouteReport_MasterDeliversToCallback) {
   const uint8_t originMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
   Mesh mesh;

--- a/tests/unit/test_route_table.cpp
+++ b/tests/unit/test_route_table.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include "src/mesh/RouteTable.h"
+
+using namespace lattice::mesh;
+
+static const uint8_t NODE[6] = {0x02, 0, 0, 0, 0, 0xEE};
+static const uint8_t R1[6] = {0x02, 0, 0, 0, 0, 0x11};
+static const uint8_t R2[6] = {0x02, 0, 0, 0, 0, 0x22};
+
+TEST(RouteTable, RecordsAndLooksUpPath) {
+  RouteTable t;
+  uint8_t path[12];
+  memcpy(path, R1, 6);
+  memcpy(path + 6, R2, 6);
+  t.record(NODE, path, 2, 1000);
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(NODE, out, &outLen));
+  EXPECT_EQ(outLen, 2);
+  EXPECT_EQ(0, memcmp(out, R1, 6));
+  EXPECT_EQ(0, memcmp(out + 6, R2, 6));
+}
+
+TEST(RouteTable, LookupMissReturnsFalse) {
+  RouteTable t;
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}
+
+TEST(RouteTable, RecordUpdatesExistingNode) {
+  RouteTable t;
+  uint8_t p1[6];
+  memcpy(p1, R1, 6);
+  t.record(NODE, p1, 1, 1000); // path via R1
+  uint8_t p2[12];
+  memcpy(p2, R2, 6);
+  memcpy(p2 + 6, R1, 6);
+  t.record(NODE, p2, 2, 2000); // newer path via R2,R1
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(NODE, out, &outLen));
+  EXPECT_EQ(outLen, 2);
+  EXPECT_EQ(0, memcmp(out, R2, 6));
+}
+
+TEST(RouteTable, RejectsOverlongPath) {
+  RouteTable t;
+  uint8_t big[66] = {};
+  t.record(NODE, big, 11, 1000); // 11 > MAX_HOPS(10) → ignored
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}
+
+TEST(RouteTable, EvictsOldestWhenFull) {
+  RouteTable t;
+  uint8_t p[6] = {0x02, 0, 0, 0, 0, 0x01};
+  // Fill: node i observed at time (i+1)*100; node 0 is oldest.
+  for (size_t i = 0; i < lattice::config::LATTICE_ROUTE_TABLE_MAX; ++i) {
+    uint8_t mac[6] = {0x02, 0, 0, 0, 0, static_cast<uint8_t>(0x80 + i)};
+    t.record(mac, p, 1, static_cast<uint32_t>((i + 1) * 100));
+  }
+  uint8_t oldest[6] = {0x02, 0, 0, 0, 0, 0x80}; // observed at t=100
+  uint8_t out[60], outLen = 0;
+  ASSERT_TRUE(t.lookup(oldest, out, &outLen));
+  // Insert one more (fresh) node → oldest must be evicted.
+  t.record(NODE, p, 1, 999999);
+  EXPECT_FALSE(t.lookup(oldest, out, &outLen)) << "oldest entry evicted";
+  EXPECT_TRUE(t.lookup(NODE, out, &outLen)) << "new entry present";
+}
+
+TEST(RouteTable, ClearEmpties) {
+  RouteTable t;
+  uint8_t p[6] = {0x02, 0, 0, 0, 0, 0x01};
+  t.record(NODE, p, 1, 1000);
+  t.clear();
+  uint8_t out[60], outLen = 0;
+  EXPECT_FALSE(t.lookup(NODE, out, &outLen));
+}


### PR DESCRIPTION
## What

Phase 3 completes spec §4 (downlink source routing) and §2 for the downlink direction, and closes the Phase-1 command-injection window.

- **Route reports accumulate the relay path** in the plaintext `route_path[]` header (relays append their own MAC in flight — legal because `route_path`/`route_len` are excluded from the AEAD AAD). The master receives the full origin→master relay chain.
- **Master `RouteTable`** (`main/src/mesh/RouteTable.h`, RAM-only, `LATTICE_ROUTE_TABLE_MAX`=32): node MAC → path, rebuilt from route reports.
- **Source-routed sealed downlink** (`sendDownlinkToNode`): the master reverses the learned path into `route_path[]`, sets `target_mac` to the destination, seals the payload with the destination's **k_down**, and unicasts to the first hop. Relays find their own MAC in `route_path[]` and forward statelessly to the next index (or `target_mac` when last). No known route → sealed broadcast-flood fallback.
- **Node opens downlink with k_down**; the master opens uplink with k_up (direction split preserved).
- **Command-injection window closed**: config opcodes (`CONFIG_SET`/`NODE_ID_SET`) are honored **only** after a successful E2E open. A forged broadcast/plaintext command with a spoofed master origin is dropped before delivery.
- **Bounded peers**: downlink auto-registered forwarding peers use an LRU (`LATTICE_DOWNLINK_PEER_MAX`=4) that never evicts enrolled peers or the master — closes an ESP-NOW peer-exhaustion vector (spec §2).
- **Cleanup**: removed the dead `MasterInfo::nextHop` field and the stale `MAX_ROUTE_PATH_LEN`.

## Security (adversarial)

- Targeted forgery: a frame not sealed to the node fails `openPayload` → dropped.
- Broadcast forgery: config opcodes gated on successful E2E open → dropped before honoring.
- `target_mac` is AAD-bound (a relay can't redirect a sealed frame). `route_path` is plaintext + relay-asserted → at worst misrouted downlink (DoS-class, documented); payload stays sealed, all indexing bounds-checked to `MAX_HOPS`.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md` §1, §2, §4
- Plan: `docs/superpowers/plans/2026-07-21-phase3-downlink-source-routing.md`

## Test

176 pass / **0 disabled** — the last disabled test (`RouteReportCarriesHopChain`) is enabled and rewritten for the header-field design. New: RouteTable unit tests, route-path accumulation, master route recording, source-route send/forward, node-open, forged-broadcast config-injection rejection, downlink peer-bound flood test, and a multi-hop sealed-downlink e2e (master→relay→leaf CONFIG_SET).

No protocol/submodule change (lattice-protocol stays v0.4.0).

Remaining: gap #8 (dual-master data failover) is Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)