### PR TITLE
feat: Phase 4 — dual-master data failover (closes gap #8)

### DIFF
--- a/docs/design-gaps/multihop-data-uplink.md
+++ b/docs/design-gaps/multihop-data-uplink.md
@@ -116,7 +116,24 @@ than an obviously-unenrolled one.
 
 ## Related gap: dual-master data failover
 
-The same "a node is only keyed to the master it enrolled with" constraint blocks
+**Status:** CLOSED (Phase 4, 2026-07-21). At enrollment the server designates a
+secondary master and supplies its MAC + public key in the JOIN_ACK (relayed
+through the primary); the leaf registers the secondary as a persisted
+`PeerRegistry` peer, so after it adopts the secondary on failover
+`masterE2EKeys()` derives a distinct `k_up`/`k_down` pair against the secondary
+and its uplink seals with keys the secondary can open (the server syncs each
+leaf's public key to the secondary). No wire-format or EEPROM-layout change was
+needed — the `secondary_master_mac`/`secondary_public_key` fields already existed
+in proto v3, and the secondary's key persists in the existing peer list.
+Executable spec: `tests/e2e/scenarios/test_dual_master_e2e.cpp` →
+`UplinkReachesSecondaryMasterAfterFailover`. Follow-up (functional, not
+blocking): downlink *commands* (`CONFIG_SET`) from the secondary are not yet
+honored post-failover — the origin gate is still primary-MAC-only
+(`Mesh.cpp` `TODO(dual-master)`).
+
+The original description of the gap follows.
+
+The same "a node is only keyed to the master it enrolled with" constraint blocked
 dual-master **data** failover (Task 12). In dual-master mode a node correctly
 TOFU-learns a secondary master's beacon and *adopts* it as `currentMaster` when
 the primary goes silent (route-adoption failover works and is tested — see

--- a/docs/superpowers/plans/2026-07-21-phase4-dual-master-failover.md
+++ b/docs/superpowers/plans/2026-07-21-phase4-dual-master-failover.md
@@ -1,0 +1,399 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Phase 4: Dual-Master Data Failover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a node fails over from a silent primary master to a secondary master, its sealed uplink reaches — and is decryptable by — the secondary. Closes design gap #8.
+
+**Architecture:** The primary's JOIN_ACK already-present-on-the-wire `secondary_master_mac`/`secondary_public_key` fields are populated by the server and passed through by the primary master. The enrolling leaf reads them and **registers the secondary master as a persisted PeerRegistry peer** (mac + pubkey) at enrollment — which is all `masterE2EKeys()` needs to derive a distinct `k_up`/`k_down` pair against the secondary after `currentMaster.mac` flips to it (the failover adoption itself already works and is tested). The secondary master obtains each leaf's pubkey via the same server→master enroll path it already has (server sync). No EEPROM-layout change (the secondary pubkey persists in the existing peer list), no wire-format change (fields already exist).
+
+**Tech Stack:** C++ (ESP32 firmware, host-tested), GoogleTest + `tests/e2e` sim harness. `main/lib/lattice-protocol` submodule at v0.4.0 (unchanged — `secondary_master_mac[6]`/`secondary_public_key[32]` already in the v3 struct).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md` §5 (dual-master data failover), §2 (keying).
+- **Confirmed assumption (from brainstorm):** both masters are hub/server-connected. The server designates the secondary and supplies its MAC+pubkey in the JOIN_ACK it relays through the primary; the server also syncs each enrolled leaf's pubkey to the secondary master.
+- **No wire-format / protocol change:** `secondary_master_mac`/`secondary_public_key` already exist in `mesh_message` (v3, `sizeof==242`). This phase only starts reading/writing them.
+- **No EEPROM-layout change (intentional deviation from spec §5's "a pubkey slot is added"):** spec §5 sketched persisting the secondary pubkey in a new EEPROM slot, but only 9 bytes are free (a 32-byte slot doesn't fit without restructuring). Instead the secondary master is stored as a normal `PeerRegistry` peer (persisted mac+pubkey via the existing `PEER_LIST` region, `MAX_PEERS=10`). This is not merely storage-convenient: registering the secondary as a peer is precisely what lets `masterE2EKeys()`'s `peers.find(currentMaster.mac)` resolve the secondary's key post-failover with **zero change** to the key-lookup path. The secondary MAC also persists in the existing `KNOWN_MASTER_MAC_SECONDARY` slot (EepromManager, addr 497) via the existing `saveKnownMasterMacSecondary`. Do NOT add a new EEPROM slot.
+- **PeerRegistry enrollment-only rule is preserved:** registering the secondary is an *enrollment-path* add (driven by the server-authenticated JOIN_ACK), through the same `registerPeerWithKey(allowRekey=false)` used for the primary. Do NOT weaken the JOIN_ACK re-key gating (Task-7 security from the e2e suite: an unauthenticated JOIN_ACK must not replace an established key; first-contact/all-zero placeholder is still upgradable).
+- **Key derivation is master-agnostic:** `masterE2EKeys()` keys off `currentMaster.mac` + `peers.find(currentMaster.mac)->publicKey`; `E2EKeyStore` caches per-MAC, so a secondary present in `peers` yields a distinct `k_up`/`k_down` automatically. The nonce (`epoch||seq||origin_mac`) is the leaf's own and master-agnostic — switching masters cannot cause nonce reuse (different key). Uplink uses `k_up` regardless of which master. Do NOT change `masterE2EKeys`/`peerE2EKeys`/nonce logic.
+- Config: `DUAL_MASTER_MODE` (`project_config.h`, default false) gates dual-master behavior; unchanged.
+- All firmware test hooks `#ifdef UNIT_TEST`-gated.
+- **clang-format 18** (CI `lint-format` checks `main/src` only). `python3 -m pip install 'clang-format==18.1.8'`; `CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")`; check changed `main/src` files with `"$CF" --style=file --dry-run --Werror <files>`. Only reformat changed lines. Local `ctest` does NOT run clang-format.
+- **CodeQL:** params `const uint8_t*` not `const uint8_t[6]`; bounds-check buffer indexing.
+- Verification loop: `cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release` (once), `cmake --build tests/build --parallel`, `ctest --test-dir tests/build --output-on-failure`. Baseline **176 pass / 0 disabled**.
+
+## Current-state facts (verified on this branch, post-Phase-3)
+
+- `secondary_master_mac`/`secondary_public_key` in `mesh_message` (`mesh_message.h:25-26`) are dead (never read/written anywhere).
+- `Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* deviceMac, RegisterPeerFn registerFn)` (`Enrollment.h:32`, body `Enrollment.cpp:92-134`): verifies the `data[0..3]` fingerprint, TOFU-gates on `knownMasterMac`, calls `registerFn(msg.origin_mac_address, msg.enrollment_public_key)` to register the **primary**, sets enrolled flag + TOFU-learns `knownMasterMac`. Never reads the secondary fields. `RegisterPeerFn = std::function<bool(const uint8_t* mac, const uint8_t* pubKey32)>` (`Enrollment.h:12`).
+- `Enrollment` dual-master state (`Enrollment.h:17-20`): `hasMasterMac`/`knownMasterMac[6]`, `hasMasterMacSecondary`/`knownMasterMacSecondary[6]`. `init()` loads both from EEPROM.
+- `Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32)` (`Mesh.h:320`, body `Mesh.cpp:1015-1047`): master-side; registers the peer via `registerPeerWithKey(...allowRekey=true)`, then builds+broadcasts a JOIN_ACK — sets `ack.enrollment_public_key = enrollment.getPublicKey()` (own pubkey), `ack.data[0..3]` fingerprint; leaves `ack.secondary_*` zero (`mesh_message ack = {}`).
+- `masterE2EKeys` (`Mesh.cpp:413-420`): `peers.find(currentMaster.mac)` → derives via `e2eKeys.getKeys(mac, ownPriv, master->publicKey, ...)`. Returns false if the master isn't in `peers` — the exact gap-#8 failure after failover (secondary never in `peers`). No change needed once the secondary IS in `peers`.
+- `processMasterBeacon` dual-master adoption (`Mesh.cpp:659-765`): TOFU-learns `knownMasterMacSecondary` (if `_dualMasterMode && !hasMasterMacSecondary`) and adopts `currentMaster.mac = secondary` on failover. Works and is tested.
+- Master serial JOIN_ACK handler (`SerialAdapter.cpp:241-260`): reads `msg.enrollment_public_key`, calls `meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key)`. The server relays approval as a full 242-byte `mesh_message` (so `secondary_*` fields are already carried over serial; the handler just ignores them).
+- `FakeHub::approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32)` (`FakeHub.h:43`): builds a JOIN_ACK with only target + `enrollment_public_key` + fingerprint. `FakeHub(SimNode* master)` models one hub. `MeshSimTest::enroll(node)` (`MeshSimTest.h:57`) calls `hub->approveEnrollment(node->mac(), req->enrollment_public_key)`.
+- `test_dual_master_e2e.cpp`: two ENABLED tests (`FailsOverToSecondaryMasterWhenPrimaryGoesSilent` asserts route adoption only; `LearnsSecondaryMasterInDualMode`). **No data-failover (decryption) test exists** — gap #8's executable spec must be authored. `bringUpSecondary` adds `master2` (isMaster, SERIAL_ADAPTER) linked to sensor + primary, but attaches NO hub to it.
+- `E2EKeyStore::getKeys(const uint8_t* mac, const uint8_t* ownPriv32, const uint8_t* peerPub32, const uint8_t** kUpOut, const uint8_t** kDownOut)` caches per-MAC — a secondary MAC yields its own cached pair automatically.
+
+## File Structure
+
+- **Modify** `main/src/mesh/Mesh.h`/`Mesh.cpp` — `enrollPeer` gains an overload carrying the secondary identity; JOIN_ACK stamps `secondary_*`.
+- **Modify** `main/src/mesh/Enrollment.h`/`Enrollment.cpp` — `processJoinAck` reads `secondary_*`, registers the secondary peer, sets/persists secondary TOFU state.
+- **Modify** `main/src/adapter/serial/SerialAdapter.cpp` — pass the server-provided `secondary_*` fields through to `enrollPeer`.
+- **Modify** `tests/e2e/harness/FakeHub.h`/`FakeHub.cpp` — `approveEnrollment` overload that populates `secondary_*`.
+- **Modify** `tests/e2e/scenarios/test_dual_master_e2e.cpp` — new data-failover e2e test (gap #8 spec).
+- **Modify** `tests/unit/test_mesh_logic.cpp` (and/or a dedicated unit test file) — unit coverage for JOIN_ACK secondary population + leaf secondary registration + `masterE2EKeys` post-failover.
+
+---
+
+### Task 1: Primary master stamps the secondary identity into JOIN_ACK
+
+**Files:**
+- Modify: `main/src/mesh/Mesh.h` (`enrollPeer` overload decl), `main/src/mesh/Mesh.cpp` (JOIN_ACK build)
+- Modify: `main/src/adapter/serial/SerialAdapter.cpp` (pass server-provided secondary fields through)
+- Modify: `tests/unit/test_mesh_logic.cpp` (unit test)
+
+**Interfaces:**
+- Produces:
+  - `void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint8_t* secondaryMac, const uint8_t* secondaryPubKey32)` — 4-arg overload; stamps `ack.secondary_master_mac`/`ack.secondary_public_key` when the secondary args are non-null (else zero, i.e. no secondary). Existing 2-arg `enrollPeer(mac, publicKey32)` delegates with `nullptr, nullptr` (preserves current single-master callers).
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add to `tests/unit/test_mesh_logic.cpp` (mirror the existing master JOIN_ACK test that inspects the broadcast frame via the esp_now mock — read it for the idiom):
+
+```cpp
+TEST_F(JoinAckRelayTest, EnrollPeerStampsSecondaryIdentityIntoJoinAck) {
+  Mesh master = makeMasterNode();
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  uint8_t leafPub[32]; for (int i = 0; i < 32; ++i) leafPub[i] = static_cast<uint8_t>(i + 1);
+  const uint8_t sec[6] = {0x02, 0, 0, 0, 0, 0x02};
+  uint8_t secPub[32]; for (int i = 0; i < 32; ++i) secPub[i] = static_cast<uint8_t>(0x40 + i);
+
+  resetEspNowMock();
+  master.enrollPeer(leaf, leafPub, sec, secPub);
+
+  // JOIN_ACK is broadcast; find it in the mock's sent frames.
+  mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK); // fixture/mock query
+  ASSERT_TRUE(sawBroadcastOfType(MESH_TYPE_JOIN_ACK));
+  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, sec, 6));
+  EXPECT_EQ(0, memcmp(ack.secondary_public_key, secPub, 32));
+}
+
+TEST_F(JoinAckRelayTest, EnrollPeerTwoArgLeavesSecondaryZero) {
+  Mesh master = makeMasterNode();
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  uint8_t leafPub[32] = {9};
+  resetEspNowMock();
+  master.enrollPeer(leaf, leafPub); // 2-arg: no secondary
+  mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK);
+  uint8_t zero6[6] = {}, zero32[32] = {};
+  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, zero6, 6));
+  EXPECT_EQ(0, memcmp(ack.secondary_public_key, zero32, 32));
+}
+```
+
+Adapt `makeMasterNode`/`lastEspNowBroadcastOfType`/`sawBroadcastOfType` to the fixture + esp_now mock helpers that actually exist (read them first; the mock records sent frames — query by message_type / broadcast dest).
+
+- [ ] **Step 2: Run RED**
+
+```bash
+cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --target test_mesh_logic --parallel && ctest --test-dir tests/build -R EnrollPeerStampsSecondaryIdentityIntoJoinAck --output-on-failure
+```
+Expected: FAIL — 4-arg `enrollPeer` not declared / secondary fields zero.
+
+- [ ] **Step 3: Implement**
+
+In `Mesh.h`, add the overload next to the existing decl:
+
+```cpp
+void enrollPeer(const uint8_t* mac, const uint8_t* publicKey32);
+void enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint8_t* secondaryMac,
+                const uint8_t* secondaryPubKey32);
+```
+
+In `Mesh.cpp`, make the existing body the 4-arg version and delegate from the 2-arg:
+
+```cpp
+void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32) {
+  enrollPeer(mac, publicKey32, nullptr, nullptr);
+}
+
+void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint8_t* secondaryMac,
+                      const uint8_t* secondaryPubKey32) {
+  // ... existing registerPeerWithKey + JOIN_ACK build ...
+  // after ack.enrollment_public_key is set, before broadcast:
+  if (secondaryMac && secondaryPubKey32) {
+    memcpy(ack.secondary_master_mac, secondaryMac, 6);
+    memcpy(ack.secondary_public_key, secondaryPubKey32, 32);
+  }
+  // ... existing broadcast ...
+}
+```
+
+In `SerialAdapter.cpp` JOIN_ACK handler (`~:241-260`): read the server-provided secondary fields and pass them through. Only pass them if non-zero (server included a secondary):
+
+```cpp
+    if (hasKey) {
+      lattice::mesh::Mesh* meshInstance = lattice::mesh::Mesh::getInstance();
+      if (meshInstance) {
+        bool hasSecondary = false;
+        for (int i = 0; i < 6; ++i)
+          if (msg.secondary_master_mac[i]) { hasSecondary = true; break; }
+        if (hasSecondary)
+          meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key,
+                                   msg.secondary_master_mac, msg.secondary_public_key);
+        else
+          meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key);
+      }
+    }
+```
+
+- [ ] **Step 4: GREEN + full suite; clang-format; commit**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/src/mesh/Mesh.h main/src/mesh/Mesh.cpp main/src/adapter/serial/SerialAdapter.cpp
+git add main/src/mesh/Mesh.h main/src/mesh/Mesh.cpp main/src/adapter/serial/SerialAdapter.cpp tests/unit/test_mesh_logic.cpp
+git commit -m "feat: primary master stamps server-provided secondary identity into JOIN_ACK"
+```
+Expected: 178 pass / 0 disabled.
+
+---
+
+### Task 2: Leaf registers the secondary master at enrollment
+
+**Files:**
+- Modify: `main/src/mesh/Enrollment.h`/`Enrollment.cpp` (`processJoinAck`)
+- Modify: `tests/unit/test_mesh_logic.cpp` or `test_enrollment`-style unit test
+
+**Interfaces:**
+- Consumes: `RegisterPeerFn registerFn` (already passed to `processJoinAck`); `EepromManager::saveKnownMasterMacSecondary`.
+- Produces: after a JOIN_ACK carrying non-zero `secondary_*`, the leaf has the secondary registered as a `PeerRegistry` peer (mac+pubkey, persisted) and `hasMasterMacSecondary`/`knownMasterMacSecondary` set+persisted.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a leaf-side unit test (mirror the existing `processJoinAck` test that checks the primary is registered — read it for how the leaf Mesh/Enrollment is built and how `registerFn` wires into `registerPeerWithKey`):
+
+```cpp
+TEST_F(JoinAckRelayTest, ProcessJoinAckRegistersSecondaryMasterAndKeys) {
+  Mesh leaf = makeIntermediateNode(); // non-master, not yet enrolled with anyone (fixture)
+  // Build a JOIN_ACK addressed to the leaf, carrying primary + secondary identities.
+  uint8_t leafPriv[32], leafPub[32], primPriv[32], primPub[32], secPriv[32], secPub[32];
+  crypto::generateKeypair(leafPriv, leafPub);
+  crypto::generateKeypair(primPriv, primPub);
+  crypto::generateKeypair(secPriv, secPub);
+  // (fixture: install leafPriv/leafPub as the leaf's device keypair)
+  const uint8_t primMac[6] = {0x02, 0, 0, 0, 0, 0x01};
+  const uint8_t secMac[6]  = {0x02, 0, 0, 0, 0, 0x02};
+  mesh_message ack = {};
+  ack.proto_version = PROTO_VERSION;
+  ack.message_type = MESH_TYPE_JOIN_ACK;
+  memcpy(ack.origin_mac_address, primMac, 6);          // primary sent it
+  memcpy(ack.target_mac_address, leaf.testDeviceMac(), 6);
+  memcpy(ack.data, leafPub, 4);                        // fingerprint of the leaf's pubkey
+  memcpy(ack.enrollment_public_key, primPub, 32);      // primary pubkey
+  memcpy(ack.secondary_master_mac, secMac, 6);
+  memcpy(ack.secondary_public_key, secPub, 32);
+
+  leaf.processJoinAck(ack); // routes to enrollment.processJoinAck with the registerFn
+
+  // Secondary registered as a routable/keyable peer with its pubkey:
+  PeerInfo* sec = leaf.peers.find(secMac);
+  ASSERT_NE(sec, nullptr);
+  EXPECT_EQ(0, memcmp(sec->publicKey, secPub, 32));
+  // Secondary TOFU state set:
+  EXPECT_TRUE(leaf.enrollment.hasMasterMacSecondary);
+  EXPECT_EQ(0, memcmp(leaf.enrollment.knownMasterMacSecondary, secMac, 6));
+  // And post-failover masterE2EKeys resolves against the secondary:
+  leaf.enrollment.hasMasterMac = true; // enrolled with primary
+  memcpy(leaf.currentMaster.mac, secMac, 6); // simulate adoption
+  leaf.currentMaster.distance = 1;
+  const uint8_t *kUp, *kDown;
+  EXPECT_TRUE(leaf.masterE2EKeys(&kUp, &kDown)) << "keys derivable against the secondary post-failover";
+}
+```
+
+Adapt to the fixture's real keypair-install + `processJoinAck` reachability (the map shows `Mesh::processJoinAck(const mesh_message&)` is public under UNIT_TEST). If the fixture requires the leaf to already be enrolled for `processJoinAck` to register a peer (TOFU gating), set that up as the existing primary-registration test does.
+
+- [ ] **Step 2: Run RED** — secondary not registered / `hasMasterMacSecondary` false.
+
+- [ ] **Step 3: Implement**
+
+In `Enrollment::processJoinAck` (`Enrollment.cpp:92-134`), after the primary is registered via `registerFn(msg.origin_mac_address, msg.enrollment_public_key)` and the enrolled flag/primary-TOFU handling, add secondary handling:
+
+```cpp
+  // Dual-master (spec §5): if the server included a secondary master, register it
+  // as a peer (persists mac+pubkey, so masterE2EKeys can derive against it after
+  // failover) and record it as the secondary for beacon adoption. Guarded on a
+  // non-zero secondary MAC.
+  bool hasSecondary = false;
+  for (int i = 0; i < 6; ++i)
+    if (msg.secondary_master_mac[i]) { hasSecondary = true; break; }
+  if (hasSecondary) {
+    registerFn(msg.secondary_master_mac, msg.secondary_public_key);
+    if (!hasMasterMacSecondary) {
+      memcpy(knownMasterMacSecondary, msg.secondary_master_mac, 6);
+      hasMasterMacSecondary = true;
+      EepromManager::getInstance().saveKnownMasterMacSecondary(knownMasterMacSecondary);
+    }
+  }
+```
+
+Ensure `EepromManager.h` is included in `Enrollment.cpp` (it already is — `saveEnrolledFlag`/`saveKnownMasterMac` are used).
+
+Note: `registerFn` is `Mesh::registerPeerWithKey(..., allowRekey=false)` — first-contact registration of the secondary is allowed; an established key is not replaced (security gating preserved). Confirm the secondary being a distinct new MAC means `append` (not rekey).
+
+- [ ] **Step 4: GREEN + full suite; clang-format; commit**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+"$CF" --style=file --dry-run --Werror main/src/mesh/Enrollment.cpp main/src/mesh/Enrollment.h
+git add main/src/mesh/Enrollment.cpp main/src/mesh/Enrollment.h tests/unit/test_mesh_logic.cpp
+git commit -m "feat: leaf registers secondary master (mac+pubkey) from JOIN_ACK for post-failover keying"
+```
+Expected: 179 pass / 0 disabled.
+
+---
+
+### Task 3: Harness two-master server-sync + data-failover e2e (gap #8 executable spec)
+
+**Files:**
+- Modify: `tests/e2e/harness/FakeHub.h`/`FakeHub.cpp` (`approveEnrollment` secondary overload)
+- Modify: `tests/e2e/scenarios/test_dual_master_e2e.cpp` (new data-failover test)
+
+**Interfaces:**
+- Consumes: Tasks 1-2 (JOIN_ACK carries secondary; leaf registers it); `Mesh::enrollPeer` (to sync a leaf's pubkey to the secondary master); dual-master adoption (existing).
+- Produces: an e2e test proving post-failover uplink DECRYPTS at the secondary (not just route adoption).
+
+- [ ] **Step 1: Add the FakeHub secondary-aware approval**
+
+In `FakeHub.h`/`FakeHub.cpp`, add an overload so a test can drive the server-provides-secondary flow:
+
+```cpp
+// approve enrollment AND tell the node about the secondary master (server-designated).
+void approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32,
+                       const uint8_t* secondaryMac, const uint8_t* secondaryPubKey32);
+```
+
+Its body mirrors the existing `approveEnrollment` but also sets `ack.secondary_master_mac`/`ack.secondary_public_key` before it injects/sends the JOIN_ACK frame into the master's serial path. Keep the existing 2-arg overload delegating with zero secondary.
+
+- [ ] **Step 2: Write the failing data-failover e2e test**
+
+In `test_dual_master_e2e.cpp`, add (reuse `DualMasterTest`/`bringUpSecondary`; the header comment already flags data-failover as untested):
+
+```cpp
+TEST_F(DualMasterTest, UplinkReachesSecondaryMasterAfterFailover) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  auto* master2 = bringUpSecondary(sensor); // dual mode on; master2 linked to sensor + primary
+
+  // Read master2's pubkey (server knows both masters' identities).
+  uint8_t m2Pub[32];
+  master2->with([&](Mesh& m, Adapter*) { memcpy(m2Pub, m.enrollment.getPublicKey(), 32); return 0; });
+
+  // Enroll the sensor with the PRIMARY, server designating master2 as the secondary.
+  const mesh_message* req = hub->enrollmentFrom(sensor->mac());
+  ASSERT_NE(req, nullptr);
+  hub->approveEnrollment(sensor->mac(), req->enrollment_public_key, master2->mac(), m2Pub);
+  runPolled(5000);
+  ASSERT_TRUE(sensor->with([&](Mesh& m, Adapter*) { return m.isEnrolled(); }));
+
+  // Server sync: teach master2 the sensor's pubkey (so master2 can open its uplink).
+  uint8_t sensorPub[32];
+  sensor->with([&](Mesh& m, Adapter*) { memcpy(sensorPub, m.enrollment.getPublicKey(), 32); return 0; });
+  master2->with([&](Mesh& m, Adapter*) { m.enrollPeer(sensor->mac(), sensorPub); return 0; });
+
+  // Attach a hub to master2 so we can observe what reaches it.
+  FakeHub hub2(master2);
+
+  // Primary goes silent → sensor fails over to master2.
+  world.bus.unlink(master, sensor);
+  runPolled(STALE_MASTER_THRESHOLD_MS + 4000);
+  ASSERT_TRUE(sensor->with([&](Mesh& m, Adapter*) {
+    return memcmp(m.currentMaster.mac, master2->mac(), 6) == 0;
+  }));
+
+  // Sensor sends PIR data; it must arrive DECRYPTED at master2's hub.
+  size_t before = hub2.adapterDataFromOrigin(sensor->mac()).size();
+  sensor->simulatePirMotion();
+  runPolled(4000);
+  hub2.poll();
+  auto frames = hub2.adapterDataFromOrigin(sensor->mac());
+  ASSERT_GT(frames.size(), before) << "post-failover uplink reached the secondary";
+  // FakeHub delivers what the master OPENED — so arrival proves master2 decrypted it
+  // with the sensor's k_up derived against the (sensor, master2) ECDH pair.
+}
+```
+
+Adapt to the harness: confirm `FakeHub` can be constructed on `master2` mid-test and that `adapterDataFromOrigin`/`poll` surface the master's opened uplink (read `FakeHub` for how it records adapter data — it decodes what the master bridged to serial, i.e. post-open). If `bringUpSecondary` enrolls the sensor before you can inject the secondary identity, restructure so the `approveEnrollment` with secondary args is the enrollment that registers the sensor (the sensor must learn the secondary at enrollment time).
+
+- [ ] **Step 3: Run RED**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build -R UplinkReachesSecondaryMasterAfterFailover --output-on-failure
+```
+Expected: FAIL at the final `ASSERT_GT` — pre-Task-1/2 the sensor never learned master2's key, so its post-failover uplink seal uses no/ wrong key and never decrypts at master2. (Since Tasks 1-2 landed, the failing driver here is the harness wiring; confirm the test genuinely exercises decryption — if it passes trivially, verify master2 actually opens the frame rather than the harness surfacing plaintext.)
+
+- [ ] **Step 4: Make it pass**
+
+With Tasks 1-2 in place, the sensor learns master2 at enrollment and seals post-failover uplink with the (sensor, master2) `k_up`; master2 opens it with `peerE2EKeys(sensor)` (sensor synced in Step 2). If the test fails, debug the real wiring (harness hub-on-master2, server-sync call, adoption timing) — do NOT weaken the decryption assertion. The test asserting arrival at master2's hub == master2 successfully decrypted (FakeHub surfaces opened payloads).
+
+- [ ] **Step 5: Full suite; clang-format (no main/src change expected here — harness/tests only); commit**
+
+```bash
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+git add tests/e2e/harness/FakeHub.h tests/e2e/harness/FakeHub.cpp tests/e2e/scenarios/test_dual_master_e2e.cpp
+git commit -m "test: dual-master data failover e2e — uplink decrypts at secondary (closes gap #8)"
+```
+Expected: 180 pass / 0 disabled.
+
+---
+
+### Task 4: Finish — full verification + gap doc + PR
+
+**Files:**
+- Modify: `docs/design-gaps/multihop-data-uplink.md` (mark #8 closed)
+
+- [ ] **Step 1: Clean-from-scratch build + suite**
+
+```bash
+rm -rf tests/build && cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
+cmake --build tests/build --parallel && ctest --test-dir tests/build --output-on-failure
+```
+Expected: all pass, 0 disabled.
+
+- [ ] **Step 2: clang-format-18 gate (main/src)**
+
+```bash
+CF=$(python3 -c "import clang_format,os;print(os.path.join(os.path.dirname(clang_format.__file__),'data','bin','clang-format'))")
+find main/src \( -name '*.cpp' -o -name '*.h' \) ! -path '*/nanopb/*' ! -name 'mesh.pb.h' ! -name 'mesh.pb.c' | xargs "$CF" --style=file --dry-run --Werror
+```
+Expected: exit 0.
+
+- [ ] **Step 3: Mark gap #8 closed**
+
+In `docs/design-gaps/multihop-data-uplink.md`, update the "Related gap: dual-master data failover" section (and any status line) to note #8 is closed in Phase 4: the leaf registers the secondary master's key at enrollment (server-provided via JOIN_ACK), so post-failover uplink seals with the secondary's `k_up` and decrypts at the secondary (which the server syncs each leaf's pubkey to).
+
+Commit:
+
+```bash
+git add docs/design-gaps/multihop-data-uplink.md
+git commit -m "docs: mark dual-master data failover (gap #8) closed in Phase 4"
+```
+
+- [ ] **Step 4: PR via superpowers:finishing-a-development-branch**
+
+Single lattice-nodes PR (no protocol/submodule change). PR body: closes gap #8; JOIN_ACK carries server-provided secondary identity; leaf registers the secondary as a persisted peer (no EEPROM/wire change); secondary opens post-failover uplink via server-synced leaf pubkey; new data-failover e2e. Note: gh active account must be `superbrobenji` (ADMIN).
+
+---
+
+## Deferred (explicitly NOT in Phase 4)
+
+- **A real server sync protocol/opcode** for pushing leaf pubkeys to the secondary master: modeled in the harness via the existing `enrollPeer` path; a production server-sync opcode (if the firmware ever needs to drive it without per-leaf enroll frames) is out of scope. The mechanism (server → secondary master `enrollPeer(leaf, pubkey)`) already exists on the serial path.
+- **`transmitCore` AAD-bound `target_mac` rewrite on relayed sealed frames** (carried from Phases 1-3): only bites when a relay's `currentMaster` differs from the origin's target — possible in a multi-master + multi-hop combination. If the dual-master e2e surfaces it, note it; otherwise it remains a documented follow-up.
+- **Sticky-low `currentMaster.distance`** and other carried minors from earlier phases.
+- **Secondary-of-secondary / >2 masters:** out of scope; the design handles exactly one secondary.

--- a/main/src/adapter/serial/SerialAdapter.cpp
+++ b/main/src/adapter/serial/SerialAdapter.cpp
@@ -251,7 +251,22 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
                     LogLevel::LOG_INFO);
       lattice::mesh::Mesh* meshInstance = lattice::mesh::Mesh::getInstance();
       if (meshInstance) {
-        meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key);
+        // Server may relay a secondary-master identity alongside the
+        // enrollment approval (Phase 4 dual-master failover) — pass it
+        // through to the JOIN_ACK only if it's actually present (non-zero).
+        bool hasSecondary = false;
+        for (int i = 0; i < 6; ++i) {
+          if (msg.secondary_master_mac[i]) {
+            hasSecondary = true;
+            break;
+          }
+        }
+        if (hasSecondary) {
+          meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key,
+                                   msg.secondary_master_mac, msg.secondary_public_key);
+        } else {
+          meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key);
+        }
       }
     } else {
       Logger::logln("Serial_Adapter", "Server rejected enrollment request", LogLevel::LOG_WARN);

--- a/main/src/adapter/serial/SerialFraming.cpp
+++ b/main/src/adapter/serial/SerialFraming.cpp
@@ -56,6 +56,30 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     }
   }
 
+  // secondary_master_mac/secondary_public_key (Phase 4 dual-master failover):
+  // the server stamps these onto a JOIN_ACK to designate a failover master
+  // alongside enrollment approval (see SerialAdapter::handleCompleteFrame /
+  // Mesh::enrollPeer's 4-arg overload). Only present, and only meaningful, on
+  // JOIN_ACK; encode only when non-zero so ordinary single-master JOIN_ACKs
+  // stay byte-identical to before this field existed.
+  if (msg.message_type == MESH_TYPE_JOIN_ACK) {
+    bool hasSecondary = false;
+    for (int i = 0; i < 6; ++i) {
+      if (msg.secondary_master_mac[i]) {
+        hasSecondary = true;
+        break;
+      }
+    }
+    if (hasSecondary) {
+      pbMsg.has_secondaryMasterMac = true;
+      pbMsg.secondaryMasterMac.size = 6;
+      memcpy(pbMsg.secondaryMasterMac.bytes, msg.secondary_master_mac, 6);
+      pbMsg.has_secondaryPublicKey = true;
+      pbMsg.secondaryPublicKey.size = 32;
+      memcpy(pbMsg.secondaryPublicKey.bytes, msg.secondary_public_key, 32);
+    }
+  }
+
   pb_ostream_t stream = pb_ostream_from_buffer(out, maxLen);
   if (!pb_encode(&stream, mesh_MeshMessage_fields, &pbMsg)) {
     Logger::logln("Serial_Adapter", "nanopb encode failed", LogLevel::LOG_ERROR);
@@ -98,6 +122,13 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
 
   if (pbMsg.has_public_key) {
     memcpy(outMsg.enrollment_public_key, pbMsg.public_key.bytes, 32);
+  }
+
+  if (pbMsg.has_secondaryMasterMac) {
+    memcpy(outMsg.secondary_master_mac, pbMsg.secondaryMasterMac.bytes, 6);
+  }
+  if (pbMsg.has_secondaryPublicKey) {
+    memcpy(outMsg.secondary_public_key, pbMsg.secondaryPublicKey.bytes, 32);
   }
 
   // For server-to-device messages (JOIN_ACK, SERIAL_CMD_BROADCAST) the MAC

--- a/main/src/mesh/Enrollment.cpp
+++ b/main/src/mesh/Enrollment.cpp
@@ -131,6 +131,26 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
     EepromManager::getInstance().saveKnownMasterMac(knownMasterMac);
     Logger::logln("MESH", "Master MAC learned and saved (TOFU)", LogLevel::LOG_INFO);
   }
+
+  // Dual-master (spec §5): if the server included a secondary master, register it
+  // as a peer (persists mac+pubkey, so masterE2EKeys can derive against it after
+  // failover) and record it as the secondary for beacon adoption. Guarded on a
+  // non-zero secondary MAC.
+  bool hasSecondary = false;
+  for (int i = 0; i < 6; ++i)
+    if (msg.secondary_master_mac[i]) {
+      hasSecondary = true;
+      break;
+    }
+  if (hasSecondary) {
+    if (registerFn)
+      registerFn(msg.secondary_master_mac, msg.secondary_public_key);
+    if (!hasMasterMacSecondary) {
+      memcpy(knownMasterMacSecondary, msg.secondary_master_mac, 6);
+      hasMasterMacSecondary = true;
+      EepromManager::getInstance().saveKnownMasterMacSecondary(knownMasterMacSecondary);
+    }
+  }
 }
 
 void Enrollment::enrollPeer(const uint8_t* mac, const uint8_t* pubKey32, RegisterPeerFn registerFn,

--- a/main/src/mesh/Mesh.cpp
+++ b/main/src/mesh/Mesh.cpp
@@ -1013,6 +1013,11 @@ bool Mesh::registerPeerWithKey(const uint8_t* mac, const uint8_t* publicKey32, b
 }
 
 void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32) {
+  enrollPeer(mac, publicKey32, nullptr, nullptr);
+}
+
+void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint8_t* secondaryMac,
+                      const uint8_t* secondaryPubKey32) {
   if (!registerPeerWithKey(mac, publicKey32, /*allowRekey=*/true))
     return; // registry full — do not ACK an enrollment we could not record
 
@@ -1039,6 +1044,13 @@ void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32) {
   // Include OUR public key so the enrolling node can register this master as
   // an encrypted, routable peer in its own registry (see Enrollment::processJoinAck).
   memcpy(ack.enrollment_public_key, enrollment.getPublicKey(), 32);
+  // Stamp the server-provided secondary-master identity, if any, so the
+  // enrolling node can TOFU-learn its failover master from this same ACK
+  // (Phase 4). Left zeroed (ack's default) when there is no secondary.
+  if (secondaryMac && secondaryPubKey32) {
+    memcpy(ack.secondary_master_mac, secondaryMac, 6);
+    memcpy(ack.secondary_public_key, secondaryPubKey32, 32);
+  }
   // Broadcast via the registered FF:FF:… peer so the new node receives the ACK
   // even before it is individually registered as a unicast peer.
   static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};

--- a/main/src/mesh/Mesh.h
+++ b/main/src/mesh/Mesh.h
@@ -318,6 +318,13 @@ public:
   }
   bool isEnrolled() const { return enrollment.isEnrolled(); }
   void enrollPeer(const uint8_t* mac, const uint8_t* publicKey32);
+  // 4-arg overload: also stamps the server-provided secondary-master identity
+  // (secondaryMac/secondaryPubKey32) into the JOIN_ACK broadcast to the newly
+  // enrolled node, so it can TOFU-learn its failover master up front (Phase 4).
+  // Pass nullptr, nullptr (as the 2-arg overload does) when there is no
+  // secondary — the ACK's secondary fields are then left zeroed.
+  void enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint8_t* secondaryMac,
+                  const uint8_t* secondaryPubKey32);
 
   // Enrollment relay callback — set by Serial_Adapter owner (main.ino)
   void setEnrollmentRelayFn(EnrollmentRelayFn fn) { enrollment.setRelayFn(fn); }

--- a/main/src/mesh/serialization/mesh.pb.h
+++ b/main/src/mesh/serialization/mesh.pb.h
@@ -12,6 +12,8 @@
 /* Struct definitions */
 typedef PB_BYTES_ARRAY_T(64) mesh_MeshMessage_data_t;
 typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_public_key_t;
+typedef PB_BYTES_ARRAY_T(6) mesh_MeshMessage_secondaryMasterMac_t;
+typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_secondaryPublicKey_t;
 typedef struct _mesh_MeshMessage {
     uint32_t messageType;
     int32_t dataType;
@@ -26,6 +28,10 @@ typedef struct _mesh_MeshMessage {
     uint32_t protoVersion;
     bool has_public_key;
     mesh_MeshMessage_public_key_t public_key;
+    bool has_secondaryMasterMac;
+    mesh_MeshMessage_secondaryMasterMac_t secondaryMasterMac;
+    bool has_secondaryPublicKey;
+    mesh_MeshMessage_secondaryPublicKey_t secondaryPublicKey;
 } mesh_MeshMessage;
 
 
@@ -34,8 +40,8 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define mesh_MeshMessage_init_default            {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}}
-#define mesh_MeshMessage_init_zero               {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}}
+#define mesh_MeshMessage_init_default            {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}}
+#define mesh_MeshMessage_init_zero               {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define mesh_MeshMessage_messageType_tag         1
@@ -49,6 +55,8 @@ extern "C" {
 #define mesh_MeshMessage_seqNum_tag              9
 #define mesh_MeshMessage_protoVersion_tag        10
 #define mesh_MeshMessage_public_key_tag          11
+#define mesh_MeshMessage_secondaryMasterMac_tag  15
+#define mesh_MeshMessage_secondaryPublicKey_tag  16
 
 /* Struct field encoding specification for nanopb */
 #define mesh_MeshMessage_FIELDLIST(X, a) \
@@ -62,7 +70,9 @@ X(a, STATIC,   SINGULAR, UINT32,   hopCount,          7) \
 X(a, STATIC,   SINGULAR, UINT32,   epochNum,          8) \
 X(a, STATIC,   SINGULAR, UINT32,   seqNum,            9) \
 X(a, STATIC,   SINGULAR, UINT32,   protoVersion,     10) \
-X(a, STATIC,   OPTIONAL, BYTES,    public_key,       11)
+X(a, STATIC,   OPTIONAL, BYTES,    public_key,       11) \
+X(a, STATIC,   OPTIONAL, BYTES,    secondaryMasterMac,  15) \
+X(a, STATIC,   OPTIONAL, BYTES,    secondaryPublicKey,  16)
 #define mesh_MeshMessage_CALLBACK NULL
 #define mesh_MeshMessage_DEFAULT NULL
 
@@ -73,7 +83,7 @@ extern const pb_msgdesc_t mesh_MeshMessage_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define MESH_MESH_PB_H_MAX_SIZE                  mesh_MeshMessage_size
-#define mesh_MeshMessage_size                    160
+#define mesh_MeshMessage_size                    202
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/tests/e2e/harness/FakeHub.cpp
+++ b/tests/e2e/harness/FakeHub.cpp
@@ -91,6 +91,13 @@ void FakeHub::sendFrame(const mesh_message& msg) {
 }
 
 void FakeHub::approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32) {
+  static const uint8_t zeroMac[6] = {0, 0, 0, 0, 0, 0};
+  static const uint8_t zeroPub[32] = {0};
+  approveEnrollment(nodeMac, nodePubKey32, zeroMac, zeroPub);
+}
+
+void FakeHub::approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32,
+                                const uint8_t* secondaryMac, const uint8_t* secondaryPubKey32) {
   mesh_message ack{};
   ack.proto_version = 2;
   ack.message_type = MESH_TYPE_JOIN_ACK;
@@ -104,6 +111,12 @@ void FakeHub::approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKe
   // later frame's data[0..3] that Enrollment::processJoinAck checks, on the
   // enrolling node, against its own device public key.
   memcpy(ack.data, nodePubKey32, 4);
+  // Server-designated secondary master (Phase 4 dual-master failover). Left
+  // zeroed by the 2-arg overload above, which SerialAdapter::handleCompleteFrame
+  // treats as "no secondary present" (see its all-zero secondary_master_mac
+  // check) and so falls back to the plain 2-arg Mesh::enrollPeer.
+  memcpy(ack.secondary_master_mac, secondaryMac, 6);
+  memcpy(ack.secondary_public_key, secondaryPubKey32, 32);
   sendFrame(ack);
 }
 

--- a/tests/e2e/harness/FakeHub.h
+++ b/tests/e2e/harness/FakeHub.h
@@ -42,6 +42,18 @@ public:
   // node's own device public key.
   void approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32);
 
+  // Same as above, but also tells the node about a server-designated secondary
+  // master (Phase 4 dual-master failover): sets ack.secondary_master_mac/
+  // secondary_public_key before injecting the JOIN_ACK. SerialAdapter::
+  // handleCompleteFrame forwards these into the 4-arg Mesh::enrollPeer overload,
+  // which relays them on to the enrolling node's own JOIN_ACK, where
+  // Enrollment::processJoinAck registers the secondary as a peer (so
+  // masterE2EKeys can derive a key against it after failover) and records it
+  // for beacon adoption. The 2-arg overload above delegates here with an
+  // all-zero secondary, which SerialAdapter treats as "no secondary present".
+  void approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32,
+                         const uint8_t* secondaryMac, const uint8_t* secondaryPubKey32);
+
   // Script a server-issued adapter reconfiguration for targetMac.
   void sendConfigSet(const uint8_t* targetMac, lattice::adapter::adapter_types newType);
 

--- a/tests/e2e/scenarios/test_dual_master_e2e.cpp
+++ b/tests/e2e/scenarios/test_dual_master_e2e.cpp
@@ -85,3 +85,67 @@ TEST_F(DualMasterTest, LearnsSecondaryMasterInDualMode) {
   });
   EXPECT_TRUE(knowsSecondary) << "sensor must TOFU-learn the secondary master in dual-master mode";
 }
+
+// Full DATA failover (closes gap #8): the server designates a secondary master
+// at enrollment time (JOIN_ACK's secondary_master_mac/secondary_public_key,
+// Phase 4 tasks 1-2), so the sensor is ECDH-keyed to BOTH masters from the
+// start. When the primary goes silent and the sensor adopts the secondary as
+// currentMaster, its post-failover uplink must actually DECRYPT there — not
+// just arrive. FakeHub only surfaces what the master's serial bridge decoded
+// AFTER Mesh opened the sealed payload with peerE2EKeys(origin) (see
+// Mesh.cpp's "needsOpen" uplink-open path); if the master couldn't open the
+// frame, it is dropped and never reaches serial/FakeHub at all. So arrival at
+// hub2 is itself proof of decryption at master2, not just of routing.
+TEST_F(DualMasterTest, UplinkReachesSecondaryMasterAfterFailover) {
+  addMaster();
+  auto* sensor = addSensor(MAC_NODE_A);
+  world.bus.link(master, sensor);
+  auto* master2 = bringUpSecondary(sensor); // dual mode on; master2 linked to sensor + primary
+
+  // Read master2's pubkey (server knows both masters' identities).
+  uint8_t m2Pub[32];
+  master2->with([&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) {
+    memcpy(m2Pub, m.enrollment.getPublicKey(), 32);
+    return 0;
+  });
+
+  // Enroll the sensor with the PRIMARY, server designating master2 as the secondary.
+  runPolled(11000);
+  const mesh_message* req = hub->enrollmentFrom(sensor->mac());
+  ASSERT_NE(req, nullptr) << "enrollment request never reached hub";
+  hub->approveEnrollment(sensor->mac(), req->enrollment_public_key, master2->mac(), m2Pub);
+  runPolled(5000);
+  ASSERT_TRUE(sensor->with(
+      [&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) { return m.isEnrolled(); }));
+
+  // Server sync: teach master2 the sensor's pubkey (so master2 can open its uplink).
+  uint8_t sensorPub[32];
+  sensor->with([&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) {
+    memcpy(sensorPub, m.enrollment.getPublicKey(), 32);
+    return 0;
+  });
+  master2->with([&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) {
+    m.enrollPeer(sensor->mac(), sensorPub);
+    return 0;
+  });
+
+  // Attach a hub to master2 so we can observe what reaches it.
+  sim::FakeHub hub2(master2);
+
+  // Primary goes silent → sensor fails over to master2.
+  world.bus.unlink(master, sensor);
+  runPolled(lattice::config::STALE_MASTER_THRESHOLD_MS + 4000);
+  ASSERT_TRUE(sensor->with([&](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) {
+    return memcmp(m.currentMaster.mac, master2->mac(), 6) == 0;
+  })) << "sensor must adopt the secondary as currentMaster once the primary goes stale";
+
+  // Sensor sends PIR data; it must arrive DECRYPTED at master2's hub.
+  size_t before = hub2.adapterDataFromOrigin(sensor->mac()).size();
+  sensor->simulatePirMotion();
+  runPolled(4000);
+  hub2.poll();
+  auto frames = hub2.adapterDataFromOrigin(sensor->mac());
+  ASSERT_GT(frames.size(), before) << "post-failover uplink reached the secondary";
+  // FakeHub delivers what the master OPENED — so arrival proves master2 decrypted it
+  // with the sensor's k_up derived against the (sensor, master2) ECDH pair.
+}

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -706,6 +706,51 @@ TEST_F(JoinAckRelayTest, JoinAckAddressedToSelf_RegistersMasterAsRoutablePeer) {
       << "uplink route must resolve through the newly registered master peer";
 }
 
+TEST_F(JoinAckRelayTest, ProcessJoinAckRegistersSecondaryMasterAndKeys) {
+  // A JOIN_ACK carrying a non-zero secondary master identity (spec §5 dual
+  // master) must register the secondary as a routable/keyable PeerRegistry
+  // peer (mac+pubkey, persisted) AND record it as the TOFU secondary — this
+  // is what lets masterE2EKeys() derive keys against the secondary once
+  // currentMaster.mac flips to it after failover.
+  Mesh leaf = makeIntermediateNode(); // non-master, not yet enrolled with anyone
+
+  uint8_t leafPriv[32], leafPub[32], primPriv[32], primPub[32], secPriv[32], secPub[32];
+  lattice::mesh::crypto::generateKeypair(leafPriv, leafPub);
+  lattice::mesh::crypto::generateKeypair(primPriv, primPub);
+  lattice::mesh::crypto::generateKeypair(secPriv, secPub);
+  memcpy(leaf.enrollment.devicePrivateKey, leafPriv, 32);
+  memcpy(leaf.enrollment.devicePublicKey, leafPub, 32);
+
+  const uint8_t primMac[6] = {0x02, 0, 0, 0, 0, 0x01};
+  const uint8_t secMac[6] = {0x02, 0, 0, 0, 0, 0x02};
+  mesh_message ack = {};
+  ack.proto_version = PROTO_VERSION;
+  ack.message_type = MESH_TYPE_JOIN_ACK;
+  memcpy(ack.origin_mac_address, primMac, 6); // primary sent it
+  memcpy(ack.target_mac_address, leaf.testDeviceMac(), 6);
+  memcpy(ack.data, leafPub, 4); // fingerprint of the leaf's pubkey
+  memcpy(ack.enrollment_public_key, primPub, 32); // primary pubkey
+  memcpy(ack.secondary_master_mac, secMac, 6);
+  memcpy(ack.secondary_public_key, secPub, 32);
+
+  leaf.processJoinAck(ack);
+
+  // Secondary registered as a routable/keyable peer with its pubkey:
+  PeerInfo* sec = leaf.peers.find(secMac);
+  ASSERT_NE(sec, nullptr) << "secondary master must be registered in the PeerRegistry";
+  EXPECT_EQ(0, memcmp(sec->publicKey, secPub, 32));
+  // Secondary TOFU state set:
+  EXPECT_TRUE(leaf.enrollment.hasMasterMacSecondary);
+  EXPECT_EQ(0, memcmp(leaf.enrollment.knownMasterMacSecondary, secMac, 6));
+  // And post-failover masterE2EKeys resolves against the secondary:
+  leaf.enrollment.hasMasterMac = true; // enrolled with primary
+  memcpy(leaf.currentMaster.mac, secMac, 6); // simulate adoption after failover
+  leaf.currentMaster.distance = 1;
+  const uint8_t *kUp, *kDown;
+  EXPECT_TRUE(leaf.masterE2EKeys(&kUp, &kDown))
+      << "keys derivable against the secondary post-failover";
+}
+
 TEST_F(JoinAckRelayTest, NextHopThroughRelayIsRegisteredAsEspNowPeer) {
   Mesh mesh = makeIntermediateNode(); // distance/enrollment set up by fixture
   // Node is distance 2; a relay at distance 1 is known ONLY via the NeighborTable

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -900,6 +900,70 @@ TEST_F(JoinAckRelayTest, DownlinkRelayForward_BoundsAutoRegisteredPeers_NeverEvi
       << "enrolled peer must never be evicted by downlink forwarding-peer churn";
 }
 
+// ─── enrollPeer: secondary-master identity stamped into JOIN_ACK ────────────
+// Helpers to inspect the broadcast JOIN_ACK by message_type — mirror
+// wasSentTo/lastEspNowSentTo above, but keyed on the broadcast dest (FF:FF:…)
+// + message_type rather than a unicast dest MAC.
+
+static bool sawBroadcastOfType(uint8_t type) {
+  static constexpr uint8_t kBroadcast[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  for (auto it = espNowSentPackets.rbegin(); it != espNowSentPackets.rend(); ++it) {
+    if (memcmp(it->addr, kBroadcast, 6) == 0 && it->data.size() >= sizeof(mesh_message)) {
+      mesh_message m{};
+      memcpy(&m, it->data.data(), sizeof(m));
+      if (m.message_type == type)
+        return true;
+    }
+  }
+  return false;
+}
+
+static mesh_message lastEspNowBroadcastOfType(uint8_t type) {
+  static constexpr uint8_t kBroadcast[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  for (auto it = espNowSentPackets.rbegin(); it != espNowSentPackets.rend(); ++it) {
+    if (memcmp(it->addr, kBroadcast, 6) == 0 && it->data.size() >= sizeof(mesh_message)) {
+      mesh_message m{};
+      memcpy(&m, it->data.data(), sizeof(m));
+      if (m.message_type == type)
+        return m;
+    }
+  }
+  ADD_FAILURE() << "no broadcast ESP-NOW packet of the requested message_type was sent";
+  return mesh_message{};
+}
+
+TEST_F(JoinAckRelayTest, EnrollPeerStampsSecondaryIdentityIntoJoinAck) {
+  Mesh master = makeMasterNode();
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  uint8_t leafPub[32];
+  for (int i = 0; i < 32; ++i) leafPub[i] = static_cast<uint8_t>(i + 1);
+  const uint8_t sec[6] = {0x02, 0, 0, 0, 0, 0x02};
+  uint8_t secPub[32];
+  for (int i = 0; i < 32; ++i) secPub[i] = static_cast<uint8_t>(0x40 + i);
+
+  resetEspNowMock();
+  master.enrollPeer(leaf, leafPub, sec, secPub);
+
+  // JOIN_ACK is broadcast; find it in the mock's sent frames.
+  ASSERT_TRUE(sawBroadcastOfType(MESH_TYPE_JOIN_ACK));
+  mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK);
+  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, sec, 6));
+  EXPECT_EQ(0, memcmp(ack.secondary_public_key, secPub, 32));
+}
+
+TEST_F(JoinAckRelayTest, EnrollPeerTwoArgLeavesSecondaryZero) {
+  Mesh master = makeMasterNode();
+  const uint8_t leaf[6] = {0x02, 0, 0, 0, 0, 0x0B};
+  uint8_t leafPub[32] = {9};
+  resetEspNowMock();
+  master.enrollPeer(leaf, leafPub); // 2-arg: no secondary
+  ASSERT_TRUE(sawBroadcastOfType(MESH_TYPE_JOIN_ACK));
+  mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK);
+  uint8_t zero6[6] = {}, zero32[32] = {};
+  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, zero6, 6));
+  EXPECT_EQ(0, memcmp(ack.secondary_public_key, zero32, 32));
+}
+
 // ─── Config-opcode injection resistance (CRITICAL finding) ──────────────────
 // Phase 3 seals+source-routes TARGETED downlink CONFIG_SET/NODE_ID_SET, and a
 // node opens a self-addressed sealed ADAPTER_DATA with its k_down before


### PR DESCRIPTION
## What

Phase 4 (final planned phase) closes design gap #8: after a node fails over from a silent primary master to a secondary, its sealed uplink reaches — and is decryptable by — the secondary.

- **JOIN_ACK carries the server-designated secondary identity**: `Mesh::enrollPeer` gains a 4-arg overload stamping `secondary_master_mac`/`secondary_public_key` (server-provided, relayed through the primary). Single-master enrollment is byte-identical (2-arg delegates with zeroed secondary).
- **Leaf registers the secondary master** as a persisted `PeerRegistry` peer (mac+pubkey) at enrollment, and records it for beacon adoption. This is what lets `masterE2EKeys()` derive a distinct `k_up`/`k_down` pair against the secondary after `currentMaster` flips to it on failover — **no change to the key-lookup path**.
- **Secondary opens the leaf's uplink** via the leaf's pubkey (server sync over the secondary's own serial link).
- **No wire-format or EEPROM-layout change**: the `secondary_*` fields already existed in proto v3; the secondary's key persists in the existing peer list (deviates from the spec's "add an EEPROM slot" — only 9 bytes were free, and the PeerRegistry approach is what makes key resolution work post-failover).

## Also fixed (real production gap this surfaced)

The nanopb serial codec (`mesh.pb.h` / `SerialFraming`) was stale — it stopped at field tag 11, so a real hub could never relay `secondary_*` to a master over serial (the fields were silently dropped). Added tags 15/16 to the generated header + wired encode/decode, JOIN_ACK-gated and non-zero-gated so all other frames are byte-identical.

## Security

- Rekey gating unchanged: the secondary registers via the same `registerPeerWithKey(allowRekey=false)` path, after all JOIN_ACK auth gates — a forged JOIN_ACK can neither inject a secondary nor rekey an established peer.
- Master-agnostic nonce (`epoch‖seq‖origin_mac`) + per-pair keys → switching masters cannot cause AEAD nonce reuse.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-16-multihop-routing-e2e-crypto-design.md` §5, §2
- Plan: `docs/superpowers/plans/2026-07-21-phase4-dual-master-failover.md`

## Test

180 pass / 0 disabled. New `UplinkReachesSecondaryMasterAfterFailover` proves **decryption** at the secondary (not just routing): the master only bridges an uplink to the hub after `openPayload` succeeds, so arrival at the secondary's hub is proof it decrypted. Route-adoption tests unchanged.

No protocol/submodule change (lattice-protocol stays v0.4.0).

## Tracked follow-ups (non-blocking)

- Add `max_size` options for tags 12–16 in `lattice-protocol/proto/mesh.options` **before any nanopb regen** — otherwise a regen emits callback fields and reverts the codec fix.
- Downlink *commands* (`CONFIG_SET`) from the secondary aren't yet honored post-failover (origin gate is primary-MAC-only, `Mesh.cpp` `TODO(dual-master)`) — functional completeness item, distinct from gap #8 (uplink data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)