### PR TITLE
docs: preserve umbrella spec + hardware requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# ESP32/arduino-cli build artifacts
+build/

--- a/docs/memory_usage.md
+++ b/docs/memory_usage.md
@@ -1,0 +1,212 @@
+# ESP32 Memory & Storage Usage
+
+Board: `esp32:esp32:esp32` (ESP32 Dev Module). Toolchain: `arduino-cli` + `esp32:esp32@3.3.10`.
+
+> **Status (2026-07-22): the hard numbers below are a stale baseline.**
+> They were measured **2026-07-13** — *before* the repo restructure (#24, 07-14)
+> and *before* Phases 1–5 (#33, #34, #35, #40, #41) landed end-to-end AEAD crypto,
+> the neighbor/route tables, dual-master failover, and the replay cache. A clean
+> firmware re-measure is currently **blocked** (see [Re-measurement is blocked](#re-measurement-is-currently-blocked));
+> the [static-allocation](#fixed-ram-allocations-current-source) and
+> [EEPROM](#eeprom-nvs-persistent-storage) sections are computed from *current* source and are live.
+
+## Baseline Summary (measured 2026-07-13 — STALE)
+
+| Region | Used | Total | % |
+|---|---|---|---|
+| Flash (program storage) | 972,596 B (950 KB) | 1,310,720 B (1,280 KB) | **74%** |
+| Static RAM (globals/BSS) | 48,532 B (47 KB) | 327,680 B (320 KB) | **14%** |
+
+Phases 1–5 have grown both figures (see [Changes since baseline](#changes-since-baseline-phases-15)).
+Static RAM is estimated ~+5.7 KB; flash is the region to watch — re-measure before trusting the 74%.
+
+## Flash Breakdown (baseline)
+
+### By ELF section
+
+| Section | Size | Purpose |
+|---|---|---|
+| `.flash.text` | 692 KB | Code in flash |
+| `.flash.rodata` | 152 KB | Constants, strings, lookup tables |
+| `.iram0.text` | 81 KB | Time-critical code mapped to IRAM |
+| `.iram0.vectors` | 1 KB | Interrupt vectors |
+| **Free** | **~338 KB** | 26% remaining |
+
+### By subsystem (`.text` symbols)
+
+| Subsystem | Flash |
+|---|---|
+| WiFi / ESP-NOW / lwIP stack | ~131 KB |
+| mbedTLS (ECDH, SHA-256, entropy, CTR-DRBG) | ~50 KB |
+| Application code (`lattice` namespace) | ~40 KB |
+| BT symbols (compiled-in despite `btStop()`) | ~10 KB |
+| nanopb | ~2.4 KB |
+| ESP-IDF SDK / FreeRTOS / HAL / misc | ~468 KB |
+
+## Static RAM Breakdown (baseline)
+
+### By ELF section
+
+| Section | Size | Purpose |
+|---|---|---|
+| `.dram0.data` | 23.5 KB | Initialized globals |
+| `.dram0.bss` | 23.9 KB | Zero-init globals |
+| `.rtc.force_slow` | 32 B | RTC slow RAM |
+| **Free for stack + heap** | **~279 KB** | 86% remaining |
+
+### By subsystem (`.data` + `.bss` symbols)
+
+| Subsystem | Static RAM |
+|---|---|
+| FreeRTOS / system | ~5.4 KB |
+| WiFi / Net static globals | ~4.0 KB |
+| Application globals (`mesh`, `adapter`, LEDs, etc.) | ~2.7 KB |
+| mbedTLS static globals | ~1.6 KB |
+
+At baseline the `mesh` object was the largest single app symbol at **868 B** BSS.
+Phases 2–5 have since grown it to an estimated **~5.7 KB** — see below.
+
+## Changes since baseline (Phases 1–5)
+
+Landed after the 07-13 measure. Directional flash/RAM impact (not yet re-measured):
+
+| Phase | Feature | Flash | Static RAM |
+|---|---|---|---|
+| 1 (#33) | Protocol v3 + end-to-end AEAD payload crypto (X25519 + AEAD) | **↑↑** new cipher + KDF paths in mbedTLS | `E2EKeyStore` ~710 B |
+| 2 (#34) | Multi-hop data uplink via `NeighborTable` | ↑ small | `NeighborTable` ~96 B |
+| 3 (#35) | Downlink source routing + `k_down` sealing | ↑ | `RouteTable` ~2.3 KB (master-side) + downlink LRU 24 B |
+| 4 (#40) | Dual-master data failover | ↑ | secondary-master MACs/keys, small |
+| 5 (#41) | Dual-master `CONFIG_SET`, relayed-target, nanopb regen | ↑ | proto fields widen `mesh_message` |
+| (#28/#23) | Replay protection + route reporting | ↑ | `ReplayCache` ~206 B |
+
+**Net:** static RAM is still trivial against the 320 KB budget. **Flash is the metric that
+actually moved** — the AEAD cipher, larger protobuf message, and dual-master paths all add
+`.text`/`.rodata`. The 74% figure is optimistic now; re-measure before the next crypto/adapter
+addition.
+
+## Fixed RAM allocations (current source)
+
+Tiger-style: every mesh data structure is a fixed-size array sized from `main/project_config.h`
+— **zero heap, allocated up-front whether or not a node uses it.** Computed from field layout
+(xtensa 4-byte alignment). All live inside the single `mesh` global (`main/src/mesh/Mesh.h`):
+
+| Structure | Bound (config) | Per entry | Total | Notes |
+|---|---|---|---|---|
+| `recvQueue` (RX ring) | `RECV_QUEUE_SIZE = 8` | 6 + 242 (`mesh_message`) | **~1.94 KB** | SPSC lock-free queue, WiFi-cb → loop |
+| `RouteTable` | `LATTICE_ROUTE_TABLE_MAX = 32` | 72 (incl. `path[60]`) | **~2.25 KB** | **Master-only use; dead weight on leaf nodes** |
+| `E2EKeyStore` | `LATTICE_E2E_KEYCACHE_MAX = 10` | 71 (`kUp[32]`+`kDown[32]`) | **~710 B** | Derived-key cache, X25519 |
+| `PeerRegistry` | `MAX_PEERS = 10` | 44 (`publicKey[32]`) | **~440 B** | Mirrors EEPROM peer list |
+| `ReplayCache` | `CACHE_SIZE = 16` | 12 | **~206 B** | Anti-replay (origin, epoch, seq) |
+| `NeighborTable` | `LATTICE_NEIGHBOR_MAX = 8` | 12 | **~96 B** | Uplink next-hop candidates |
+| `downlinkPeerLru` | `LATTICE_DOWNLINK_PEER_MAX = 4` | 6 | **24 B** | Bounds ESP-NOW peer-table exhaustion |
+| misc (MACs, `meshKey[16]`, fwd peer, scalars) | — | — | **~60 B** | |
+| **`mesh` object total** | | | **~5.7 KB** | vs 868 B at baseline |
+
+`mesh_message` is the in-RAM wire struct from the vendored `lattice-protocol/c` (242 B,
+`static_assert`-locked to the server proto), aliased in via `using ::mesh_message`. The `recvQueue`
+and any per-frame stack copies inherit its 242 B — the single largest lever on both RAM and stack
+depth.
+
+## EEPROM / NVS (persistent storage)
+
+Layout in `main/src/persistence/EepromManager.h`. `EEPROM.begin(TOTAL_SIZE)` maps a 512-byte NVS blob.
+
+| Region | Addr | Size |
+|---|---|---|
+| MASTER_FLAG / DEV_FLAG / ADAPTER_TYPE | 0,1,8 | 3 B |
+| MESH_KEY | 16 | 16 B |
+| PEER_LIST (10 × 38 B: MAC + pubkey) | 32 | 380 B |
+| REBOOT_REASON / COUNT + reserved | 412 | 5 B |
+| PRIVATE_KEY / PUBLIC_KEY / KEYPAIR_CRC | 417 | 66 B |
+| ENROLLED_FLAG / BOOT_EPOCH | 483 | 5 B |
+| KNOWN_MASTER_MAC (primary) | 488 | 6 B |
+| SCHEMA_VERSION / TX_POWER / NODE_ID | 494 | 3 B |
+| KNOWN_MASTER_MAC_SECONDARY | 497 | 6 B |
+| **Total used** | | **503 / 512 B (98%)** |
+
+> **EEPROM is the tightest budget in the whole system — 9 bytes free.**
+> `PEER_LIST` (380 B) dominates: raising `MAX_PEERS` past 10 overflows 512 B immediately
+> (each peer = 38 B). Any new persisted field needs the 3 reserved bytes (414–416) or an
+> `EEPROM.begin()` size bump + a schema-version migration (see `EepromManager::init()`).
+
+## Runtime Heap
+
+Runtime-only, not in the static figures. At steady state after `setup()`:
+
+- WiFi stack claims ~80–100 KB heap
+- FreeRTOS task stacks claim additional space
+- Effective usable heap for application: **~150–180 KB**
+
+E2E AEAD (Phase 1) runs X25519 on the stack per key derivation (~ms); the `E2EKeyStore` exists
+specifically to amortise that so it isn't re-run per frame.
+
+## Re-measurement is currently BLOCKED
+
+The firmware **does not build cleanly under `arduino-cli`** (only host unit/e2e tests and CodeQL
+build in CI — no CI job compiles the firmware). Three issues block a fresh `xtensa-esp32-elf-size`
+measure; the Arduino IDE hides all three via different include resolution:
+
+1. **nanopb include path** — `mesh.pb.h` does `#include "pb.h"` but `.../serialization/nanopb`
+   isn't on the default sketch include path. Fix: add it, or flatten nanopb into the sketch.
+2. **Non-self-contained headers** — `main/src/app/ButtonHandler.h` uses `Logger` / `LogLevel`
+   unqualified, relying on a `using namespace lattice::utils;` that `main.ino` declares *before*
+   including it. (The baseline doc noted the same class of bug for `Serial_Adapter`; it moved in
+   the restructure, not fixed.) Fix: each header includes what it uses and fully-qualifies names.
+3. **Duplicate `mesh_message` typedef** — the vendored `main/lib/lattice-protocol/c/mesh_message.h`
+   is auto-scanned from `lib/` and its `typedef struct … mesh_message` collides with the alias
+   pulled in via `using ::mesh_message`. Fix: keep the vendored C tree out of the Arduino
+   `lib/` auto-scan, or gate its inclusion.
+
+**Prerequisite for accurate optimization work:** fix 1–3 so `arduino-cli compile --fqbn
+esp32:esp32:esp32` succeeds, then add a CI firmware-build + size-report job so this doc can't
+silently rot again. Re-run:
+
+```sh
+arduino-cli compile --fqbn esp32:esp32:esp32 --build-path build/fw main
+xtensa-esp32-elf-size -A build/fw/main.ino.elf
+```
+
+## Optimization Plan
+
+Prioritised by (constraint pressure × payoff). Do the measurement-unblock first — everything
+below is estimated until the firmware compiles under `arduino-cli`.
+
+### P0 — Unblock measurement (prerequisite)
+- Fix the three build blockers above; add a CI size-report job. **Without this every number here
+  is a guess.** Low effort, unlocks everything else.
+
+### P1 — Flash (the real constraint, ~74%→higher)
+| Lever | Est. saving | Effort | Risk |
+|---|---|---|---|
+| **Drop BT** — `CONFIG_BT_ENABLED=n`. Needs an ESP-IDF (not Arduino) build; `btStop()` only disables at runtime. | ~10 KB + heap | High (toolchain switch) | Med |
+| **Trim mbedTLS** — Phase-1 AEAD pulled in a cipher; prune unused suites via `mbedtls_config` (drop RSA/DHE/unused curves, keep X25519 + the one AEAD). | 10–30 KB | Med (custom config on IDF) | Med |
+| **Strip logging in prod** — `DEFAULT_LOG_LEVEL = LOG_NONE` already; ensure format strings/`.rodata` are compiled out, not just gated at runtime (`#if` not `if`). | few–10 KB `.rodata` | Low | Low |
+| **`-Os` + LTO + `-ffunction-sections,-Wl,--gc-sections`** if not already set by the core. | 5–15 KB | Low | Low |
+| **Single AEAD** — if Phase 1 links both AES-GCM and ChaCha20-Poly1305, pick one. | 5–15 KB | Low | Low |
+
+### P2 — EEPROM (98% full — hardest ceiling)
+| Lever | Payoff | Effort |
+|---|---|---|
+| **Shrink `PEER_LIST`** — 380 B / 512 is the whole squeeze. Store a peer-count + packed records instead of a fixed 10×38 B, or move peers to a dedicated NVS namespace and free the raw-EEPROM budget. | frees ~350 B | Med (migration) |
+| **Migrate raw EEPROM → NVS/Preferences** — key/value NVS avoids the 512 B fixed map and versioning gymnastics entirely. | removes the ceiling | Med-High (rewrite `EepromManager`) |
+| Use the 3 reserved bytes (414–416) for the *next* small field only — not a growth strategy. | 3 B | trivial |
+
+### P3 — Static RAM (~5.7 KB mesh object; not urgent, but wasteful)
+| Lever | Est. saving | Notes |
+|---|---|---|
+| **`RouteTable` on masters only** — 2.25 KB is allocated on every leaf but only the master routes downlink. Gate behind role (compile-time or a pointer allocated on promotion). | ~2.25 KB on leaves | Biggest single RAM win; needs role known before construction |
+| **Right-size the bounds** — `LATTICE_ROUTE_TABLE_MAX=32`, `RECV_QUEUE_SIZE=8`, `CACHE_SIZE=16` are generous. Tune to real deployment fan-out. | 0.5–2 KB | Measure real occupancy first |
+| **Shrink `mesh_message` residency** — 242 B copied into an 8-deep ring (~1.94 KB) and onto the stack per frame. If most fields are optional, a compact internal form or a smaller ring would cut both RAM and worst-case stack. | up to ~1 KB | Touches wire struct — coordinate with server proto `static_assert` |
+
+### P4 — Hygiene (enables the above, no direct saving)
+- Make headers self-contained (blocker #2) — also the correctness fix for non-Arduino toolchains.
+- Keep the vendored `lattice-protocol` submodule out of Arduino `lib/` auto-scan (blocker #3).
+- **Re-run this analysis after every major dependency/feature change** and commit the diff, so
+  flash %, the mesh-object RAM total, and EEPROM headroom are always current.
+
+## Notes
+
+- **Flash is the pressure point; EEPROM is the hard ceiling (98%).** RAM has huge headroom.
+- **BT ~10 KB flash** despite `btStop()` — compiled in, runtime-disabled only. Removing needs an
+  ESP-IDF build (`CONFIG_BT_ENABLED=n`), unavailable in the Arduino toolchain.
+- Baseline flash/RAM figures are **2026-07-13, pre-Phase 1–5** — treat as a floor, not current.

--- a/docs/superpowers/plans/2026-07-13-repo-restructure.md
+++ b/docs/superpowers/plans/2026-07-13-repo-restructure.md
@@ -1,0 +1,1835 @@
+# Repo Restructure & Code Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Full directory restructure, file decomposition, and naming normalisation of lattice-nodes firmware — zero functional change.
+
+**Architecture:** Work bottom-up: rename leaf dependencies first (Logger → `logging/`, `EepromManager`), then rename mid-tier dirs and classes (`mesh/`, `adapter/`, `PirAdapter`, `SerialAdapter`), then extract Mesh sub-components (`ReplayCache`, `MeshCrypto`, `PeerRegistry`, `Enrollment`), then extract `SerialFraming`, then create `app/` layer from `main.ino`. Tests pass after every task. A key structural improvement: once mbedtls is isolated in `MeshCrypto.h` / `Enrollment.cpp`, `mesh_logic_impl.cpp` shrinks — the production `.cpp` files are compiled directly in tests.
+
+**Tech Stack:** C++17, Arduino/ESP-IDF (ESP32), GoogleTest, CMake (test build), `git mv` for history-preserving renames.
+
+## Global Constraints
+
+- Zero functional change — all logic moves verbatim, no behaviour modifications
+- Use `git mv` for all file/directory renames (preserves history)
+- Tests must pass after every task: `cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure`
+- No heap allocation introduced; static arrays only
+- `IRAM_ATTR` callbacks must remain in `Mesh.cpp`
+- `project_config.h` stays at `main/project_config.h` (Arduino IDE requirement)
+- All paths in this plan are relative to repo root (`lattice-nodes/`)
+- Include paths in firmware source are rooted at `main/` (Arduino sketch root) OR `main/src/` (CMake include root — check CMakeLists.txt line 19–26)
+
+---
+
+## File Map
+
+**New files created:**
+- `main/src/logging/Logger.h/.cpp` (moved from `src/core/`)
+- `main/src/persistence/EepromManager.h/.cpp` (moved + renamed from `EEPROM_Manager`)
+- `main/src/mesh/` entire dir (moved from `src/Mesh/`)
+- `main/src/mesh/ReplayCache.h` (extracted from Mesh)
+- `main/src/mesh/MeshCrypto.h` (extracted from Mesh.cpp)
+- `main/src/mesh/PeerRegistry.h/.cpp` (extracted from Mesh)
+- `main/src/mesh/Enrollment.h/.cpp` (extracted from Mesh)
+- `main/src/adapter/` entire dir (moved from `src/Adapter/`)
+- `main/src/adapter/pir/PirAdapter.h/.cpp` (moved + renamed from `PIR_Adapter`)
+- `main/src/adapter/serial/SerialAdapter.h/.cpp` (moved + renamed from `Serial_Adapter`)
+- `main/src/adapter/serial/SerialFraming.h/.cpp` (extracted from SerialAdapter)
+- `main/src/app/BootManager.h` (extracted from `main.ino`)
+- `main/src/app/DisplayManager.h` (extracted from `main.ino`)
+- `main/src/app/ButtonHandler.h` (extracted from `main.ino`)
+
+**Deleted (via git mv):**
+- All original locations of moved files above
+
+**Modified:**
+- `main/main.ino` (reduced to ~150 lines)
+- `main/project_config.h` (include paths)
+- `tests/CMakeLists.txt` (all paths + 3 new sources)
+- `tests/mocks/mesh_logic_impl.cpp` (member paths updated; many methods removed — they move to production `.cpp` files compiled in tests)
+- `tests/mocks/firmware_stubs.cpp` (add stubs for `Enrollment::init` + `Enrollment::enrollPeer`)
+- All test `unit/` files (include paths)
+- `REFACTORING_GUIDE.md`
+
+---
+
+### Task 1: Rename `src/core/` → `src/logging/`
+
+**Files:**
+- Move: `main/src/core/Logger.h` → `main/src/logging/Logger.h`
+- Move: `main/src/core/Logger.cpp` → `main/src/logging/Logger.cpp`
+- Modify: `tests/CMakeLists.txt`, `main/project_config.h`, and all firmware files that include Logger
+
+**Interfaces:** Logger API unchanged.
+
+- [ ] **Step 1: Move the directory**
+
+```bash
+git mv main/src/core main/src/logging
+```
+
+- [ ] **Step 2: Update CMakeLists.txt**
+
+In `tests/CMakeLists.txt`, change:
+```cmake
+  ../main/src/core/Logger.cpp
+```
+to:
+```cmake
+  ../main/src/logging/Logger.cpp
+```
+
+- [ ] **Step 3: Update all `#include "src/core/Logger.h"` occurrences**
+
+```bash
+grep -rl '"src/core/Logger.h"' main/ tests/
+```
+
+Replace in each file found:
+```cpp
+// OLD:
+#include "src/core/Logger.h"
+// NEW:
+#include "src/logging/Logger.h"
+```
+
+Also check for the short form used in mock files:
+```bash
+grep -rl '"core/Logger.h"' main/ tests/
+```
+Replace with `"logging/Logger.h"` in any hits.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "refactor: rename src/core/ to src/logging/"
+```
+
+---
+
+### Task 2: Rename `EEPROM_Manager` → `EepromManager`
+
+**Files:**
+- Move: `main/src/persistence/EEPROM_Manager.h` → `main/src/persistence/EepromManager.h`
+- Move: `main/src/persistence/EEPROM_Manager.cpp` → `main/src/persistence/EepromManager.cpp`
+- Modify: class internals, all consumers
+
+**Interfaces:** Class renamed `lattice::utils::EepromManager`. Singleton: `EepromManager::getInstance()`. All method signatures unchanged.
+
+- [ ] **Step 1: Move files**
+
+```bash
+git mv main/src/persistence/EEPROM_Manager.h main/src/persistence/EepromManager.h
+git mv main/src/persistence/EEPROM_Manager.cpp main/src/persistence/EepromManager.cpp
+```
+
+- [ ] **Step 2: Rename class declaration in `EepromManager.h`**
+
+```cpp
+// OLD:
+class EEPROM_Manager {
+// ...
+  static EEPROM_Manager& getInstance();
+  EEPROM_Manager(const EEPROM_Manager&) = delete;
+  EEPROM_Manager& operator=(const EEPROM_Manager&) = delete;
+  EEPROM_Manager(EEPROM_Manager&&) = delete;
+  EEPROM_Manager& operator=(EEPROM_Manager&&) = delete;
+// ...
+  EEPROM_Manager();
+
+// NEW:
+class EepromManager {
+// ...
+  static EepromManager& getInstance();
+  EepromManager(const EepromManager&) = delete;
+  EepromManager& operator=(const EepromManager&) = delete;
+  EepromManager(EepromManager&&) = delete;
+  EepromManager& operator=(EepromManager&&) = delete;
+// ...
+  EepromManager();
+```
+
+Leave the header guard `#ifndef EEPROM_MANAGER_H` unchanged.
+
+- [ ] **Step 3: Rename class in `EepromManager.cpp`**
+
+Replace every `EEPROM_Manager::` → `EepromManager::` and update the singleton:
+```cpp
+// OLD:
+EEPROM_Manager& EEPROM_Manager::getInstance() {
+  static EEPROM_Manager instance;
+  return instance;
+}
+// NEW:
+EepromManager& EepromManager::getInstance() {
+  static EepromManager instance;
+  return instance;
+}
+```
+
+- [ ] **Step 4: Update all consumers**
+
+```bash
+grep -rl 'EEPROM_Manager' main/ tests/
+```
+
+In every file found, replace:
+- `#include "src/persistence/EEPROM_Manager.h"` → `#include "src/persistence/EepromManager.h"`
+- `EEPROM_Manager::getInstance()` → `EepromManager::getInstance()`
+- `EEPROM_Manager&` → `EepromManager&`
+
+Also check mock/test files for the short include form:
+```bash
+grep -rl 'EEPROM_Manager' tests/
+```
+
+- [ ] **Step 5: Update CMakeLists.txt**
+
+```cmake
+# OLD:
+  ../main/src/persistence/EEPROM_Manager.cpp
+# NEW:
+  ../main/src/persistence/EepromManager.cpp
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor: rename EEPROM_Manager → EepromManager"
+```
+
+---
+
+### Task 3: Rename directories + `PIR_Adapter` / `Serial_Adapter` classes
+
+Move `src/Mesh/` → `src/mesh/`, `src/Adapter/` → `src/adapter/`, rename `PIR_Adapter` → `PirAdapter`, `Serial_Adapter` → `SerialAdapter` (class names + files). Do all renames in one task to keep includes consistent.
+
+**Files:**
+- Move: `main/src/Mesh/` → `main/src/mesh/`
+- Move: `main/src/Adapter/` → `main/src/adapter/`
+- Move+rename: `PIR_Adapter/PIR_Adapter.h/.cpp` → `pir/PirAdapter.h/.cpp`
+- Move+rename: `Serial_Adapter/Serial_Adapter.h/.cpp` → `serial/SerialAdapter.h/.cpp`
+- Modify: all `#include` paths and class references throughout
+
+**Interfaces:**
+- `PirAdapter` replaces `PIR_Adapter` — identical API
+- `SerialAdapter` replaces `Serial_Adapter` — static method becomes `SerialAdapter::relayEnrollmentToServer`
+
+- [ ] **Step 1: Move Mesh and Adapter directories**
+
+```bash
+git mv main/src/Mesh main/src/mesh
+git mv main/src/Adapter main/src/adapter
+```
+
+- [ ] **Step 2: Rename adapter subdirectories**
+
+```bash
+git mv main/src/adapter/PIR_Adapter main/src/adapter/pir
+git mv main/src/adapter/Serial_Adapter main/src/adapter/serial
+```
+
+- [ ] **Step 3: Rename PIR_Adapter files**
+
+```bash
+git mv main/src/adapter/pir/PIR_Adapter.h main/src/adapter/pir/PirAdapter.h
+git mv main/src/adapter/pir/PIR_Adapter.cpp main/src/adapter/pir/PirAdapter.cpp
+```
+
+- [ ] **Step 4: Rename Serial_Adapter files**
+
+```bash
+git mv main/src/adapter/serial/Serial_Adapter.h main/src/adapter/serial/SerialAdapter.h
+git mv main/src/adapter/serial/Serial_Adapter.cpp main/src/adapter/serial/SerialAdapter.cpp
+```
+
+- [ ] **Step 5: Rename class `PIR_Adapter` → `PirAdapter` in its files**
+
+In `main/src/adapter/pir/PirAdapter.h`:
+```cpp
+// OLD:
+class PIR_Adapter : public Adapter {
+public:
+  explicit PIR_Adapter(int pirPin);
+// NEW:
+class PirAdapter : public Adapter {
+public:
+  explicit PirAdapter(int pirPin);
+```
+
+In `main/src/adapter/pir/PirAdapter.cpp`:
+```cpp
+// Update include:
+#include "PirAdapter.h"   // was: #include "PIR_Adapter.h"
+// Replace all method definitions:
+PirAdapter::PirAdapter(int pirPin) ...   // was: PIR_Adapter::PIR_Adapter
+PirAdapter::init() ...                   // was: PIR_Adapter::init
+// etc. — replace every PIR_Adapter:: → PirAdapter::
+```
+
+- [ ] **Step 6: Rename class `Serial_Adapter` → `SerialAdapter` in its files**
+
+In `main/src/adapter/serial/SerialAdapter.h`:
+```cpp
+// OLD:
+class Serial_Adapter : public Adapter {
+public:
+  explicit Serial_Adapter(int pin);
+  static void relayEnrollmentToServer(const uint8_t mac[6], const uint8_t pubKey[32]);
+// NEW:
+class SerialAdapter : public Adapter {
+public:
+  explicit SerialAdapter(int pin);
+  static void relayEnrollmentToServer(const uint8_t mac[6], const uint8_t pubKey[32]);
+```
+
+In `main/src/adapter/serial/SerialAdapter.cpp`:
+```cpp
+// Update include:
+#include "SerialAdapter.h"   // was: #include "Serial_Adapter.h"
+// Replace every Serial_Adapter:: → SerialAdapter::
+```
+
+- [ ] **Step 7: Update all `#include` paths and class references**
+
+```bash
+grep -rl 'PIR_Adapter\|Serial_Adapter\|src/Mesh\|src/Adapter' main/ tests/
+```
+
+Key substitutions across all files found:
+
+```cpp
+// Include paths:
+"src/Mesh/Mesh.h"                             → "src/mesh/Mesh.h"
+"Mesh/Mesh.h"                                 → "mesh/Mesh.h"         // in tests/mocks/
+"src/Adapter/Adapter.h"                       → "src/adapter/Adapter.h"
+"src/Adapter/AdapterFactory.h"                → "src/adapter/AdapterFactory.h"
+"src/Adapter/PIR_Adapter/PIR_Adapter.h"       → "src/adapter/pir/PirAdapter.h"
+"src/Adapter/Serial_Adapter/Serial_Adapter.h" → "src/adapter/serial/SerialAdapter.h"
+"src/Mesh/serialization/..."                  → "src/mesh/serialization/..."
+"src/Mesh/serialization/nanopb/..."           → "src/mesh/serialization/nanopb/..."
+
+// Class references:
+PIR_Adapter(         → PirAdapter(
+new PIR_Adapter      → new PirAdapter
+Serial_Adapter::     → SerialAdapter::
+new Serial_Adapter   → new SerialAdapter
+```
+
+- [ ] **Step 8: Update CMakeLists.txt — all paths and include dirs**
+
+```cmake
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/mocks
+  ${CMAKE_CURRENT_SOURCE_DIR}/../main/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/../main
+  ${CMAKE_CURRENT_SOURCE_DIR}/../main/lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../main/src/mesh/serialization/nanopb
+  ${CMAKE_CURRENT_SOURCE_DIR}/../main/src/mesh/serialization
+)
+
+set(FIRMWARE_SOURCES
+  ../main/src/mesh/serialization/mesh.pb.c
+  ../main/src/mesh/serialization/nanopb/pb_encode.c
+  ../main/src/mesh/serialization/nanopb/pb_decode.c
+  ../main/src/mesh/serialization/nanopb/pb_common.c
+  ../main/src/persistence/EepromManager.cpp
+  ../main/src/adapter/AdapterFactory.cpp
+  ../main/src/adapter/Adapter.cpp
+  ../main/src/adapter/serial/SerialAdapter.cpp
+  ../main/src/adapter/pir/PirAdapter.cpp
+  ../main/src/logging/Logger.cpp
+  ../main/src/error/ErrorCore.cpp
+  ../main/src/hardware/output/GpioOutput.cpp
+  ../main/src/hardware/output/Led.cpp
+  ../main/src/hardware/output/SevenSegDisplay.cpp
+  ../main/src/hardware/input/GpioInput.cpp
+  ../main/src/hardware/input/Pir.cpp
+  mocks/esp_now_mock.cpp
+  mocks/esp_wifi_mock.cpp
+  mocks/time_mock.cpp
+  mocks/serial_mock.cpp
+  mocks/Arduino.cpp
+  mocks/EEPROM.cpp
+  mocks/WiFi.cpp
+  mocks/firmware_stubs.cpp
+  mocks/mesh_logic_impl.cpp
+)
+```
+
+- [ ] **Step 9: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A && git commit -m "refactor: rename mesh/, adapter/ dirs + PirAdapter/SerialAdapter classes"
+```
+
+---
+
+### Task 4: Extract `ReplayCache.h`
+
+Extract replay protection into a standalone header-only struct. Mesh composes it as a member. The struct is a pure struct (no Arduino/ESP-NOW deps) — header-only is safe.
+
+**Files:**
+- Create: `main/src/mesh/ReplayCache.h`
+- Modify: `main/src/mesh/Mesh.h` (remove replay fields, add `ReplayCache replay` member)
+- Modify: `main/src/mesh/Mesh.cpp` (use `replay.` prefix for all replay fields)
+- Modify: `tests/mocks/mesh_logic_impl.cpp` (use `replay.` prefix)
+- Modify: `tests/unit/test_replay_cache.cpp` (test `ReplayCache` directly)
+
+- [ ] **Step 1: Create `main/src/mesh/ReplayCache.h`**
+
+The body of `isReplay` is the exact implementation from `mesh_logic_impl.cpp` (`Mesh::isReplay`, lines 22–35). Move it verbatim, substituting `replayCache` → `cache`, `replayCacheIdx` → `idx`.
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "../../lib/lattice-protocol/c/mesh_message.h"
+
+namespace lattice {
+namespace mesh {
+
+struct ReplayCache {
+  static constexpr size_t CACHE_SIZE = 16;
+
+  struct Entry {
+    uint8_t mac[6];
+    uint32_t epoch;
+    uint16_t seq;
+  };
+
+  Entry cache[CACHE_SIZE]{};
+  size_t idx{0};
+  uint32_t bootEpoch{0};
+  uint16_t txSeqNum{0};
+  uint32_t lastRelayedEpoch{0};
+  uint16_t lastRelayedSeqNum{0};
+
+  void init(uint32_t epoch) {
+    bootEpoch = epoch;
+    txSeqNum = 0;
+    idx = 0;
+    lastRelayedEpoch = 0;
+    lastRelayedSeqNum = 0;
+    memset(cache, 0, sizeof(cache));
+  }
+
+  uint16_t nextSeq() { return ++txSeqNum; }
+
+  inline bool isReplay(const mesh_message& msg) {
+    for (size_t i = 0; i < CACHE_SIZE; ++i) {
+      if (memcmp(cache[i].mac, msg.origin_mac_address, 6) == 0 &&
+          cache[i].epoch == msg.epoch_num && cache[i].seq == msg.seq_num) {
+        return true;
+      }
+    }
+    memcpy(cache[idx].mac, msg.origin_mac_address, 6);
+    cache[idx].epoch = msg.epoch_num;
+    cache[idx].seq = msg.seq_num;
+    idx = (idx + 1) % CACHE_SIZE;
+    return false;
+  }
+};
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 2: Update `Mesh.h` — remove replay fields, add composed member**
+
+Add include near the top of `Mesh.h`:
+```cpp
+#include "ReplayCache.h"
+```
+
+Remove from the private section (search for each):
+```cpp
+// REMOVE:
+struct ReplayEntry { uint8_t mac[6]; uint32_t epoch; uint16_t seq; };
+static constexpr size_t REPLAY_CACHE_SIZE = 16;
+ReplayEntry replayCache[REPLAY_CACHE_SIZE];
+size_t replayCacheIdx;
+bool isReplay(const mesh_message& msg);
+uint32_t bootEpoch;
+uint16_t txSeqNum;
+uint32_t lastRelayedEpoch;
+uint16_t lastRelayedSeqNum;
+```
+
+Add to the private section:
+```cpp
+ReplayCache replay;
+```
+
+- [ ] **Step 3: Update `Mesh.cpp` — use `replay.` prefix**
+
+Replace all occurrences (use search-replace):
+```
+replayCache[  →  replay.cache[
+replayCacheIdx  →  replay.idx
+REPLAY_CACHE_SIZE  →  ReplayCache::CACHE_SIZE
+bootEpoch  →  replay.bootEpoch
+txSeqNum  →  replay.txSeqNum
+lastRelayedEpoch  →  replay.lastRelayedEpoch
+lastRelayedSeqNum  →  replay.lastRelayedSeqNum
+isReplay(  →  replay.isReplay(
+```
+
+In `Mesh::init()`, find where `bootEpoch` is loaded from EEPROM and replace:
+```cpp
+// OLD:
+bootEpoch = EepromManager::getInstance().loadBootEpoch() + 1;
+EepromManager::getInstance().saveBootEpoch(bootEpoch);
+txSeqNum = 0;
+memset(replayCache, 0, sizeof(replayCache));
+replayCacheIdx = 0;
+// NEW:
+uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
+EepromManager::getInstance().saveBootEpoch(epoch);
+replay.init(epoch);
+```
+
+- [ ] **Step 4: Update `mesh_logic_impl.cpp` — use `replay.` prefix**
+
+`Mesh::isReplay` is implemented in `mesh_logic_impl.cpp` (lines 22–35). Remove it entirely — it now lives in `ReplayCache::isReplay` inside `ReplayCache.h`, which is compiled everywhere via the header.
+
+In `Mesh::processMasterBeacon` (lines 101–118 of `mesh_logic_impl.cpp`), replace:
+```cpp
+// OLD:
+lastRelayedEpoch = msg.epoch_num;
+lastRelayedSeqNum = msg.seq_num;
+bool isNewer = (msg.epoch_num > lastRelayedEpoch) ||
+               (msg.epoch_num == lastRelayedEpoch && msg.seq_num > lastRelayedSeqNum);
+// NEW:
+bool isNewer = (msg.epoch_num > replay.lastRelayedEpoch) ||
+               (msg.epoch_num == replay.lastRelayedEpoch && msg.seq_num > replay.lastRelayedSeqNum);
+// ...
+replay.lastRelayedEpoch = msg.epoch_num;
+replay.lastRelayedSeqNum = msg.seq_num;
+```
+
+In `Mesh::drainRecvQueue` (line 136), the call `isReplay(msg)` becomes `replay.isReplay(msg)`.
+
+- [ ] **Step 5: Update `test_replay_cache.cpp` — test `ReplayCache` directly**
+
+The existing test accesses `Mesh::replayCache` via the `UNIT_TEST` public hack. Replace the entire test to use `ReplayCache` directly — no Mesh needed:
+
+```cpp
+#include <gtest/gtest.h>
+#include "mesh/ReplayCache.h"
+
+using namespace lattice::mesh;
+
+TEST(ReplayCacheTest, FreshMessageNotReplay) {
+  ReplayCache rc;
+  rc.init(1);
+  mesh_message msg{};
+  msg.epoch_num = 1;
+  msg.seq_num = 1;
+  memset(msg.origin_mac_address, 0xAA, 6);
+  EXPECT_FALSE(rc.isReplay(msg));
+}
+
+TEST(ReplayCacheTest, DuplicateIsReplay) {
+  ReplayCache rc;
+  rc.init(1);
+  mesh_message msg{};
+  msg.epoch_num = 1;
+  msg.seq_num = 1;
+  memset(msg.origin_mac_address, 0xAA, 6);
+  rc.isReplay(msg);   // first — records it
+  EXPECT_TRUE(rc.isReplay(msg));  // second — replay
+}
+
+TEST(ReplayCacheTest, DifferentSeqNotReplay) {
+  ReplayCache rc;
+  rc.init(1);
+  mesh_message msg{};
+  msg.epoch_num = 1;
+  msg.seq_num = 1;
+  memset(msg.origin_mac_address, 0xAA, 6);
+  rc.isReplay(msg);
+  msg.seq_num = 2;
+  EXPECT_FALSE(rc.isReplay(msg));
+}
+
+TEST(ReplayCacheTest, RingBufferWrapsWithoutFalsePositive) {
+  ReplayCache rc;
+  rc.init(1);
+  mesh_message msg{};
+  msg.epoch_num = 1;
+  memset(msg.origin_mac_address, 0xBB, 6);
+  // Fill cache entirely
+  for (uint16_t i = 1; i <= ReplayCache::CACHE_SIZE + 1; ++i) {
+    msg.seq_num = i;
+    EXPECT_FALSE(rc.isReplay(msg));
+  }
+}
+```
+
+Note: keep any existing test cases from the original `test_replay_cache.cpp` that aren't covered above — migrate them to use `ReplayCache` directly.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass, including `test_replay_cache`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract ReplayCache from Mesh"
+```
+
+---
+
+### Task 5: Extract `MeshCrypto.h`
+
+Extract the two static file-scope crypto helpers from `Mesh.cpp` into a header-only namespace. Inline functions are valid C++17 — duplicate definitions across TUs are merged by the linker.
+
+**Files:**
+- Create: `main/src/mesh/MeshCrypto.h`
+- Modify: `main/src/mesh/Mesh.cpp` (remove static functions, add include, update call sites)
+
+- [ ] **Step 1: Create `main/src/mesh/MeshCrypto.h`**
+
+The function bodies are the verbatim content of `static derivePeerLMK` and `static registerPeerWithEspNow` from `Mesh.cpp` (lines 29–160), plus the keygen branch from `Mesh::loadOrGenerateKeypair`. Change `static void` → `inline void`.
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecp.h>
+#include <mbedtls/sha256.h>
+#include "src/error/Error.h"
+#include "src/error/ErrorCore.h"
+
+namespace lattice {
+namespace mesh {
+namespace crypto {
+
+// Move exact body of static derivePeerLMK() from Mesh.cpp (search "static void derivePeerLMK").
+// Change: static void → inline void
+inline void derivePeerLMK(const uint8_t* ownPriv32, const uint8_t* peerPub32,
+                          uint8_t* lmk16Out) {
+  // ... verbatim from Mesh.cpp
+}
+
+// Move exact body of static registerPeerWithEspNow() from Mesh.cpp.
+// Change: static void → inline void
+inline void registerPeerWithEspNow(const uint8_t mac[6], const uint8_t* ownPriv32,
+                                   const uint8_t* peerPub32) {
+  // ... verbatim from Mesh.cpp
+  // Internal call: derivePeerLMK(ownPriv32, peerPub32, lmk);  (no change needed)
+}
+
+// Extract ONLY the key generation branch from Mesh::loadOrGenerateKeypair().
+// The load-from-EEPROM branch stays in Enrollment::init().
+inline void generateKeypair(uint8_t* priv32Out, uint8_t* pub32Out) {
+  // ... verbatim mbedtls keygen block from Mesh::loadOrGenerateKeypair() generation branch
+}
+
+} // namespace crypto
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 2: Update `Mesh.cpp`**
+
+Add near the top of `Mesh.cpp`:
+```cpp
+#include "MeshCrypto.h"
+```
+
+Remove the two static functions (`derivePeerLMK` and `registerPeerWithEspNow`) entirely from `Mesh.cpp`.
+
+Update all call sites — they previously called these as file-scope statics; now qualify:
+```cpp
+// OLD:
+derivePeerLMK(ownPriv, peerPub, lmk);
+registerPeerWithEspNow(mac, devicePrivateKey, peerPubKey);
+// NEW:
+lattice::mesh::crypto::derivePeerLMK(ownPriv, peerPub, lmk);
+lattice::mesh::crypto::registerPeerWithEspNow(mac, devicePrivateKey, peerPubKey);
+```
+
+In `Mesh::loadOrGenerateKeypair()`, replace the key generation block with:
+```cpp
+lattice::mesh::crypto::generateKeypair(devicePrivateKey, devicePublicKey);
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass. (mbedtls symbols are stubbed in `firmware_stubs.cpp` — no change needed there since `MeshCrypto.h` isn't compiled into test TUs yet; `Mesh.cpp` is still excluded from FIRMWARE_SOURCES.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract MeshCrypto.h from Mesh"
+```
+
+---
+
+### Task 6: Extract `PeerRegistry`
+
+Extract peer list management into a composable class. `PeerRegistry.cpp` goes into `FIRMWARE_SOURCES` — it has no mbedtls dependency. Methods currently provided by `mesh_logic_impl.cpp` move to the real production file.
+
+**Files:**
+- Create: `main/src/mesh/PeerRegistry.h`
+- Create: `main/src/mesh/PeerRegistry.cpp`
+- Modify: `main/src/mesh/Mesh.h` (remove peer fields + `PeerInfo`/`MasterInfo` structs, add `PeerRegistry peers` member)
+- Modify: `main/src/mesh/Mesh.cpp` (use `peers.` prefix; `findNextHopToMaster` stays in Mesh — it uses `currentMaster`)
+- Modify: `tests/mocks/mesh_logic_impl.cpp` (remove methods that moved; update remaining)
+- Modify: `tests/CMakeLists.txt` (add new source)
+
+**Interfaces:**
+- Produces:
+```cpp
+namespace lattice::mesh {
+
+struct PeerInfo {
+  uint8_t mac[6];
+  uint8_t publicKey[32];
+  uint32_t lastSeenMillis;
+};
+
+struct MasterInfo {
+  uint8_t mac[6];
+  uint8_t distance;
+  uint8_t nextHop[6];
+};
+
+class PeerRegistry {
+public:
+  PeerInfo peerMacs[MAX_PEERS]{};   // public for direct iteration in Mesh
+  size_t peerCount{0};
+
+  void setDeviceMac(const uint8_t mac[6]);
+  PeerInfo* find(const uint8_t mac[6]);
+  bool append(const PeerInfo& peer);
+  void remove(const uint8_t mac[6]);
+  bool isPeerInRange(const uint8_t mac[6]) const;
+  void updateLastSeen(const uint8_t mac[6]);
+  void loadFromEEPROM();
+  void saveToEEPROM();
+  void addAndPersist(const uint8_t mac[6]);
+  void removeAndPersist(const uint8_t mac[6]);
+  size_t count() const { return peerCount; }
+
+private:
+  uint8_t deviceMac[6]{};
+};
+}
+```
+
+- [ ] **Step 1: Create `main/src/mesh/PeerRegistry.h`**
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include "src/persistence/EepromManager.h"
+#include "src/network/MacAddress.h"
+#include "../../project_config.h"
+
+namespace lattice {
+namespace mesh {
+
+using lattice::utils::EEPROM_SIZES::MAX_PEERS;
+
+struct PeerInfo {
+  uint8_t mac[6];
+  uint8_t publicKey[32];
+  uint32_t lastSeenMillis;
+};
+
+struct MasterInfo {
+  uint8_t mac[6];
+  uint8_t distance;
+  uint8_t nextHop[6];
+};
+
+class PeerRegistry {
+public:
+  PeerInfo peerMacs[MAX_PEERS]{};
+  size_t peerCount{0};
+
+  PeerRegistry();
+  void setDeviceMac(const uint8_t mac[6]);
+
+  PeerInfo* find(const uint8_t mac[6]);
+  bool append(const PeerInfo& peer);
+  void remove(const uint8_t mac[6]);
+  bool isPeerInRange(const uint8_t mac[6]) const;
+  void updateLastSeen(const uint8_t mac[6]);
+
+  void loadFromEEPROM();
+  void saveToEEPROM();
+  void addAndPersist(const uint8_t mac[6]);
+  void removeAndPersist(const uint8_t mac[6]);
+
+  size_t count() const { return peerCount; }
+
+private:
+  uint8_t deviceMac[6]{};
+};
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 2: Create `main/src/mesh/PeerRegistry.cpp`**
+
+Move the following method bodies **verbatim** from `Mesh.cpp` and `mesh_logic_impl.cpp`, replacing `Mesh::` → `PeerRegistry::`, `peerMacs` → `peerMacs` (same name, now on `this`), `deviceMacAddress` → `deviceMac`:
+
+| Source method | Destination |
+|---|---|
+| `Mesh::loadPeersFromEEPROM` | `PeerRegistry::loadFromEEPROM` |
+| `Mesh::savePeersToEEPROM` | `PeerRegistry::saveToEEPROM` |
+| `Mesh::addPeerToEEPROM` | `PeerRegistry::addAndPersist` |
+| `Mesh::removePeerFromEEPROM` | `PeerRegistry::removeAndPersist` |
+| `Mesh::appendPeer` (mesh_logic_impl.cpp) | `PeerRegistry::append` |
+| `Mesh::findPeer` (mesh_logic_impl.cpp) | `PeerRegistry::find` |
+| `Mesh::isPeerInRange` (mesh_logic_impl.cpp) | `PeerRegistry::isPeerInRange` |
+| `Mesh::updatePeerLastSeen` | `PeerRegistry::updateLastSeen` |
+
+```cpp
+#include "PeerRegistry.h"
+#include "src/logging/Logger.h"
+#include "src/error/Error.h"
+
+namespace lattice {
+namespace mesh {
+
+PeerRegistry::PeerRegistry() {
+  memset(peerMacs, 0, sizeof(peerMacs));
+  memset(deviceMac, 0, sizeof(deviceMac));
+}
+
+void PeerRegistry::setDeviceMac(const uint8_t mac[6]) {
+  memcpy(deviceMac, mac, 6);
+}
+
+// ... verbatim bodies from Mesh.cpp / mesh_logic_impl.cpp for each method above
+} // namespace mesh
+} // namespace lattice
+```
+
+`addAndPersist` (was `addPeerToEEPROM`) uses `deviceMacAddress` — replace with `deviceMac`.
+
+- [ ] **Step 3: Update `Mesh.h` — remove peer fields, add composed member**
+
+Remove `PeerInfo` and `MasterInfo` struct definitions (now in `PeerRegistry.h`).
+
+Add include:
+```cpp
+#include "PeerRegistry.h"
+```
+
+Remove from private section:
+```cpp
+// REMOVE:
+PeerInfo peerMacs[MAX_PEERS];
+size_t peerCount;
+PeerInfo* findPeer(const uint8_t mac[6]);
+bool isPeerInRange(const uint8_t mac[6]);
+bool appendPeer(const PeerInfo& peer);
+void loadPeersFromEEPROM();
+void savePeersToEEPROM();
+void addPeerToEEPROM(const uint8_t mac[6]);
+void removePeerFromEEPROM(const uint8_t mac[6]);
+void updatePeerLastSeen(const uint8_t mac[6]);
+using lattice::utils::EEPROM_SIZES::MAX_PEERS;  // also remove if present
+```
+
+Add to private section:
+```cpp
+PeerRegistry peers;
+```
+
+Update public delegation methods:
+```cpp
+void addPeer(const uint8_t mac[6]) { peers.addAndPersist(mac); }
+void removePeer(const uint8_t mac[6]) { peers.removeAndPersist(mac); }
+const PeerInfo* getPeerList() const { return peers.peerMacs; }
+size_t getPeerCount() const { return peers.peerCount; }
+```
+
+- [ ] **Step 4: Update `Mesh.cpp` — use `peers.` prefix**
+
+Replace in `Mesh.cpp` (search-replace, careful not to touch `PeerRegistry.cpp`):
+```
+peerMacs[   →  peers.peerMacs[
+peerCount   →  peers.peerCount
+findPeer(   →  peers.find(
+appendPeer( →  peers.append(
+isPeerInRange(  →  peers.isPeerInRange(
+updatePeerLastSeen(  →  peers.updateLastSeen(
+loadPeersFromEEPROM()  →  peers.loadFromEEPROM()
+savePeersToEEPROM()    →  peers.saveToEEPROM()
+```
+
+In `Mesh::init()`, after `readMacAddress()`, add:
+```cpp
+peers.setDeviceMac(deviceMacAddress);
+```
+
+`findNextHopToMaster()` stays in `Mesh.cpp` — it uses `currentMaster.nextHop`. Update its body to use `peers.`:
+```cpp
+PeerInfo* Mesh::findNextHopToMaster() {
+  if (currentMaster.distance == 0xFF) return nullptr;
+  for (size_t i = 0; i < peers.peerCount; ++i) {
+    if (lattice::utils::MacAddress(peers.peerMacs[i].mac) ==
+            lattice::utils::MacAddress(currentMaster.nextHop) &&
+        peers.isPeerInRange(peers.peerMacs[i].mac) &&
+        lattice::utils::MacAddress(peers.peerMacs[i].mac) !=
+            lattice::utils::MacAddress(deviceMacAddress))
+      return &peers.peerMacs[i];
+  }
+  return nullptr;
+}
+```
+
+- [ ] **Step 5: Update `mesh_logic_impl.cpp` — remove moved methods, fix remaining**
+
+**Remove** the following method bodies from `mesh_logic_impl.cpp` (they now live in `PeerRegistry.cpp` which is compiled in tests):
+- `Mesh::appendPeer` (lines 167–172)
+- `Mesh::findPeer` (lines 249–256)
+- `Mesh::isPeerInRange` (lines 258–263)
+- `Mesh::findNextHopToMaster` (lines 265–278)
+
+**Update** remaining methods that reference peer fields directly — replace with `peers.` prefix:
+
+In `Mesh::relayDownlink` (line 193–197): `peerCount` → `peers.peerCount`, `peerMacs[i].mac` → `peers.peerMacs[i].mac`
+
+In `Mesh::broadcastToAllPeers` (line 280–290): same substitutions.
+
+In `Mesh::transmitCore` (line 238): `findNextHopToMaster()` — this call stays as-is (it's a Mesh method).
+
+In `Mesh::processAdapterData` (line 382–384): `hasMasterMac` is still a Mesh field at this point (Enrollment extraction is Task 7 — leave these alone for now).
+
+- [ ] **Step 6: Update CMakeLists.txt**
+
+Add to `FIRMWARE_SOURCES`:
+```cmake
+  ../main/src/mesh/PeerRegistry.cpp
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract PeerRegistry from Mesh"
+```
+
+---
+
+### Task 7: Extract `Enrollment`
+
+Extract the enrollment protocol state machine. `Enrollment.cpp` has two mbedtls-heavy methods (`init` for key generation, `enrollPeer` for LMK derivation) — stub those in `firmware_stubs.cpp`. All other enrollment methods move to the production file and compile in tests.
+
+**Files:**
+- Create: `main/src/mesh/Enrollment.h`
+- Create: `main/src/mesh/Enrollment.cpp`
+- Modify: `main/src/mesh/Mesh.h`
+- Modify: `main/src/mesh/Mesh.cpp`
+- Modify: `tests/mocks/mesh_logic_impl.cpp` (remove moved methods; update `hasMasterMac` → `enrollment.hasMasterMac` etc.)
+- Modify: `tests/mocks/firmware_stubs.cpp` (add stubs for `Enrollment::init` + `Enrollment::enrollPeer`)
+- Modify: `tests/CMakeLists.txt`
+
+**Interfaces:**
+- Consumes: `MeshCrypto.h`, `EepromManager`
+- Produces:
+```cpp
+namespace lattice::mesh {
+using EnrollmentRelayFn = void (*)(const uint8_t mac[6], const uint8_t pubKey[32]);
+using SendMessageFn = std::function<void(const uint8_t target[6], mesh_message)>;
+using RegisterPeerFn = std::function<void(const uint8_t mac[6], const uint8_t* pubKey32)>;
+
+class Enrollment {
+public:
+  // TOFU state (read by Mesh for beacon/config processing)
+  bool hasMasterMac{false};
+  uint8_t knownMasterMac[6]{};
+  bool hasMasterMacSecondary{false};
+  uint8_t knownMasterMacSecondary[6]{};
+
+  Enrollment();
+  void init();   // loads or generates keypair; loads enrolled flag + TOFU MACs from EEPROM
+
+  bool isEnrolled() const;
+  const uint8_t* getPublicKey() const { return devicePublicKey; }
+  const uint8_t* getPrivateKey() const { return devicePrivateKey; }
+
+  void sendRequest(const uint8_t* deviceMac, SendMessageFn sendFn);
+  void processRequest(const mesh_message& msg);
+  void processJoinAck(const mesh_message& msg, const uint8_t* deviceMac,
+                      RegisterPeerFn registerFn);
+  void enrollPeer(const uint8_t mac[6], const uint8_t pubKey32[32],
+                  RegisterPeerFn registerFn, bool dualMasterMode);
+
+  void setRelayFn(EnrollmentRelayFn fn);
+  void setPendingRelay(const uint8_t mac[6], const uint8_t pubKey[32]);
+  void drainPendingRelay();
+
+private:
+  uint8_t devicePrivateKey[32]{};
+  uint8_t devicePublicKey[32]{};
+  volatile bool _pendingEnrollmentRelay{false};
+  uint8_t _pendingEnrollmentMac[6]{};
+  uint8_t _pendingEnrollmentPubKey[32]{};
+  EnrollmentRelayFn _enrollmentRelayFn{nullptr};
+};
+}
+```
+
+- [ ] **Step 1: Create `main/src/mesh/Enrollment.h`**
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include "../../lib/lattice-protocol/c/mesh_message.h"
+
+namespace lattice {
+namespace mesh {
+
+using EnrollmentRelayFn = void (*)(const uint8_t mac[6], const uint8_t pubKey[32]);
+using SendMessageFn = std::function<void(const uint8_t target[6], mesh_message)>;
+using RegisterPeerFn = std::function<void(const uint8_t mac[6], const uint8_t* pubKey32)>;
+
+class Enrollment {
+public:
+  bool hasMasterMac{false};
+  uint8_t knownMasterMac[6]{};
+  bool hasMasterMacSecondary{false};
+  uint8_t knownMasterMacSecondary[6]{};
+
+  Enrollment();
+  void init();
+
+  bool isEnrolled() const;
+  const uint8_t* getPublicKey() const { return devicePublicKey; }
+  const uint8_t* getPrivateKey() const { return devicePrivateKey; }
+
+  void sendRequest(const uint8_t* deviceMac, SendMessageFn sendFn);
+  void processRequest(const mesh_message& msg);
+  void processJoinAck(const mesh_message& msg, const uint8_t* deviceMac,
+                      RegisterPeerFn registerFn);
+  void enrollPeer(const uint8_t mac[6], const uint8_t pubKey32[32],
+                  RegisterPeerFn registerFn, bool dualMasterMode);
+
+  void setRelayFn(EnrollmentRelayFn fn);
+  void setPendingRelay(const uint8_t mac[6], const uint8_t pubKey[32]);
+  void drainPendingRelay();
+
+private:
+  uint8_t devicePrivateKey[32]{};
+  uint8_t devicePublicKey[32]{};
+  volatile bool _pendingEnrollmentRelay{false};
+  uint8_t _pendingEnrollmentMac[6]{};
+  uint8_t _pendingEnrollmentPubKey[32]{};
+  EnrollmentRelayFn _enrollmentRelayFn{nullptr};
+};
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 2: Create `main/src/mesh/Enrollment.cpp`**
+
+Move the following verbatim from `Mesh.cpp` (production implementation) and `mesh_logic_impl.cpp` (test implementation — same logic for these methods), replacing `Mesh::` → `Enrollment::`:
+
+| Source | Destination |
+|---|---|
+| `Mesh::loadOrGenerateKeypair` | `Enrollment::init` — loads keypair from EEPROM + calls `crypto::generateKeypair` for the generation branch; also loads `enrolledFlag`, `knownMasterMac`, `knownMasterMacSecondary` |
+| `Mesh::isEnrolled` | `Enrollment::isEnrolled` |
+| `Mesh::sendEnrollmentRequest` (mesh_logic_impl) | `Enrollment::sendRequest` — takes `deviceMac` + `sendFn` params instead of accessing `Mesh::deviceMacAddress` and `Mesh::esp_now_send` directly |
+| `Mesh::processEnrollmentRequest` (mesh_logic_impl) | `Enrollment::processRequest` |
+| `Mesh::processJoinAck` (mesh_logic_impl) | `Enrollment::processJoinAck` — takes `deviceMac` + `registerFn` |
+| `Mesh::enrollPeer` | `Enrollment::enrollPeer` — takes `registerFn` + `dualMasterMode` |
+| `Mesh::setEnrollmentRelayFn` (mesh_logic_impl) | `Enrollment::setRelayFn` |
+| `Mesh::drainPendingEnrollment` (mesh_logic_impl) | `Enrollment::drainPendingRelay` |
+
+Signature adaptations for `sendRequest`:
+```cpp
+void Enrollment::sendRequest(const uint8_t* deviceMac, SendMessageFn sendFn) {
+  mesh_message msg = {};
+  msg.message_type = MESH_TYPE_ENROLLMENT;
+  // ... exact body from Mesh::sendEnrollmentRequest
+  // Replace: devicePublicKey → devicePublicKey (same, it's now 'this' field)
+  // Replace: deviceMacAddress → deviceMac (parameter)
+  // Replace: esp_now_send(broadcastMac, ...) → sendFn(broadcastMac, msg)  OR keep direct esp_now_send
+  //   (checking mesh_logic_impl.cpp: it calls esp_now_send directly — keep that)
+}
+```
+
+For `processJoinAck`, it was:
+```cpp
+// mesh_logic_impl.cpp:
+void Mesh::processJoinAck(const mesh_message& msg) {
+  if (memcmp(msg.target_mac_address, deviceMacAddress, 6) != 0) { relayDownlink(msg); return; }
+  // ...
+  if (!hasMasterMac) { memcpy(knownMasterMac, ...); hasMasterMac = true; ... }
+}
+```
+The `relayDownlink` call must stay in `Mesh` — extract just the "addressed to us" branch:
+```cpp
+void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* deviceMac,
+                                 RegisterPeerFn /*registerFn*/) {
+  // Called only when msg.target_mac_address == deviceMacAddress (Mesh checks this before calling)
+  if (memcmp(msg.data, devicePublicKey, 4) != 0) { /* log + return */ return; }
+  EepromManager::getInstance().saveEnrolledFlag(true);
+  if (!hasMasterMac) {
+    memcpy(knownMasterMac, msg.origin_mac_address, 6);
+    hasMasterMac = true;
+    EepromManager::getInstance().saveKnownMasterMac(knownMasterMac);
+  }
+}
+```
+The relay check (`relayDownlink`) stays in Mesh.cpp `Mesh::drainRecvQueue`.
+
+```cpp
+#include "Enrollment.h"
+#include "MeshCrypto.h"
+#include "src/persistence/EepromManager.h"
+#include "src/logging/Logger.h"
+#include "src/error/Error.h"
+#include "../../lib/lattice-protocol/c/opcodes.h"
+#include <esp_now.h>
+
+namespace lattice {
+namespace mesh {
+
+Enrollment::Enrollment() {
+  memset(devicePrivateKey, 0, 32);
+  memset(devicePublicKey, 0, 32);
+  memset(knownMasterMac, 0xFF, 6);
+  memset(knownMasterMacSecondary, 0xFF, 6);
+  memset(_pendingEnrollmentMac, 0, 6);
+  memset(_pendingEnrollmentPubKey, 0, 32);
+}
+
+// NOTE: Enrollment::init() and Enrollment::enrollPeer() use mbedtls.
+// In test builds, these are STUBBED in firmware_stubs.cpp.
+// The remaining methods compile cleanly without mbedtls.
+
+// ... verbatim bodies
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 3: Add stubs to `tests/mocks/firmware_stubs.cpp`**
+
+Add at the bottom (after existing stubs):
+```cpp
+#include "mesh/Enrollment.h"
+
+namespace lattice {
+namespace mesh {
+
+// Stub: key generation uses mbedtls — not available on host.
+// Tests that call sendEnrollmentRequest() must set devicePublicKey directly via
+// the UNIT_TEST public access (enrollment.devicePublicKey[...] = ...).
+void Enrollment::init() {
+  // Load enrolled flag from EEPROM (real impl)
+  auto& em = lattice::utils::EepromManager::getInstance();
+  // enrolled flag
+  bool enrolled = em.loadEnrolledFlag();
+  (void)enrolled;  // stored in test-accessible field — see Enrollment::isEnrolled()
+  // TOFU MACs
+  if (em.loadKnownMasterMac(knownMasterMac)) hasMasterMac = true;
+  if (em.loadKnownMasterMacSecondary(knownMasterMacSecondary)) hasMasterMacSecondary = true;
+  // Keys: leave zeroed (tests set them directly if needed)
+}
+
+void Enrollment::enrollPeer(const uint8_t mac[6], const uint8_t pubKey32[32],
+                             RegisterPeerFn registerFn, bool /*dualMasterMode*/) {
+  // Stub: skip LMK derivation — just invoke the callback with null key
+  if (registerFn) registerFn(mac, pubKey32);
+}
+
+} // namespace mesh
+} // namespace lattice
+```
+
+- [ ] **Step 4: Update `Mesh.h`**
+
+Add include:
+```cpp
+#include "Enrollment.h"
+```
+
+Remove from private section:
+```cpp
+// REMOVE:
+uint8_t devicePrivateKey[32];
+uint8_t devicePublicKey[32];
+void loadOrGenerateKeypair();
+uint8_t knownMasterMac[6];
+bool hasMasterMac;
+uint8_t knownMasterMacSecondary[6];
+bool hasMasterMacSecondary;
+volatile bool _pendingEnrollmentRelay;
+uint8_t _pendingEnrollmentMac[6];
+uint8_t _pendingEnrollmentPubKey[32];
+EnrollmentRelayFn _enrollmentRelayFn;
+void processEnrollmentRequest(const mesh_message& msg);
+void processJoinAck(const mesh_message& msg);
+void drainPendingEnrollment();
+```
+
+Remove `EnrollmentRelayFn` typedef (it now lives in `Enrollment.h`).
+
+Add to private section:
+```cpp
+Enrollment enrollment;
+```
+
+Update public delegation methods:
+```cpp
+void sendEnrollmentRequest() {
+  enrollment.sendRequest(deviceMacAddress,
+    [this](const uint8_t* t, mesh_message m){ this->sendMessage(t, m); });
+}
+bool isEnrolled() const { return enrollment.isEnrolled(); }
+void enrollPeer(const uint8_t mac[6], const uint8_t pubKey[32]);  // impl in Mesh.cpp
+void setEnrollmentRelayFn(EnrollmentRelayFn fn) { enrollment.setRelayFn(fn); }
+const uint8_t* getDevicePublicKey() const { return enrollment.getPublicKey(); }
+```
+
+- [ ] **Step 5: Update `Mesh.cpp`**
+
+- Remove `Mesh::loadOrGenerateKeypair`, `Mesh::isEnrolled`, `Mesh::sendEnrollmentRequest`, `Mesh::processEnrollmentRequest`, `Mesh::processJoinAck`, `Mesh::enrollPeer`, `Mesh::setEnrollmentRelayFn`, `Mesh::drainPendingEnrollment`.
+- In `Mesh::init()`, replace `loadOrGenerateKeypair()` with `enrollment.init()`.
+- In `Mesh::loadPersistentState()`, replace direct key/enrollment field reads using `enrollment.`.
+- In `Mesh::drainRecvQueue()`:
+  - `processEnrollmentRequest(msg)` → `enrollment.processRequest(msg)`
+  - `processJoinAck(msg)` → check target first, then `enrollment.processJoinAck(msg, deviceMacAddress, [this](...){})`; relay via `relayDownlink` if not addressed to us
+  - `drainPendingEnrollment()` → `enrollment.drainPendingRelay()`
+- In `Mesh::processMasterBeacon()`: replace `hasMasterMac`, `knownMasterMac`, `hasMasterMacSecondary`, `knownMasterMacSecondary` with `enrollment.hasMasterMac` etc.
+- In `Mesh::processAdapterData()`: same for `hasMasterMac`, `knownMasterMac` references.
+- `Mesh::enrollPeer` thin wrapper:
+```cpp
+void Mesh::enrollPeer(const uint8_t mac[6], const uint8_t pubKey[32]) {
+  enrollment.enrollPeer(mac, pubKey,
+    [this](const uint8_t* m, const uint8_t* k) {
+      lattice::mesh::crypto::registerPeerWithEspNow(m, enrollment.getPrivateKey(), k);
+      peers.addAndPersist(m);
+    },
+    _dualMasterMode);
+}
+```
+- Print public key in `Mesh::init()` (was using `devicePublicKey` directly): → `enrollment.getPublicKey()`
+
+- [ ] **Step 6: Update `mesh_logic_impl.cpp` — remove moved methods, fix remaining**
+
+**Remove** entirely (they now live in `Enrollment.cpp` which is compiled in tests):
+- `Mesh::sendEnrollmentRequest` (lines 401–414)
+- `Mesh::processEnrollmentRequest` (lines 416–425)
+- `Mesh::setEnrollmentRelayFn` (lines 427–429)
+- `Mesh::drainPendingEnrollment` (lines 431–438)
+
+**Update** `processJoinAck` (lines 200–221): it remains in `mesh_logic_impl.cpp` OR can be removed if `Enrollment::processJoinAck` covers it. Since the relay-check part stays in Mesh, keep only the relay dispatch and call through:
+```cpp
+void Mesh::processJoinAck(const mesh_message& msg) {
+  if (memcmp(msg.target_mac_address, deviceMacAddress, 6) != 0) {
+    relayDownlink(msg);
+    return;
+  }
+  enrollment.processJoinAck(msg, deviceMacAddress, nullptr);
+}
+```
+
+**Update** `processMasterBeacon`: replace all direct `hasMasterMac`, `knownMasterMac`, `hasMasterMacSecondary`, `knownMasterMacSecondary`, `_dualMasterMode` with `enrollment.hasMasterMac` etc.
+
+**Update** `processAdapterData`: replace `hasMasterMac`, `knownMasterMac` → `enrollment.hasMasterMac`, `enrollment.knownMasterMac`.
+
+- [ ] **Step 7: Update CMakeLists.txt**
+
+Add to `FIRMWARE_SOURCES`:
+```cmake
+  ../main/src/mesh/Enrollment.cpp
+```
+
+- [ ] **Step 8: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract Enrollment from Mesh"
+```
+
+---
+
+### Task 8: Extract `SerialFraming`
+
+Extract the framing state machine from `SerialAdapter` into a testable class. Currently `injectByte` is `#ifdef UNIT_TEST` only in `SerialAdapter`; in `SerialFraming` it's always public (cleaner).
+
+**Files:**
+- Create: `main/src/adapter/serial/SerialFraming.h`
+- Create: `main/src/adapter/serial/SerialFraming.cpp`
+- Modify: `main/src/adapter/serial/SerialAdapter.h` (remove framing fields/methods, add `SerialFraming _framing` member)
+- Modify: `main/src/adapter/serial/SerialAdapter.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+Current framing state in `SerialAdapter.h` (lines 53–58):
+```cpp
+enum class FrameState : uint8_t { AwaitingLen1, AwaitingLen2, AwaitingPayload };
+FrameState frameState;
+uint16_t frameLength;
+size_t frameIndex;
+static constexpr size_t MAX_PAYLOAD = 256;
+uint8_t payloadBuffer[MAX_PAYLOAD];
+```
+
+**Interfaces:**
+- Produces:
+```cpp
+namespace lattice::adapter::serial {
+class SerialFraming {
+public:
+  static size_t encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen);
+  static bool decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& out);
+  bool injectByte(uint8_t b);  // always public (was UNIT_TEST-only in SerialAdapter)
+  const uint8_t* frameBuffer() const { return payloadBuffer; }
+  size_t frameLen() const { return frameIndex; }  // valid after injectByte returns true
+private:
+  enum class FrameState : uint8_t { AwaitingLen1, AwaitingLen2, AwaitingPayload };
+  FrameState frameState{FrameState::AwaitingLen1};
+  uint16_t frameLength{0};
+  size_t frameIndex{0};
+  static constexpr size_t MAX_PAYLOAD = 256;
+  uint8_t payloadBuffer[MAX_PAYLOAD]{};
+};
+}
+```
+
+- [ ] **Step 1: Create `main/src/adapter/serial/SerialFraming.h`**
+
+```cpp
+#pragma once
+#include <cstdint>
+#include "../../mesh/serialization/mesh.pb.h"
+#include "src/mesh/Mesh.h"  // for mesh_message
+
+namespace lattice {
+namespace adapter {
+namespace serial {
+
+class SerialFraming {
+public:
+  static size_t encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen);
+  static bool decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& out);
+
+  // Feed one byte into the framing state machine.
+  // Returns true when a complete frame is ready; read it via frameBuffer()/frameLen().
+  bool injectByte(uint8_t b);
+
+  const uint8_t* frameBuffer() const { return payloadBuffer; }
+  size_t frameLen() const { return frameIndex; }
+
+private:
+  enum class FrameState : uint8_t { AwaitingLen1, AwaitingLen2, AwaitingPayload };
+  FrameState frameState{FrameState::AwaitingLen1};
+  uint16_t frameLength{0};
+  size_t frameIndex{0};
+  static constexpr size_t MAX_PAYLOAD = 256;
+  uint8_t payloadBuffer[MAX_PAYLOAD]{};
+};
+
+} // namespace serial
+} // namespace adapter
+} // namespace lattice
+```
+
+- [ ] **Step 2: Create `main/src/adapter/serial/SerialFraming.cpp`**
+
+Move method bodies verbatim from `SerialAdapter.cpp`:
+- `Serial_Adapter::encodeMeshMessage` → `SerialFraming::encode` (static)
+- `Serial_Adapter::decodeMeshMessage` → `SerialFraming::decode` (static)
+- `Serial_Adapter::injectByte` → `SerialFraming::injectByte` (replace `frameState`, `frameLength`, `frameIndex`, `payloadBuffer` — same field names, now on `this`)
+
+```cpp
+#include "SerialFraming.h"
+#include "src/mesh/serialization/mesh.pb.h"
+#include "src/mesh/serialization/nanopb/pb_encode.h"
+#include "src/mesh/serialization/nanopb/pb_decode.h"
+
+namespace lattice {
+namespace adapter {
+namespace serial {
+
+size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen) {
+  // verbatim from Serial_Adapter::encodeMeshMessage
+}
+
+bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& out) {
+  // verbatim from Serial_Adapter::decodeMeshMessage
+}
+
+bool SerialFraming::injectByte(uint8_t b) {
+  // verbatim from Serial_Adapter::injectByte
+}
+
+} // namespace serial
+} // namespace adapter
+} // namespace lattice
+```
+
+- [ ] **Step 3: Update `SerialAdapter.h`**
+
+Add include:
+```cpp
+#include "SerialFraming.h"
+```
+
+Remove from private section:
+```cpp
+// REMOVE:
+enum class FrameState : uint8_t { AwaitingLen1, AwaitingLen2, AwaitingPayload };
+FrameState frameState;
+uint16_t frameLength;
+size_t frameIndex;
+static constexpr size_t MAX_PAYLOAD = 256;
+uint8_t payloadBuffer[MAX_PAYLOAD];
+static size_t encodeMeshMessage(...);
+static bool decodeMeshMessage(...);
+```
+
+Remove the `#ifdef UNIT_TEST` block for `injectByte` / `lastOpcode` (testing now goes through `SerialFraming`).
+
+Add to private section:
+```cpp
+SerialFraming _framing;
+```
+
+- [ ] **Step 4: Update `SerialAdapter.cpp`**
+
+Replace method calls:
+```cpp
+// OLD (in loop()):
+if (injectByte(b)) { handleCompleteFrame(payloadBuffer, frameIndex); }
+// NEW:
+if (_framing.injectByte(b)) { handleCompleteFrame(_framing.frameBuffer(), _framing.frameLen()); }
+
+// OLD (in sendHealthReport / onMeshDataImpl):
+size_t len = encodeMeshMessage(msg, buf, sizeof(buf));
+// NEW:
+size_t len = SerialFraming::encode(msg, buf, sizeof(buf));
+
+// OLD (in handleCompleteFrame):
+if (!decodeMeshMessage(data, len, msg)) ...
+// NEW:
+if (!SerialFraming::decode(data, len, msg)) ...
+```
+
+Also remove `Serial_Adapter::injectByte` and `Serial_Adapter::lastOpcode` definitions.
+
+- [ ] **Step 5: Update `test_serial_framing.cpp`**
+
+The test currently accesses `Serial_Adapter::injectByte` via `UNIT_TEST`. Update it to instantiate `SerialFraming` directly:
+
+```cpp
+#include <gtest/gtest.h>
+#include "adapter/serial/SerialFraming.h"
+
+using namespace lattice::adapter::serial;
+
+// Test encode → decode round-trip
+TEST(SerialFramingTest, EncodeDecodeRoundTrip) {
+  lattice::mesh::mesh_message original{};
+  original.message_type = MESH_TYPE_ADAPTER_DATA;
+  memset(original.origin_mac_address, 0x11, 6);
+  original.data[0] = 0x42;
+
+  uint8_t buf[256];
+  size_t len = SerialFraming::encode(original, buf, sizeof(buf));
+  ASSERT_GT(len, 0u);
+
+  lattice::mesh::mesh_message decoded{};
+  EXPECT_TRUE(SerialFraming::decode(buf, len, decoded));
+  EXPECT_EQ(decoded.message_type, original.message_type);
+  EXPECT_EQ(decoded.data[0], original.data[0]);
+  EXPECT_EQ(memcmp(decoded.origin_mac_address, original.origin_mac_address, 6), 0);
+}
+
+// Test injectByte state machine: feed framed bytes one at a time
+TEST(SerialFramingTest, InjectByteReassemblesFrame) {
+  lattice::mesh::mesh_message original{};
+  original.message_type = MESH_TYPE_MASTER_BEACON;
+
+  uint8_t buf[256];
+  size_t len = SerialFraming::encode(original, buf, sizeof(buf));
+  ASSERT_GT(len, 0u);
+
+  SerialFraming framing;
+  bool complete = false;
+  for (size_t i = 0; i < len; ++i) {
+    complete = framing.injectByte(buf[i]);
+  }
+  EXPECT_TRUE(complete);
+
+  lattice::mesh::mesh_message decoded{};
+  EXPECT_TRUE(SerialFraming::decode(framing.frameBuffer(), framing.frameLen(), decoded));
+  EXPECT_EQ(decoded.message_type, original.message_type);
+}
+```
+
+Retain any additional test cases from the original `test_serial_framing.cpp`.
+
+- [ ] **Step 6: Update CMakeLists.txt**
+
+Add to `FIRMWARE_SOURCES`:
+```cmake
+  ../main/src/adapter/serial/SerialFraming.cpp
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass including `test_serial_framing`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract SerialFraming from SerialAdapter"
+```
+
+---
+
+### Task 9: Create `src/app/` layer + reduce `main.ino`
+
+Extract three inline state machines from `main.ino` into header-only classes. No new `.cpp` files — header-only. No CMakeLists change needed.
+
+**Files:**
+- Create: `main/src/app/BootManager.h`
+- Create: `main/src/app/DisplayManager.h`
+- Create: `main/src/app/ButtonHandler.h`
+- Modify: `main/main.ino`
+
+- [ ] **Step 1: Create `main/src/app/BootManager.h`**
+
+The body is the verbatim reset-reason block from `main.ino setup()` (the `esp_reset_reason_t reason = ...` block, ~lines 93–111). EEPROM must already be initialised before calling (same constraint as today).
+
+```cpp
+#pragma once
+#include <esp_system.h>
+#include <Arduino.h>
+#include "src/persistence/EepromManager.h"
+#include "src/logging/Logger.h"
+
+namespace lattice {
+namespace app {
+
+struct BootManager {
+  static void check(lattice::utils::EepromManager& em) {
+    esp_reset_reason_t reason = esp_reset_reason();
+    em.saveRebootReason(static_cast<uint8_t>(reason));
+    if (reason == ESP_RST_WDT || reason == ESP_RST_TASK_WDT || reason == ESP_RST_INT_WDT) {
+      uint8_t count = em.loadRebootCount();
+      count++;
+      em.saveRebootCount(count);
+      Serial.printf("[BOOT] WDT reset #%d (reason: %d)\n", count, (int)reason);
+      if (count >= 5) {
+        Serial.println("[BOOT] WDT loop detected — halting. Manual reset required.");
+        while (true) { delay(1000); }
+      }
+    } else {
+      em.saveRebootCount(0);
+    }
+  }
+};
+
+} // namespace app
+} // namespace lattice
+```
+
+- [ ] **Step 2: Create `main/src/app/DisplayManager.h`**
+
+Extract the `if (lattice::config::ENABLE_SEVSEG_DISPLAY)` block from `main.ino loop()` (lines ~312–342). The `static` local variables move inside the function — valid in a header-only inline static method.
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <Arduino.h>
+#include "src/hardware/output/SevenSegDisplay.h"
+
+namespace lattice {
+namespace app {
+
+struct DisplayManager {
+  static void tick(lattice::hardware::SevenSegDisplay& display,
+                   bool enrolled, bool isMaster, uint8_t nodeId) {
+    static uint32_t lastToggleMs = 0;
+    static bool dashVisible = false;
+
+    if (!enrolled) {
+      if (millis() - lastToggleMs >= 500) {
+        lastToggleMs = static_cast<uint32_t>(millis());
+        dashVisible = !dashVisible;
+        if (dashVisible) {
+          static const uint8_t dashes[4] = {0x40, 0x40, 0x40, 0x40};
+          display.setSegments(dashes);
+        } else {
+          display.clear();
+        }
+      }
+    } else if (nodeId == 0) {
+      display.show(0, false);
+    } else if (isMaster) {
+      display.showWithDP(static_cast<int>(nodeId), false);
+    } else {
+      display.show(static_cast<int>(nodeId), false);
+    }
+  }
+};
+
+} // namespace app
+} // namespace lattice
+```
+
+- [ ] **Step 3: Create `main/src/app/ButtonHandler.h`**
+
+Extract both button state machines from `main.ino loop()` (lines ~364–430 for config button, ~368–430 for reset button). Static locals move into the private tick methods.
+
+```cpp
+#pragma once
+#include <Arduino.h>
+#include "src/hardware/input/Button.h"
+#include "src/hardware/output/Led.h"
+#include "src/mesh/Mesh.h"
+#include "src/persistence/EepromManager.h"
+#include "src/logging/Logger.h"
+
+namespace lattice {
+namespace app {
+
+struct ButtonHandler {
+  static constexpr unsigned long HOLD_MS = 5000;
+
+  static void tick(lattice::hardware::Button& configBtn,
+                   lattice::hardware::Button& resetBtn,
+                   lattice::mesh::Mesh& mesh,
+                   lattice::utils::EepromManager& em,
+                   lattice::hardware::Led& greenLed,
+                   lattice::hardware::Led& redLed,
+                   bool isDevMode,
+                   bool& devMasterFlag) {
+    tickConfig(configBtn, mesh, em, greenLed, isDevMode, devMasterFlag);
+    tickReset(resetBtn, em, greenLed, redLed);
+  }
+
+private:
+  static void tickConfig(lattice::hardware::Button& btn, lattice::mesh::Mesh& mesh,
+                         lattice::utils::EepromManager& em,
+                         lattice::hardware::Led& greenLed,
+                         bool isDevMode, bool& devMasterFlag) {
+    static bool wasPressed = false;
+    static unsigned long holdStart = 0;
+    // verbatim config button block from main.ino loop() — lines ~371–397
+    // Replace 'BUTTON_HOLD_TIME_MS' with 'HOLD_MS'
+  }
+
+  static void tickReset(lattice::hardware::Button& btn,
+                        lattice::utils::EepromManager& em,
+                        lattice::hardware::Led& greenLed,
+                        lattice::hardware::Led& redLed) {
+    static bool wasPressed = false;
+    static unsigned long holdStart = 0;
+    static bool confirmPending = false;
+    static uint32_t confirmDeadline = 0;
+    // verbatim reset button block from main.ino loop() — lines ~401–430
+    // Replace 'BUTTON_HOLD_TIME_MS' with 'HOLD_MS'
+  }
+};
+
+} // namespace app
+} // namespace lattice
+```
+
+- [ ] **Step 4: Update `main.ino`**
+
+Add includes at top of `main.ino`:
+```cpp
+#include "src/app/BootManager.h"
+#include "src/app/DisplayManager.h"
+#include "src/app/ButtonHandler.h"
+```
+
+In `setup()`, replace the reset-reason block (`esp_reset_reason_t reason = ...` through `em.saveRebootCount(0)`) with:
+```cpp
+lattice::app::BootManager::check(EepromManager::getInstance());
+```
+
+In `loop()`, replace the display block with:
+```cpp
+if (lattice::config::ENABLE_SEVSEG_DISPLAY) {
+  bool enrolled = mesh.isEnrolled() || mesh.getIsMaster();
+  uint8_t nodeId = lattice::utils::EepromManager::getInstance().loadNodeId();
+  lattice::app::DisplayManager::tick(sevenSeg, enrolled, mesh.getIsMaster(), nodeId);
+}
+```
+
+Replace both button blocks with:
+```cpp
+lattice::app::ButtonHandler::tick(configButton, resetButton, mesh,
+  lattice::utils::EepromManager::getInstance(),
+  greenLed, redLed, isDevMode, devMasterFlag);
+```
+
+- [ ] **Step 5: Verify `main.ino` line count**
+
+```bash
+wc -l main/main.ino
+```
+
+Expected: ≤ 160 lines.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass. (app/ has no unit tests — it wraps Arduino hardware.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor: extract app/ layer from main.ino"
+```
+
+---
+
+### Task 10: Update `REFACTORING_GUIDE.md` + final verification
+
+**Files:**
+- Modify: `REFACTORING_GUIDE.md`
+
+- [ ] **Step 1: Rewrite `REFACTORING_GUIDE.md` module map section**
+
+Replace the `## Module Map` section with:
+
+```markdown
+## Module Map
+
+### `main/main.ino`
+Wiring only: initialises hardware in dependency order, wires callbacks, runs main loop.
+Delegates all logic to `src/app/` components.
+
+### `main/project_config.h`
+Single source of truth for every compile-time constant. Edit here only.
+
+### `src/app/`
+Application-level coordination extracted from `main.ino`. Header-only — no `.cpp` files.
+- `BootManager` — reset reason check, WDT loop detection, reboot counter.
+- `DisplayManager` — 7-seg enrolled/unenrolled/master state machine.
+- `ButtonHandler` — config role-toggle and double-confirm EEPROM-wipe state machines.
+
+### `src/mesh/`
+- `Mesh` — thin orchestrator: ESP-NOW radio init, lock-free SPSC recv queue, routing dispatch, beacon relay, `loop()`.
+- `PeerRegistry` — peer list CRUD, EEPROM serialisation, staleness checks.
+- `Enrollment` — Curve25519 keypair load/generate, enrollment broadcast, JOIN_ACK processing, TOFU master MAC persistence.
+- `ReplayCache` — per-boot epoch + sequence-number replay protection (header-only struct).
+- `MeshCrypto` — ECDH shared-secret derivation, peer LMK, keypair generation, ESP-NOW peer registration (header-only inline functions).
+- `serialization/` — nanopb-generated `mesh.pb.c/.h` + nanopb runtime. Do not hand-edit.
+
+### `src/adapter/`
+- `Adapter` — abstract base: owns `mesh_transmit_fn`, handles `OP_CONFIG_SET` for all adapter types.
+- `AdapterFactory` — creates adapters from EEPROM type byte; provides default pins.
+- `pir/PirAdapter` — HC-SR501 motion events → mesh broadcast.
+- `serial/SerialAdapter` — framed Protobuf I/O to host server; health reports.
+- `serial/SerialFraming` — 2-byte-length-prefixed protobuf encode/decode + byte-feed state machine. Testable without hardware.
+
+### `src/hardware/`
+- `GpioOutput` / `GpioInput` — pin-validation and `_initialized` guard. All single-pin peripherals inherit from one.
+- `Led`, `SevenSegDisplay`, `Button`, `Pir` — single-pin peripheral drivers.
+
+### `src/logging/`
+Levelled logging (`LOG_DEBUG` → `LOG_NONE`). Set `DEFAULT_LOG_LEVEL = LOG_NONE` when the serial port is used for host-server framing.
+
+### `src/error/`
+- `Error.h` — public API: `lattice::err::fail()` / `lattice::err::fatal()`.
+- `ErrorCore` — error LED blink pattern and TM1637 display.
+- `ErrorCodes.h` — numeric `T·M·S` code registry.
+
+### `src/persistence/`
+`EepromManager` — all EEPROM reads/writes through singleton. `DEV_MODE` no-ops all writes. Centralises address constants in `EEPROM_ADDRESSES::*`.
+
+### `src/network/`
+`MacAddress` — MAC comparison, formatting, zero-checking utilities.
+
+## Adding a Module
+
+1. Place it under the most relevant `src/<subsystem>/` directory.
+2. Single responsibility — if it touches two concerns, split it.
+3. Route all errors through `src/error/Error.h`.
+4. Use `GpioOutput` / `GpioInput` for new single-pin hardware drivers.
+5. Reserve dynamic containers at `setup()` time; never grow them in `loop()`.
+6. Add new `.cpp` files to `tests/CMakeLists.txt` `FIRMWARE_SOURCES` if they are hardware-independent (no mbedtls). Add stubs to `tests/mocks/firmware_stubs.cpp` for any mbedtls-using methods.
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd tests && cmake -B build && cmake --build build && ctest --test-dir build --output-on-failure -V
+```
+
+Expected: **all tests pass, zero failures**.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add REFACTORING_GUIDE.md && git commit -m "docs: update REFACTORING_GUIDE for restructured layout"
+```

--- a/docs/superpowers/plans/nodes-phase1-multihop-relay.md
+++ b/docs/superpowers/plans/nodes-phase1-multihop-relay.md
@@ -1,0 +1,724 @@
+# Phase 1: Multi-hop Relay Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three independent routing bugs that silently prevent any ESP32 node more than one hop from the master from sending or receiving data.
+
+**Architecture:** All three bugs are in `Mesh.cpp`'s message dispatch loop (`drainRecvQueue → processAdapterData / processJoinAck`). The relay table is already correct (beacons propagate it); only the data/command relay paths are missing. The fix adds a `relayDownlink()` helper and wires it into `processAdapterData()` and `processJoinAck()`. A broadcast-target convention (`targetMacAddress = FF:FF:…`) is introduced so master-initiated broadcasts propagate beyond 1-hop neighbors. Replay cache (existing, 16-entry ring on mac+epoch+seq) stops loops.
+
+**Tech Stack:** C++17, Arduino/ESP-IDF, ESP-NOW, Google Test (native host build), CMake.
+
+## Global Constraints
+
+- All firmware changes are in the `main/` Arduino sketch.
+- No changes to files outside `main/src/Mesh/` and `tests/unit/test_mesh_logic.cpp`.
+- Tests run on host: `cmake -B tests/build -S tests && cmake --build tests/build && ctest --test-dir tests/build --output-on-failure`
+- `static_assert(sizeof(mesh_message) == 75)` must continue to pass (this plan does NOT change the struct — that is Phase 3 / spec §5.4).
+- `MAX_HOPS` is `planetopia::config::MAX_HOPS` (10).
+- `STALE_PEER_THRESHOLD_MS` is `planetopia::config::STALE_PEER_THRESHOLD_MS` (8000ms). Peers added with `lastSeenMillis = 0` are "in range" when `millis() = 0` (mock default).
+- In unit-test builds (`UNIT_TEST` defined), all `Mesh` members are `public` — tests access state directly without getters.
+- Commit after every task.
+
+---
+
+### Task 1: `relayDownlink()` helper — declaration + implementation + tests
+
+This helper is the shared relay primitive used by Tasks 2–4. It increments hop count, updates `lastHopMacAddress`, and unicasts the message to every enrolled peer (without overwriting `targetMacAddress`, so the original destination is preserved through intermediate nodes).
+
+**Files:**
+- Modify: `main/src/Mesh/Mesh.h` (private method declaration)
+- Modify: `main/src/Mesh/Mesh.cpp` (implementation)
+- Modify: `tests/unit/test_mesh_logic.cpp` (tests)
+
+**Interfaces:**
+- Produces: `void Mesh::relayDownlink(const mesh_message& msg)` — private method
+
+- [ ] **Step 1.1: Write failing tests**
+
+Append to `tests/unit/test_mesh_logic.cpp` (before the closing `}`):
+
+```cpp
+// ─── relayDownlink ───────────────────────────────────────────────────────────
+
+class RelayDownlinkTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    EEPROM.reset();
+    resetMillis();
+    resetEspNowMock();
+  }
+
+  static constexpr uint8_t kMyMac[6]    = {0x11,0x22,0x33,0x44,0x55,0x66};
+  static constexpr uint8_t kPeer1Mac[6] = {0xAA,0xAA,0xAA,0xAA,0xAA,0x01};
+  static constexpr uint8_t kPeer2Mac[6] = {0xBB,0xBB,0xBB,0xBB,0xBB,0x02};
+  static constexpr uint8_t kOriginMac[6]= {0xCC,0xCC,0xCC,0xCC,0xCC,0x03};
+
+  Mesh makeMeshWithPeers(int numPeers) {
+    Mesh mesh;
+    memcpy(mesh.deviceMacAddress, kMyMac, 6);
+    if (numPeers >= 1) {
+      PeerInfo p{}; memcpy(p.mac, kPeer1Mac, 6); p.lastSeenMillis = 0; mesh.appendPeer(p);
+    }
+    if (numPeers >= 2) {
+      PeerInfo p{}; memcpy(p.mac, kPeer2Mac, 6); p.lastSeenMillis = 0; mesh.appendPeer(p);
+    }
+    return mesh;
+  }
+
+  mesh_message makeDataMsg(const uint8_t origin[6], const uint8_t target[6],
+                           uint32_t epoch, uint16_t seq, uint8_t hopCount = 0) {
+    mesh_message m{};
+    m.protoVersion = 1;
+    m.messageType  = MESH_TYPE_ADAPTER_DATA;
+    m.dataType     = adapter_types::PIR_ADAPTER;
+    memcpy(m.originMacAddress, origin, 6);
+    memcpy(m.targetMacAddress, target, 6);
+    memcpy(m.lastHopMacAddress, origin, 6);
+    m.hopCount = hopCount;
+    m.epochNum = epoch;
+    m.seqNum   = seq;
+    return m;
+  }
+};
+
+constexpr uint8_t RelayDownlinkTest::kMyMac[];
+constexpr uint8_t RelayDownlinkTest::kPeer1Mac[];
+constexpr uint8_t RelayDownlinkTest::kPeer2Mac[];
+constexpr uint8_t RelayDownlinkTest::kOriginMac[];
+
+TEST_F(RelayDownlinkTest, SendsToPeers_IncrementHopCount) {
+  Mesh mesh = makeMeshWithPeers(2);
+  auto msg = makeDataMsg(kOriginMac, kPeer2Mac, 1, 1, /*hopCount=*/1);
+
+  mesh.relayDownlink(msg);
+
+  // 2 peers → 2 sends
+  EXPECT_EQ(espNowSentPackets.size(), 2u);
+  for (const auto& pkt : espNowSentPackets) {
+    const auto& sent = *reinterpret_cast<const mesh_message*>(pkt.data.data());
+    EXPECT_EQ(sent.hopCount, 2u);                          // incremented
+    EXPECT_EQ(memcmp(sent.targetMacAddress, kPeer2Mac, 6), 0); // target preserved
+    EXPECT_EQ(memcmp(sent.lastHopMacAddress, kMyMac, 6), 0);   // lastHop = my MAC
+  }
+}
+
+TEST_F(RelayDownlinkTest, DropsReplay) {
+  Mesh mesh = makeMeshWithPeers(1);
+  auto msg = makeDataMsg(kOriginMac, kPeer1Mac, 1, 99);
+
+  mesh.isReplay(msg);  // Pre-record in replay cache
+  mesh.relayDownlink(msg);
+
+  EXPECT_EQ(espNowSentPackets.size(), 0u);
+}
+
+TEST_F(RelayDownlinkTest, DropsAtMaxHops) {
+  Mesh mesh = makeMeshWithPeers(1);
+  auto msg = makeDataMsg(kOriginMac, kPeer1Mac, 1, 1,
+                         /*hopCount=*/planetopia::config::MAX_HOPS);
+
+  mesh.relayDownlink(msg);
+
+  EXPECT_EQ(espNowSentPackets.size(), 0u);
+}
+
+TEST_F(RelayDownlinkTest, SkipsSelf_WhenSelfInPeerList) {
+  Mesh mesh = makeMeshWithPeers(1);
+  // Add self to peer list (shouldn't happen in production but guard against it)
+  PeerInfo self{}; memcpy(self.mac, kMyMac, 6); self.lastSeenMillis = 0;
+  mesh.appendPeer(self);
+
+  auto msg = makeDataMsg(kOriginMac, kPeer2Mac, 1, 1);
+  mesh.relayDownlink(msg);
+
+  // Only 1 peer (kPeer1Mac) — self skipped
+  EXPECT_EQ(espNowSentPackets.size(), 1u);
+  EXPECT_EQ(memcmp(espNowSentPackets[0].addr, kPeer1Mac, 6), 0);
+}
+```
+
+- [ ] **Step 1.2: Run tests — expect compile error (relayDownlink undefined)**
+
+```bash
+cmake --build tests/build 2>&1 | grep "relayDownlink\|error:"
+```
+
+Expected: compile error — `'relayDownlink' is not a member of 'planetopia::mesh::Mesh'`
+
+- [ ] **Step 1.3: Declare `relayDownlink` in Mesh.h**
+
+In `main/src/Mesh/Mesh.h`, find the block of private relay/process helpers (~line 143):
+```cpp
+  void processMasterBeacon(const mesh_message& msg);
+  void processAdapterData(const mesh_message& msg);
+```
+Add after `processAdapterData`:
+```cpp
+  void relayDownlink(const mesh_message& msg);
+```
+
+- [ ] **Step 1.4: Implement `relayDownlink` in Mesh.cpp**
+
+In `main/src/Mesh/Mesh.cpp`, add the implementation immediately after `processAdapterData` (~line 935):
+
+```cpp
+void Mesh::relayDownlink(const mesh_message& msg) {
+  if (isReplay(msg)) return;
+  if (msg.hopCount >= planetopia::config::MAX_HOPS) return;
+  mesh_message relay = msg;
+  relay.hopCount++;
+  memcpy(relay.lastHopMacAddress, deviceMacAddress, 6);
+  for (size_t i = 0; i < peerCount; ++i) {
+    if (memcmp(peerMacs[i].mac, deviceMacAddress, 6) == 0) continue;
+    sendMessage(peerMacs[i].mac, relay);
+  }
+}
+```
+
+- [ ] **Step 1.5: Build and run tests — expect pass**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: all 40 tests pass (36 existing + 4 new).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add main/src/Mesh/Mesh.h main/src/Mesh/Mesh.cpp tests/unit/test_mesh_logic.cpp
+git commit -m "feat(mesh): add relayDownlink() helper for multi-hop data relay"
+```
+
+---
+
+### Task 2: Uplink relay in `processAdapterData` (sensor → master)
+
+When a non-master node receives `MESH_TYPE_ADAPTER_DATA` addressed to the master, it must relay it toward the master via the existing `transmitCore` routing (which uses `findNextHopToMaster()`). Without this, any sensor >1 hop from the master is invisible to the server.
+
+**Files:**
+- Modify: `main/src/Mesh/Mesh.cpp` — `processAdapterData()` (~line 924)
+- Modify: `tests/unit/test_mesh_logic.cpp`
+
+**Interfaces:**
+- Consumes: `void Mesh::relayDownlink(const mesh_message&)` from Task 1
+- Consumes: `void Mesh::transmitCore(adapter_types, const uint8_t[12], MeshMessageType, const mesh_message*)` (existing)
+
+- [ ] **Step 2.1: Write failing tests**
+
+Append to `tests/unit/test_mesh_logic.cpp`:
+
+```cpp
+// ─── processAdapterData: uplink relay ────────────────────────────────────────
+
+class AdapterDataRelayTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    EEPROM.reset();
+    resetMillis();
+    resetEspNowMock();
+  }
+
+  static constexpr uint8_t kMyMac[6]     = {0x11,0x22,0x33,0x44,0x55,0x66};
+  static constexpr uint8_t kMasterMac[6] = {0xAA,0xBB,0xCC,0xDD,0xEE,0x01};
+  static constexpr uint8_t kSensorMac[6] = {0x77,0x88,0x99,0xAA,0xBB,0xCC};
+  static constexpr uint8_t kPeerMac[6]   = {0x55,0x55,0x55,0x55,0x55,0x55};
+
+  Mesh makeIntermediateNode() {
+    Mesh mesh;
+    memcpy(mesh.deviceMacAddress, kMyMac, 6);
+    mesh.isMaster = false;
+    // Set master route: next hop IS the master (1 hop away)
+    memcpy(mesh.currentMaster.mac,     kMasterMac, 6);
+    memcpy(mesh.currentMaster.nextHop, kMasterMac, 6);
+    mesh.currentMaster.distance = 1;
+    mesh.hasMasterMac = true;
+    memcpy(mesh.knownMasterMac, kMasterMac, 6);
+    // Register master as enrolled peer (required for sendMessage + isPeerInRange)
+    PeerInfo p{}; memcpy(p.mac, kMasterMac, 6); p.lastSeenMillis = 0; mesh.appendPeer(p);
+    return mesh;
+  }
+
+  mesh_message makeUplinkMsg(uint32_t epoch, uint16_t seq, uint8_t hopCount = 1) {
+    mesh_message m{};
+    m.protoVersion = 1;
+    m.messageType  = MESH_TYPE_ADAPTER_DATA;
+    m.dataType     = adapter_types::PIR_ADAPTER;
+    memcpy(m.originMacAddress,  kSensorMac,  6);
+    memcpy(m.targetMacAddress,  kMasterMac,  6);  // addressed to master
+    memcpy(m.lastHopMacAddress, kSensorMac,  6);
+    m.hopCount = hopCount;
+    m.epochNum = epoch;
+    m.seqNum   = seq;
+    return m;
+  }
+};
+
+constexpr uint8_t AdapterDataRelayTest::kMyMac[];
+constexpr uint8_t AdapterDataRelayTest::kMasterMac[];
+constexpr uint8_t AdapterDataRelayTest::kSensorMac[];
+constexpr uint8_t AdapterDataRelayTest::kPeerMac[];
+
+TEST_F(AdapterDataRelayTest, IntermediateNode_RelaysUplinkTowardMaster) {
+  Mesh mesh = makeIntermediateNode();
+  auto msg  = makeUplinkMsg(1, 1, /*hopCount=*/1);
+
+  size_t before = espNowSentPackets.size();
+  mesh.processAdapterData(msg);
+
+  EXPECT_EQ(espNowSentPackets.size(), before + 1);
+  const auto& sent = *reinterpret_cast<const mesh_message*>(
+      espNowSentPackets.back().data.data());
+  EXPECT_EQ(sent.hopCount, 2u);                              // incremented
+  EXPECT_EQ(memcmp(espNowSentPackets.back().addr, kMasterMac, 6), 0); // routed via nextHop
+}
+
+TEST_F(AdapterDataRelayTest, IntermediateNode_DropsUplinkReplay) {
+  Mesh mesh = makeIntermediateNode();
+  auto msg  = makeUplinkMsg(1, 7);
+
+  mesh.processAdapterData(msg);  // first — relayed
+  size_t after1 = espNowSentPackets.size();
+
+  mesh.processAdapterData(msg);  // same epoch+seq — replay, dropped
+  EXPECT_EQ(espNowSentPackets.size(), after1);
+}
+
+TEST_F(AdapterDataRelayTest, Master_DoesNotRelayUplink_DeliversLocally) {
+  Mesh mesh = makeIntermediateNode();
+  mesh.isMaster = true;
+
+  bool callbackFired = false;
+  mesh.linkDataRecvCallback([&](mesh_message) { callbackFired = true; });
+
+  auto msg = makeUplinkMsg(1, 1);
+  memcpy(msg.targetMacAddress, mesh.deviceMacAddress, 6); // addressed to self (master)
+
+  size_t before = espNowSentPackets.size();
+  mesh.processAdapterData(msg);
+
+  EXPECT_TRUE(callbackFired);
+  EXPECT_EQ(espNowSentPackets.size(), before); // no relay
+}
+```
+
+- [ ] **Step 2.2: Run tests — expect failure**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure 2>&1 | grep -E "FAILED|PASSED|IntermediateNode"
+```
+
+Expected: `AdapterDataRelayTest.IntermediateNode_RelaysUplinkTowardMaster` FAILED (no sends occur).
+
+- [ ] **Step 2.3: Update `processAdapterData()` with uplink relay**
+
+Replace the entire `processAdapterData` body in `main/src/Mesh/Mesh.cpp` (~line 924–935):
+
+```cpp
+void Mesh::processAdapterData(const mesh_message& msg) {
+  static constexpr uint8_t OP_CONFIG_SET = 0xA0;
+  static const uint8_t kBroadcastMac[6] = {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
+
+  bool addressedToSelf    = (memcmp(msg.targetMacAddress, deviceMacAddress, 6) == 0);
+  bool isBroadcastTarget  = (memcmp(msg.targetMacAddress, kBroadcastMac,    6) == 0);
+  bool addressedToMaster  = hasMasterMac &&
+                            (memcmp(msg.targetMacAddress, currentMaster.mac, 6) == 0);
+
+  if (!isMaster && !addressedToSelf && !isBroadcastTarget) {
+    if (addressedToMaster) {
+      // Uplink: relay toward master via routing table
+      if (isReplay(msg)) return;
+      if (msg.hopCount >= planetopia::config::MAX_HOPS) return;
+      mesh_message relay = msg;
+      relay.hopCount++;
+      memcpy(relay.lastHopMacAddress, deviceMacAddress, 6);
+      transmitCore(relay.dataType, relay.data, MESH_TYPE_ADAPTER_DATA, &relay);
+      return;
+    }
+    // Downlink to another node: relay outward (Tasks 3 fills this in)
+    relayDownlink(msg);
+    return;
+  }
+
+  // Local delivery
+  bool isConfigOpcode = (msg.dataType == adapter_types::SERIAL_ADAPTER &&
+                         msg.data[0] == OP_CONFIG_SET);
+  if (isConfigOpcode && hasMasterMac &&
+      memcmp(msg.originMacAddress, knownMasterMac, 6) != 0) {
+    Logger::logln("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
+    return;
+  }
+  if (externalRecvCallback)
+    externalRecvCallback(msg);
+
+  // Broadcast: also relay so multi-hop nodes receive it (Task 3 test covers this)
+  if (isBroadcastTarget && !isMaster) {
+    relayDownlink(msg);
+  }
+}
+```
+
+- [ ] **Step 2.4: Build and run tests — expect pass**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add main/src/Mesh/Mesh.cpp tests/unit/test_mesh_logic.cpp
+git commit -m "feat(mesh): relay ADAPTER_DATA uplink toward master for multi-hop nodes"
+```
+
+---
+
+### Task 3: Downlink + broadcast relay in `processAdapterData`
+
+Two downlink paths need testing:
+1. **Targeted downlink** — master sends ADAPTER_DATA to a specific sensor node; intermediate nodes must relay it outward until the target receives it. `relayDownlink()` already wired in Task 2; this task covers tests and the `broadcastAdapterData` broadcast-target fix.
+2. **Broadcast downlink** — master wants all nodes to receive a command. `broadcastAdapterData()` currently sets `targetMacAddress = peer.mac` individually, so nodes >1 hop away never hear it. Fix: set `targetMacAddress = FF:FF:FF:FF:FF:FF` before sending, so every receiving node can identify it as broadcast, deliver locally, and relay outward.
+
+**Files:**
+- Modify: `main/src/Mesh/Mesh.cpp` — `broadcastAdapterData()` (~line 791)
+- Modify: `tests/unit/test_mesh_logic.cpp`
+
+- [ ] **Step 3.1: Write failing tests**
+
+Append to `tests/unit/test_mesh_logic.cpp`:
+
+```cpp
+// ─── processAdapterData: downlink + broadcast relay ──────────────────────────
+
+TEST_F(AdapterDataRelayTest, IntermediateNode_RelaysDownlinkToOtherTarget) {
+  // Node receives ADAPTER_DATA addressed to a different sensor — must relay outward
+  Mesh mesh = makeIntermediateNode();
+  // Add a second peer (different from master) to relay toward
+  PeerInfo extra{}; memcpy(extra.mac, kPeerMac, 6); extra.lastSeenMillis = 0;
+  mesh.appendPeer(extra);
+
+  mesh_message msg{};
+  msg.protoVersion = 1;
+  msg.messageType  = MESH_TYPE_ADAPTER_DATA;
+  msg.dataType     = adapter_types::PIR_ADAPTER;
+  memcpy(msg.originMacAddress,  kMasterMac, 6);
+  memcpy(msg.targetMacAddress,  kSensorMac, 6); // some other sensor, not me, not master
+  msg.hopCount = 1; msg.epochNum = 2; msg.seqNum = 1;
+
+  size_t before = espNowSentPackets.size();
+  mesh.processAdapterData(msg);
+
+  // Should relay to all peers: kMasterMac + kPeerMac (2 peers)
+  EXPECT_GT(espNowSentPackets.size(), before);
+  // Target preserved in every relayed copy
+  for (size_t i = before; i < espNowSentPackets.size(); ++i) {
+    const auto& sent = *reinterpret_cast<const mesh_message*>(
+        espNowSentPackets[i].data.data());
+    EXPECT_EQ(memcmp(sent.targetMacAddress, kSensorMac, 6), 0);
+    EXPECT_EQ(sent.hopCount, 2u);
+  }
+}
+
+TEST_F(AdapterDataRelayTest, IntermediateNode_BroadcastTarget_DeliveredAndRelayed) {
+  Mesh mesh = makeIntermediateNode();
+  PeerInfo extra{}; memcpy(extra.mac, kPeerMac, 6); extra.lastSeenMillis = 0;
+  mesh.appendPeer(extra);
+
+  bool callbackFired = false;
+  mesh.linkDataRecvCallback([&](mesh_message) { callbackFired = true; });
+
+  static constexpr uint8_t kBroadcast[6] = {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
+  mesh_message msg{};
+  msg.protoVersion = 1;
+  msg.messageType  = MESH_TYPE_ADAPTER_DATA;
+  msg.dataType     = adapter_types::PIR_ADAPTER;
+  memcpy(msg.originMacAddress,  kMasterMac,  6);
+  memcpy(msg.targetMacAddress,  kBroadcast,  6); // broadcast
+  msg.hopCount = 1; msg.epochNum = 3; msg.seqNum = 1;
+
+  size_t before = espNowSentPackets.size();
+  mesh.processAdapterData(msg);
+
+  EXPECT_TRUE(callbackFired);                                 // delivered locally
+  EXPECT_GT(espNowSentPackets.size(), before);                // AND relayed outward
+}
+
+TEST_F(AdapterDataRelayTest, BroadcastAdapterData_UsesBroadcastTargetMAC) {
+  // Verify master's broadcastAdapterData sets FF:FF target so multi-hop works
+  Mesh mesh = makeIntermediateNode();
+  mesh.isMaster = true;
+  // Add a peer so broadcastToAllPeers has someone to send to
+  PeerInfo extra{}; memcpy(extra.mac, kPeerMac, 6); extra.lastSeenMillis = 0;
+  mesh.appendPeer(extra);
+
+  static constexpr uint8_t kPayload[12] = {0x01,0x02,0x03,0,0,0,0,0,0,0,0,0};
+  size_t before = espNowSentPackets.size();
+  mesh.broadcastAdapterData(adapter_types::PIR_ADAPTER, kPayload);
+
+  EXPECT_GT(espNowSentPackets.size(), before);
+  // Every sent message should have FF:FF target
+  static constexpr uint8_t kBroadcast[6] = {0xFF,0xFF,0xFF,0xFF,0xFF,0xFF};
+  for (size_t i = before; i < espNowSentPackets.size(); ++i) {
+    const auto& sent = *reinterpret_cast<const mesh_message*>(
+        espNowSentPackets[i].data.data());
+    EXPECT_EQ(memcmp(sent.targetMacAddress, kBroadcast, 6), 0);
+  }
+}
+```
+
+- [ ] **Step 3.2: Run tests — expect failure on broadcast target test**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure 2>&1 | grep -E "FAILED|PASSED|Broadcast|Downlink"
+```
+
+Expected: `BroadcastAdapterData_UsesBroadcastTargetMAC` FAILED (target is currently set to `currentMaster.mac` by `buildMessage`, not broadcast MAC).
+
+- [ ] **Step 3.3: Fix `broadcastAdapterData()` and `broadcastToAllPeers()`**
+
+In `main/src/Mesh/Mesh.cpp`, find `broadcastAdapterData` (~line 791):
+
+```cpp
+// BEFORE:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[12]) {
+  mesh_message msg = buildMessage(type, data, MESH_TYPE_ADAPTER_DATA);
+  broadcastToAllPeers(msg);
+}
+```
+
+Replace with:
+```cpp
+// AFTER:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[12]) {
+  mesh_message msg = buildMessage(type, data, MESH_TYPE_ADAPTER_DATA);
+  memset(msg.targetMacAddress, 0xFF, 6); // broadcast indicator — relayed by all intermediate nodes
+  broadcastToAllPeers(msg);
+}
+```
+
+Then find `broadcastToAllPeers` (~line 640):
+
+```cpp
+// BEFORE:
+void Mesh::broadcastToAllPeers(mesh_message msg) {
+  if (peerCount == 0) {
+    Logger::logln("MESH", "WARNING: No peers to broadcast to!", LogLevel::LOG_WARN);
+    return;
+  }
+  for (size_t i = 0; i < peerCount; ++i) {
+    if (memcmp(peerMacs[i].mac, deviceMacAddress, 6) == 0)
+      continue; // Skip self
+    memcpy(msg.targetMacAddress, peerMacs[i].mac, 6);
+    sendMessage(peerMacs[i].mac, msg);
+  }
+}
+```
+
+Replace with:
+```cpp
+// AFTER (no longer overwrites targetMacAddress — caller sets it):
+void Mesh::broadcastToAllPeers(mesh_message msg) {
+  if (peerCount == 0) {
+    Logger::logln("MESH", "WARNING: No peers to broadcast to!", LogLevel::LOG_WARN);
+    return;
+  }
+  for (size_t i = 0; i < peerCount; ++i) {
+    if (memcmp(peerMacs[i].mac, deviceMacAddress, 6) == 0)
+      continue; // Skip self
+    sendMessage(peerMacs[i].mac, msg);
+  }
+}
+```
+
+- [ ] **Step 3.4: Build and run tests — expect pass**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add main/src/Mesh/Mesh.cpp tests/unit/test_mesh_logic.cpp
+git commit -m "feat(mesh): relay downlink and broadcast ADAPTER_DATA to multi-hop nodes"
+```
+
+---
+
+### Task 4: `processJoinAck` relay — enrollment for multi-hop nodes
+
+`processJoinAck()` currently drops any JOIN_ACK not addressed to itself (`memcmp != 0 → return`). Nodes >1 hop from master send an enrollment request that the master approves, but the JOIN_ACK can't reach them. Fix: relay outward before the target check.
+
+**Files:**
+- Modify: `main/src/Mesh/Mesh.cpp` — `processJoinAck()` (~line 1040)
+- Modify: `tests/unit/test_mesh_logic.cpp`
+
+**Interfaces:**
+- Consumes: `void Mesh::relayDownlink(const mesh_message&)` from Task 1
+
+- [ ] **Step 4.1: Write failing tests**
+
+Append to `tests/unit/test_mesh_logic.cpp`:
+
+```cpp
+// ─── processJoinAck: relay ───────────────────────────────────────────────────
+
+class JoinAckRelayTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    EEPROM.reset();
+    resetMillis();
+    resetEspNowMock();
+  }
+
+  static constexpr uint8_t kMyMac[6]       = {0x11,0x22,0x33,0x44,0x55,0x66};
+  static constexpr uint8_t kMasterMac[6]   = {0xAA,0xBB,0xCC,0xDD,0xEE,0x01};
+  static constexpr uint8_t kDistantNode[6] = {0x99,0x88,0x77,0x66,0x55,0x44};
+  static constexpr uint8_t kPeerMac[6]     = {0x33,0x33,0x33,0x33,0x33,0x33};
+
+  Mesh makeIntermediateNode() {
+    Mesh mesh;
+    memcpy(mesh.deviceMacAddress, kMyMac, 6);
+    mesh.isMaster = false;
+    PeerInfo p{}; memcpy(p.mac, kPeerMac, 6); p.lastSeenMillis = 0; mesh.appendPeer(p);
+    return mesh;
+  }
+
+  mesh_message makeJoinAck(const uint8_t target[6], uint8_t hopCount = 1) {
+    mesh_message m{};
+    m.protoVersion = 1;
+    m.messageType  = MESH_TYPE_JOIN_ACK;
+    m.dataType     = adapter_types::UNKNOWN_ADAPTER;
+    memcpy(m.originMacAddress,  kMasterMac, 6);
+    memcpy(m.targetMacAddress,  target,     6);
+    memcpy(m.lastHopMacAddress, kMasterMac, 6);
+    m.hopCount = hopCount;
+    m.epochNum = 1;
+    m.seqNum   = 1;
+    return m;
+  }
+};
+
+constexpr uint8_t JoinAckRelayTest::kMyMac[];
+constexpr uint8_t JoinAckRelayTest::kMasterMac[];
+constexpr uint8_t JoinAckRelayTest::kDistantNode[];
+constexpr uint8_t JoinAckRelayTest::kPeerMac[];
+
+TEST_F(JoinAckRelayTest, RelaysJoinAck_WhenNotAddressedToSelf) {
+  Mesh mesh = makeIntermediateNode();
+  auto msg  = makeJoinAck(kDistantNode); // addressed to a distant node, not me
+
+  size_t before = espNowSentPackets.size();
+  mesh.processJoinAck(msg);
+
+  EXPECT_GT(espNowSentPackets.size(), before); // relayed to kPeerMac
+  EXPECT_EQ(memcmp(espNowSentPackets.back().addr, kPeerMac, 6), 0);
+  const auto& sent = *reinterpret_cast<const mesh_message*>(
+      espNowSentPackets.back().data.data());
+  EXPECT_EQ(sent.hopCount, 2u);
+  EXPECT_EQ(memcmp(sent.targetMacAddress, kDistantNode, 6), 0); // target preserved
+}
+
+TEST_F(JoinAckRelayTest, DoesNotRelayJoinAck_WhenAddressedToSelf) {
+  // When addressed to self: process (enroll), do NOT relay
+  Mesh mesh = makeIntermediateNode();
+
+  // Provide a fingerprint (first 4 bytes of devicePublicKey)
+  // devicePublicKey is zeroed in constructor — fingerprint = {0,0,0,0}
+  auto msg = makeJoinAck(kMyMac);
+  memset(msg.data, 0, sizeof(msg.data)); // fingerprint matches zeroed pubkey
+
+  size_t before = espNowSentPackets.size();
+  mesh.processJoinAck(msg);
+
+  EXPECT_EQ(espNowSentPackets.size(), before); // no relay
+}
+
+TEST_F(JoinAckRelayTest, DropsJoinAckRelay_WhenReplay) {
+  Mesh mesh = makeIntermediateNode();
+  auto msg  = makeJoinAck(kDistantNode);
+
+  mesh.processJoinAck(msg);          // first: relayed
+  size_t after1 = espNowSentPackets.size();
+  mesh.processJoinAck(msg);          // replay: dropped
+  EXPECT_EQ(espNowSentPackets.size(), after1);
+}
+```
+
+- [ ] **Step 4.2: Run tests — expect failure**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure 2>&1 | grep -E "FAILED|PASSED|JoinAck"
+```
+
+Expected: `JoinAckRelayTest.RelaysJoinAck_WhenNotAddressedToSelf` FAILED (current code returns immediately when target != self).
+
+- [ ] **Step 4.3: Update `processJoinAck()` to relay before target check**
+
+In `main/src/Mesh/Mesh.cpp`, find `processJoinAck` (~line 1040):
+
+```cpp
+// BEFORE:
+void Mesh::processJoinAck(const mesh_message& msg) {
+  // Verify the ack is addressed to us
+  if (memcmp(msg.targetMacAddress, deviceMacAddress, 6) != 0)
+    return;
+  // Verify fingerprint matches our public key (first 4 bytes)
+  ...
+```
+
+Replace with:
+```cpp
+// AFTER:
+void Mesh::processJoinAck(const mesh_message& msg) {
+  // Relay outward if not addressed to us (multi-hop enrollment)
+  if (memcmp(msg.targetMacAddress, deviceMacAddress, 6) != 0) {
+    relayDownlink(msg);
+    return;
+  }
+  // Verify fingerprint matches our public key (first 4 bytes)
+  ...
+```
+
+(Leave everything after the fingerprint check unchanged.)
+
+- [ ] **Step 4.4: Build and run tests — expect pass**
+
+```bash
+cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add main/src/Mesh/Mesh.cpp tests/unit/test_mesh_logic.cpp
+git commit -m "feat(mesh): relay JOIN_ACK outward so nodes >1 hop can enroll"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec item | Task | Status |
+|---|---|---|
+| §5.1 Multi-hop uplink relay (`processAdapterData`) | Task 2 | ✓ |
+| §5.2 Multi-hop downlink relay (`relayDownlink` helper) | Task 1 | ✓ |
+| §5.2 Downlink relay wired into `processAdapterData` | Task 2/3 | ✓ |
+| §5.2 `SERIAL_CMD_BROADCAST` relay | n/a — master converts to ADAPTER_DATA via `broadcastAdapterData`; fix is the broadcast-target MAC in Task 3 | ✓ |
+| §5.3 JOIN_ACK relay | Task 4 | ✓ |
+
+**Replay protection:** All relay paths call `isReplay()` first — either directly in `relayDownlink()` or inline in the uplink path. No message loops past `MAX_HOPS`.
+
+**Broadcast-target convention:** `broadcastAdapterData()` now sets `targetMacAddress = FF:FF:...` and `broadcastToAllPeers()` no longer overwrites it. Existing `transmitCore` path (for targeted messages) sets `targetMacAddress = currentMaster.mac` unchanged. No regression.
+
+**Placeholder scan:** None found. All code blocks contain compilable C++. All test assertions are concrete.
+
+**Type consistency:** `mesh_message` unchanged throughout (Phase 3 changes struct). `relayDownlink` signature used identically in Tasks 1–4.

--- a/docs/superpowers/plans/nodes-phase2-bug-fixes.md
+++ b/docs/superpowers/plans/nodes-phase2-bug-fixes.md
@@ -1,0 +1,347 @@
+# Phase 2 Bug Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four production bugs across firmware and server — WDT EEPROM wipe, JOIN_ACK peer MAC field, TX power raw-frame bypass, and stale online-node timeout.
+
+**Architecture:** Two repositories, two tasks. Task 1 touches only firmware (ESP32 Arduino/CMake project). Task 2 touches only the Go server. Each task is independently committable and reviewable. Changes are small (1–10 lines each) with targeted tests.
+
+**Tech Stack:** C++17 / Arduino ESP32 (firmware), Go 1.26 (server), GoogleTest + CMake (firmware tests), `go test` (server tests), nanopb/protobuf3 (wire format).
+
+## Global Constraints
+
+- Firmware repo root: `/Users/benjamin.swanepoel/projects/personal/Planetopia-nodes`
+- Server repo root: `/Users/benjamin.swanepoel/projects/personal/motionSensorServer`
+- Both repos are on branch `feat/phase2-bug-fixes` off `main` — do NOT commit to `main`
+- Firmware test command: `cmake -B tests/build -S tests && cmake --build tests/build && ctest --test-dir tests/build --output-on-failure`
+- Server test command (run from `server/orchestrator/`): `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/...`
+- Git identity for commits: local config is already set to `49689582+superbrobenji@users.noreply.github.com` — do not change it
+- No new abstractions, no refactoring beyond what each fix requires
+- `Serial_Adapter.cpp` is NOT compiled in the firmware unit test build (it is hardware-dependent) — firmware tests only cover Mesh logic; behavioral correctness of Serial_Adapter changes is verified by the corresponding server-side test
+
+---
+
+### Task 1: Firmware bug fixes — WDT loop + JOIN_ACK peer MAC
+
+Two one-line fixes in firmware. Neither has a dedicated unit test (Serial_Adapter is excluded from the test build); the passing test suite confirms no regression.
+
+**Files:**
+- Modify: `main/main.ino` (lines 104–108)
+- Modify: `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp` (line 403)
+
+**Interfaces:**
+- Consumes: nothing from other tasks
+- Produces: nothing consumed by other tasks
+
+---
+
+- [ ] **Step 1: Write the WDT fix**
+
+In `main/main.ino` around line 104, find this block:
+
+```cpp
+      Serial.println("[BOOT] WDT loop detected — clearing EEPROM and halting");
+      em.clearAll();
+      while (true) { delay(1000); }
+```
+
+Replace with:
+
+```cpp
+      Serial.println("[BOOT] WDT loop detected — halting. Manual reset required.");
+      while (true) { delay(1000); }
+```
+
+The `clearAll()` call was destroying enrollment state and peer keys on every WDT recovery loop, forcing re-enrollment after every firmware crash. Physical factory-reset (button sequence) is the intentional path for wiping EEPROM.
+
+- [ ] **Step 2: Write the JOIN_ACK peer MAC fix**
+
+In `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp` around line 403, find:
+
+```cpp
+        meshInstance->enrollPeer(msg.originMacAddress, msg.enrollmentPublicKey);
+```
+
+Replace with:
+
+```cpp
+        meshInstance->enrollPeer(msg.targetMacAddress, msg.enrollmentPublicKey);
+```
+
+The peer being enrolled is the node receiving the JOIN_ACK — that is the *target* of the message, not the origin. The server populates `targetMacAddress` with the enrolling node's MAC; `originMacAddress` was populated with the master's MAC (wrong peer added).
+
+- [ ] **Step 3: Run firmware tests**
+
+```bash
+cmake -B tests/build -S tests && cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: all 47 tests pass, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes \
+  add main/main.ino main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes \
+  commit -m "fix(firmware): remove EEPROM wipe on WDT loop; use targetMacAddress in enrollPeer"
+```
+
+---
+
+### Task 2: Server bug fixes — TX power protobuf, JOIN_ACK TargetMacAddress, online timeout
+
+Three fixes in two Go files. New tests for the TX power and JOIN_ACK changes; the timeout change is covered by a new threshold boundary test on `NodeRegistry`.
+
+**Files:**
+- Modify: `server/orchestrator/mesh/server.go` (two locations: `SetTxPowerPreset` ~line 584, `ApproveEnrollment` ~line 436)
+- Modify: `server/orchestrator/mesh/api.go` (line 241)
+- Modify (tests): `server/orchestrator/mesh/mesh_test.go` — add `TestGetOnlineNodes_ThresholdBoundary`
+- Modify (tests): `server/orchestrator/mesh/server_enrollment_test.go` — update `TestApproveEnrollment_SendsJoinAckWithPubKey`
+- Create (tests): `server/orchestrator/mesh/server_test.go` — add `TestSetTxPowerPreset_SendsProtoFrame`
+
+**Interfaces:**
+- Consumes: nothing from Task 1
+- Produces: nothing consumed downstream
+
+---
+
+- [ ] **Step 1: Write the failing TX power test**
+
+Create `server/orchestrator/mesh/server_test.go`:
+
+```go
+package mesh
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSetTxPowerPreset_SendsProtoFrame(t *testing.T) {
+	ms := newTestMeshServer(t)
+	mockPort := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(mockPort)
+
+	if err := ms.SetTxPowerPreset(1); err != nil {
+		t.Fatalf("SetTxPowerPreset(1) returned error: %v", err)
+	}
+
+	data := mockPort.GetWrittenData()
+	if len(data) < 2 {
+		t.Fatalf("no frame written: only %d bytes", len(data))
+	}
+	length := int(binary.LittleEndian.Uint16(data[:2]))
+	if len(data) < 2+length {
+		t.Fatalf("frame truncated: need %d bytes after header, have %d", length, len(data)-2)
+	}
+
+	var msg MeshMessage
+	if err := proto.Unmarshal(data[2:2+length], &msg); err != nil {
+		t.Fatalf("frame is not valid protobuf: %v — WriteRaw was used instead of WriteFrame", err)
+	}
+
+	if msg.MessageType != MessageTypeAdapterData {
+		t.Errorf("MessageType = %d, want %d (MessageTypeAdapterData)", msg.MessageType, MessageTypeAdapterData)
+	}
+	if msg.DataType != AdapterTypeSerial {
+		t.Errorf("DataType = %d, want %d (AdapterTypeSerial)", msg.DataType, AdapterTypeSerial)
+	}
+	if len(msg.Data) == 0 || msg.Data[0] != OpTxPowerSet {
+		t.Errorf("Data[0] = %d, want %d (OpTxPowerSet)", msg.Data[0], OpTxPowerSet)
+	}
+	if len(msg.Data) < 2 || msg.Data[1] != 1 {
+		t.Errorf("Data[1] = %d, want 1 (preset)", msg.Data[1])
+	}
+}
+
+func TestSetTxPowerPreset_InvalidPreset_ReturnsError(t *testing.T) {
+	ms := newTestMeshServer(t)
+	if err := ms.SetTxPowerPreset(3); err == nil {
+		t.Error("expected error for preset=3, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify TX power test fails**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestSetTxPowerPreset -v
+```
+
+Expected: `TestSetTxPowerPreset_SendsProtoFrame` FAIL with "frame is not valid protobuf" (because `WriteRaw` produces a non-protobuf payload). `TestSetTxPowerPreset_InvalidPreset_ReturnsError` PASS (validation already exists).
+
+- [ ] **Step 3: Fix SetTxPowerPreset to use WriteFrame**
+
+In `server/orchestrator/mesh/server.go`, find `SetTxPowerPreset` (~line 575). Replace the entire payload/frame/WriteRaw block:
+
+```go
+// Before:
+	// Frame: [2-byte LE length][A1][preset]
+	payload := []byte{OpTxPowerSet, preset}
+	header := []byte{byte(len(payload) & 0xFF), byte((len(payload) >> 8) & 0xFF)}
+	frame := append(header, payload...)
+
+	if err := ms.serialComm.WriteRaw(frame); err != nil {
+		return fmt.Errorf("failed to send TX power preset: %w", err)
+	}
+```
+
+```go
+// After:
+	payload := make([]byte, MaxDataLength)
+	payload[0] = OpTxPowerSet
+	payload[1] = preset
+	msg := &MeshMessage{
+		MessageType: MessageTypeAdapterData,
+		DataType:    AdapterTypeSerial,
+		Data:        payload,
+	}
+	if err := ms.serialComm.WriteFrame(msg); err != nil {
+		return fmt.Errorf("failed to send TX power preset: %w", err)
+	}
+```
+
+- [ ] **Step 4: Run to verify TX power test passes**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestSetTxPowerPreset -v
+```
+
+Expected: both TX power tests PASS.
+
+- [ ] **Step 5: Write the failing JOIN_ACK TargetMacAddress assertion**
+
+In `server/orchestrator/mesh/server_enrollment_test.go`, find `TestApproveEnrollment_SendsJoinAckWithPubKey` (around line 45). Add these assertions at the end of the test, after the existing `PublicKey` check:
+
+```go
+	// TargetMacAddress must carry the enrolling node's MAC — not OriginMacAddress
+	wantMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF} // from enrollTestNode helper
+	if !bytes.Equal(msg.TargetMacAddress, wantMAC) {
+		t.Errorf("TargetMacAddress = %x, want %x", msg.TargetMacAddress, wantMAC)
+	}
+	if len(msg.OriginMacAddress) != 0 {
+		t.Errorf("OriginMacAddress should be absent, got %x", msg.OriginMacAddress)
+	}
+```
+
+Add `"bytes"` to the import block if not already present.
+
+- [ ] **Step 6: Run to verify JOIN_ACK test fails**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestApproveEnrollment_SendsJoinAckWithPubKey -v
+```
+
+Expected: FAIL — `TargetMacAddress` is empty/nil because `ApproveEnrollment` currently sets `OriginMacAddress`.
+
+- [ ] **Step 7: Fix ApproveEnrollment to use TargetMacAddress**
+
+In `server/orchestrator/mesh/server.go`, find `ApproveEnrollment` (~line 434). Change:
+
+```go
+// Before:
+		ackMsg := &MeshMessage{
+			MessageType:      MessageTypeJoinAck,
+			OriginMacAddress: node.MAC[:],
+			PublicKey:        node.PublicKey[:],
+		}
+```
+
+```go
+// After:
+		ackMsg := &MeshMessage{
+			MessageType:      MessageTypeJoinAck,
+			TargetMacAddress: node.MAC[:],
+			PublicKey:        node.PublicKey[:],
+		}
+```
+
+The JOIN_ACK is a message FROM the master TO the enrolling node. The node is the *target*. Firmware's `processJoinAck` checks `msg.targetMacAddress` to determine if the ACK is for this node.
+
+- [ ] **Step 8: Run to verify JOIN_ACK test passes**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestApproveEnrollment -v
+```
+
+Expected: all `TestApproveEnrollment_*` tests PASS.
+
+- [ ] **Step 9: Write the failing online timeout threshold test**
+
+In `server/orchestrator/mesh/mesh_test.go`, add after `TestNodeRegistry` (around line 178):
+
+```go
+func TestGetOnlineNodes_ThresholdBoundary(t *testing.T) {
+	registry := NewNodeRegistry()
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	macStr := macToString(mac)
+
+	registry.UpdateNode(mac, AdapterTypePIR, 1000, 1)
+
+	// Backdate LastSeen to 45 seconds ago: within 75s threshold but outside 30s threshold
+	registry.mu.Lock()
+	registry.nodes[macStr].LastSeen = time.Now().Add(-45 * time.Second)
+	registry.mu.Unlock()
+
+	if got := registry.GetOnlineNodes(30 * time.Second); len(got) != 0 {
+		t.Errorf("GetOnlineNodes(30s): expected 0 nodes for a 45s-old node, got %d", len(got))
+	}
+	if got := registry.GetOnlineNodes(75 * time.Second); len(got) != 1 {
+		t.Errorf("GetOnlineNodes(75s): expected 1 node for a 45s-old node, got %d", len(got))
+	}
+}
+```
+
+Make sure `"time"` is already in the imports of `mesh_test.go` (it is, from existing tests).
+
+- [ ] **Step 10: Run to verify threshold test passes**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestGetOnlineNodes_ThresholdBoundary -v
+```
+
+Expected: PASS (the test doesn't test `api.go`'s hardcoded value yet — it documents the correct threshold behavior).
+
+- [ ] **Step 11: Fix the hardcoded 30s timeout in api.go**
+
+In `server/orchestrator/mesh/api.go` line 241, change:
+
+```go
+// Before:
+	onlineNodes := registry.GetOnlineNodes(30 * time.Second) // 30 second timeout
+```
+
+```go
+// After:
+	onlineNodes := registry.GetOnlineNodes(75 * time.Second) // 2.5× the 30s health interval — single missed report no longer marks offline
+```
+
+- [ ] **Step 12: Run full server test suite**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/...
+```
+
+Expected: all tests pass, 0 failures.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer \
+  add server/orchestrator/mesh/server.go \
+      server/orchestrator/mesh/api.go \
+      server/orchestrator/mesh/mesh_test.go \
+      server/orchestrator/mesh/server_enrollment_test.go \
+      server/orchestrator/mesh/server_test.go
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer \
+  commit -m "fix(server): TX power via WriteFrame, JOIN_ACK TargetMacAddress, online timeout 75s"
+```

--- a/docs/superpowers/plans/nodes-phase3-proto-v2.md
+++ b/docs/superpowers/plans/nodes-phase3-proto-v2.md
@@ -1,0 +1,653 @@
+# Phase 3 Proto V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `mesh_message.data` from 12 to 64 bytes, bump `PROTO_VERSION` to 2, and remove the 3-chunk enrollment workaround that only existed because 32-byte keys couldn't fit in 12 bytes.
+
+**Architecture:** Two tasks — one per repo. Firmware (Task 1) changes the on-air struct layout, proto options, version constant, and enrollment send/receive. Server (Task 2) updates its data length constant and proto version guard. Both must be deployed together since `PROTO_VERSION` 1 ↔ 2 are incompatible; after Task 2, the server drops firmware v1 messages and vice versa.
+
+**Tech Stack:** C++17 / Arduino ESP32 (firmware), nanopb-0.4.9.1 (protobuf), GoogleTest + CMake (firmware tests), Go 1.26 + `go test` (server tests).
+
+## Global Constraints
+
+- Firmware repo root: `/Users/benjamin.swanepoel/projects/personal/Planetopia-nodes`
+- Server repo root: `/Users/benjamin.swanepoel/projects/personal/motionSensorServer`
+- Both repos: branch `feat/phase3-proto-v2` — do NOT commit to `main`
+- Git identity: already configured to `49689582+superbrobenji@users.noreply.github.com` on both repos — do not change it
+- Firmware test command (from repo root): `cmake -B tests/build -S tests && cmake --build tests/build && ctest --test-dir tests/build --output-on-failure`
+- Server test command (from `server/orchestrator/`): `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/...`
+- nanopb generator: `python3 /Users/benjamin.swanepoel/Library/Python/3.9/lib/python/site-packages/nanopb/generator/nanopb_generator.py`
+- `Serial_Adapter.cpp` and `PIR_Adapter.cpp` are NOT compiled in the firmware unit test build — changes there are verified by building the test suite without errors (CMake picks them up as source targets)
+- No new abstractions beyond what the spec requires; no refactoring unrelated to the data-field expansion
+
+---
+
+### Task 1: Firmware — data[64], PROTO_VERSION 2, single-message enrollment
+
+**Scope:** Grow `mesh_message.data[12]` → `data[64]`, bump `static_assert` and `PROTO_VERSION`, update the `.options` file and regenerate nanopb, update every `data[12]` signature and buffer declaration, replace 3-chunk enrollment send+receive with a single message using the existing `enrollmentPublicKey[32]` field.
+
+**Files:**
+- Modify: `main/proto/mesh.options`
+- Regenerate: `main/src/Mesh/serialization/mesh.pb.h` and `mesh.pb.c`
+- Modify: `main/src/Mesh/Mesh.h` (struct field, static_assert, PROTO_VERSION, method signatures)
+- Modify: `main/src/Mesh/Mesh.cpp` (method signatures, sendEnrollmentRequest, processEnrollmentRequest)
+- Modify: `main/src/Adapter/Adapter.h` (sendDataThroughMesh signature)
+- Modify: `main/src/Adapter/Adapter.cpp` (sendDataThroughMesh signature)
+- Modify: `main/src/Adapter/PIR_Adapter/PIR_Adapter.h` (sendDataTrampoline signature)
+- Modify: `main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp` (signature + local buffer)
+- Modify: `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp` (local buffer)
+- Modify: `tests/mocks/firmware_stubs.cpp` (buildMessage stub signature; remove processEnrollmentRequest stub)
+- Modify: `tests/mocks/mesh_logic_impl.cpp` (transmitCore + broadcastAdapterData signatures; add sendEnrollmentRequest + processEnrollmentRequest real impls)
+- Modify: `tests/unit/test_mesh_logic.cpp` (kPayload[12] → [64]; add EnrollmentTest)
+
+**Interfaces:**
+- Consumes: nothing from Task 2
+- Produces: `PROTO_VERSION = 2` constant; `sizeof(mesh_message) == 127`; `sendEnrollmentRequest()` sends exactly 1 ESP-NOW packet; `processEnrollmentRequest()` sets `_pendingEnrollmentRelay`, `_pendingEnrollmentMac`, `_pendingEnrollmentPubKey` in one call
+
+---
+
+- [ ] **Step 1: Update mesh.options max_size**
+
+In `main/proto/mesh.options`, change line 4:
+
+```
+# Before:
+mesh.MeshMessage.data              max_size:12
+
+# After:
+mesh.MeshMessage.data              max_size:64
+```
+
+Full file after edit:
+```
+mesh.MeshMessage.originMacAddress  max_size:6  fixed_length:true
+mesh.MeshMessage.targetMacAddress  max_size:6  fixed_length:true
+mesh.MeshMessage.lastHopMacAddress max_size:6  fixed_length:true
+mesh.MeshMessage.data              max_size:64
+mesh.MeshMessage.public_key        max_size:32
+```
+
+- [ ] **Step 2: Regenerate mesh.pb.h and mesh.pb.c**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+python3 /Users/benjamin.swanepoel/Library/Python/3.9/lib/python/site-packages/nanopb/generator/nanopb_generator.py \
+  --output-dir main/src/Mesh/serialization/ \
+  main/proto/mesh.proto
+```
+
+Expected: command exits 0, no error output. Then verify:
+```bash
+grep "PB_BYTES_ARRAY_T(64)" main/src/Mesh/serialization/mesh.pb.h
+```
+Expected: `typedef PB_BYTES_ARRAY_T(64) mesh_MeshMessage_data_t;`
+
+- [ ] **Step 3: Update struct field, static_assert, and PROTO_VERSION in Mesh.h**
+
+In `main/src/Mesh/Mesh.h`:
+
+Line 38 — bump PROTO_VERSION:
+```cpp
+// Before:
+static constexpr uint8_t PROTO_VERSION = 1;
+// After:
+static constexpr uint8_t PROTO_VERSION = 2;
+```
+
+Line 42 — update comment:
+```cpp
+// Before:
+  uint8_t protoVersion; // Always PROTO_VERSION (1)
+// After:
+  uint8_t protoVersion; // Always PROTO_VERSION (2)
+```
+
+Line 48 — grow data field:
+```cpp
+// Before:
+  uint8_t data[12];
+// After:
+  uint8_t data[64];
+```
+
+Line 55 — update static_assert:
+```cpp
+// Before:
+static_assert(sizeof(mesh_message) == 75, "mesh_message size changed — update server proto");
+// After:
+static_assert(sizeof(mesh_message) == 127, "mesh_message size changed — update server proto");
+```
+
+- [ ] **Step 4: Update method signatures in Mesh.h**
+
+Still in `main/src/Mesh/Mesh.h`, update these five signatures (change `data[12]` → `data[64]` in each):
+
+Line 104:
+```cpp
+// Before:
+  mesh_message buildMessage(adapter_types type, const uint8_t data[12], MeshMessageType msgType);
+// After:
+  mesh_message buildMessage(adapter_types type, const uint8_t data[64], MeshMessageType msgType);
+```
+
+Line 132:
+```cpp
+// Before:
+  void transmitCore(const adapter_types type, const uint8_t data[12],
+// After:
+  void transmitCore(const adapter_types type, const uint8_t data[64],
+```
+
+Line 216:
+```cpp
+// Before:
+  static void transmit(const adapter_types type, const uint8_t data[12]);
+// After:
+  static void transmit(const adapter_types type, const uint8_t data[64]);
+```
+
+Line 240:
+```cpp
+// Before:
+  void broadcastAdapterData(adapter_types type, const uint8_t data[12]);
+// After:
+  void broadcastAdapterData(adapter_types type, const uint8_t data[64]);
+```
+
+Line 243:
+```cpp
+// Before:
+  static void broadcastAdapterDataStatic(adapter_types type, const uint8_t data[12]);
+// After:
+  static void broadcastAdapterDataStatic(adapter_types type, const uint8_t data[64]);
+```
+
+- [ ] **Step 5: Update method signatures in Mesh.cpp**
+
+In `main/src/Mesh/Mesh.cpp`, change the following function definition signatures (`data[12]` → `data[64]`):
+
+Line 364:
+```cpp
+// Before:
+mesh_message Mesh::buildMessage(adapter_types type, const uint8_t data[12],
+// After:
+mesh_message Mesh::buildMessage(adapter_types type, const uint8_t data[64],
+```
+
+Line 652:
+```cpp
+// Before:
+void Mesh::transmitCore(const adapter_types type, const uint8_t data[12], MeshMessageType msgType,
+// After:
+void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMessageType msgType,
+```
+
+Line 681:
+```cpp
+// Before:
+void Mesh::transmit(const adapter_types type, const uint8_t data[12]) {
+// After:
+void Mesh::transmit(const adapter_types type, const uint8_t data[64]) {
+```
+
+Line 791:
+```cpp
+// Before:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[12]) {
+// After:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[64]) {
+```
+
+Line 797:
+```cpp
+// Before:
+void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t data[12]) {
+// After:
+void Mesh::broadcastAdapterDataStatic(adapter_types type, const uint8_t data[64]) {
+```
+
+- [ ] **Step 6: Replace sendEnrollmentRequest in Mesh.cpp**
+
+In `main/src/Mesh/Mesh.cpp`, replace the entire function from line 984 (`void Mesh::sendEnrollmentRequest()`) through line 1014 (the closing `}`):
+
+```cpp
+void Mesh::sendEnrollmentRequest() {
+  mesh_message msg = {};
+  msg.messageType = MESH_TYPE_ENROLLMENT;
+  msg.dataType = adapter_types::UNKNOWN_ADAPTER;
+  memcpy(msg.originMacAddress, deviceMacAddress, 6);
+  memset(msg.targetMacAddress, 0xFF, 6);
+  memcpy(msg.lastHopMacAddress, deviceMacAddress, 6);
+  msg.hopCount = 0;
+  memcpy(msg.enrollmentPublicKey, devicePublicKey, 32);
+
+  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
+  Logger::logln("MESH", "Enrollment request sent", LogLevel::LOG_INFO);
+}
+```
+
+- [ ] **Step 7: Replace processEnrollmentRequest in Mesh.cpp**
+
+In `main/src/Mesh/Mesh.cpp`, replace the entire function from line 1016 (`void Mesh::processEnrollmentRequest(const mesh_message& msg)`) through line 1081 (the closing `}`):
+
+```cpp
+void Mesh::processEnrollmentRequest(const mesh_message& msg) {
+  if (!isMaster) {
+    return;
+  }
+  memcpy(_pendingEnrollmentMac, msg.originMacAddress, 6);
+  memcpy(_pendingEnrollmentPubKey, msg.enrollmentPublicKey, 32);
+  _pendingEnrollmentRelay = true;
+  Logger::logln("MESH", "Enrollment request received, deferring relay to loop()",
+                LogLevel::LOG_INFO);
+}
+```
+
+- [ ] **Step 8: Update Adapter.h and Adapter.cpp signatures**
+
+In `main/src/Adapter/Adapter.h` line 40:
+```cpp
+// Before:
+                           const uint8_t data[12]); // sends data through mesh
+// After:
+                           const uint8_t data[64]); // sends data through mesh
+```
+
+In `main/src/Adapter/Adapter.cpp` line 23:
+```cpp
+// Before:
+void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[12]) {
+// After:
+void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[64]) {
+```
+
+- [ ] **Step 9: Update PIR_Adapter signatures and buffer**
+
+In `main/src/Adapter/PIR_Adapter/PIR_Adapter.h` line 20:
+```cpp
+// Before:
+  static void sendDataTrampoline(adapter_types adapterType, uint8_t data[12]);
+// After:
+  static void sendDataTrampoline(adapter_types adapterType, uint8_t data[64]);
+```
+
+In `main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp` line 48:
+```cpp
+// Before:
+void PIR_Adapter::sendDataTrampoline(adapter_types adapterType, uint8_t data[12]) {
+// After:
+void PIR_Adapter::sendDataTrampoline(adapter_types adapterType, uint8_t data[64]) {
+```
+
+In `main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp` line 77:
+```cpp
+// Before:
+    uint8_t data[12] = {1};
+// After:
+    uint8_t data[64] = {1};
+```
+
+- [ ] **Step 10: Update Serial_Adapter local buffer**
+
+In `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp` line 27:
+```cpp
+// Before:
+  uint8_t data[12] = {0};
+// After:
+  uint8_t data[64] = {0};
+```
+
+- [ ] **Step 11: Update firmware_stubs.cpp**
+
+In `tests/mocks/firmware_stubs.cpp`:
+
+Line 92 — update buildMessage stub signature:
+```cpp
+// Before:
+mesh_message Mesh::buildMessage(adapter_types, const uint8_t[12], MeshMessageType) {
+// After:
+mesh_message Mesh::buildMessage(adapter_types, const uint8_t[64], MeshMessageType) {
+```
+
+Line 121 — **remove** the `processEnrollmentRequest` stub (real implementation moves to mesh_logic_impl.cpp in Step 12):
+```cpp
+// Remove this entire line:
+void Mesh::processEnrollmentRequest(const mesh_message&) {}
+```
+
+And **remove** the `sendEnrollmentRequest` stub at line 80 (also moves to mesh_logic_impl.cpp):
+```cpp
+// Remove this entire line:
+void Mesh::sendEnrollmentRequest() {}
+```
+
+Update the comment block that follows (around line 125) to reflect the moves:
+```cpp
+// sendEnrollmentRequest and processEnrollmentRequest are implemented in mesh_logic_impl.cpp (real logic)
+// processJoinAck is implemented in mesh_logic_impl.cpp (real logic)
+```
+
+- [ ] **Step 12: Add real enrollment implementations to mesh_logic_impl.cpp**
+
+In `tests/mocks/mesh_logic_impl.cpp`, update the two function signatures that contain `data[12]` and add the real enrollment implementations at the end of the `mesh` namespace block.
+
+First, update `transmitCore` signature at line 195:
+```cpp
+// Before:
+void Mesh::transmitCore(const adapter_types type, const uint8_t data[12], MeshMessageType msgType,
+// After:
+void Mesh::transmitCore(const adapter_types type, const uint8_t data[64], MeshMessageType msgType,
+```
+
+Update `broadcastAdapterData` signature at line 264:
+```cpp
+// Before:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[12]) {
+// After:
+void Mesh::broadcastAdapterData(adapter_types type, const uint8_t data[64]) {
+```
+
+Then append the following two real implementations at the end of the `mesh` namespace block (before the closing `}  // namespace mesh`):
+
+```cpp
+void Mesh::sendEnrollmentRequest() {
+  mesh_message msg = {};
+  msg.messageType = MESH_TYPE_ENROLLMENT;
+  msg.dataType = adapter_types::UNKNOWN_ADAPTER;
+  memcpy(msg.originMacAddress, deviceMacAddress, 6);
+  memset(msg.targetMacAddress, 0xFF, 6);
+  memcpy(msg.lastHopMacAddress, deviceMacAddress, 6);
+  msg.hopCount = 0;
+  memcpy(msg.enrollmentPublicKey, devicePublicKey, 32);
+
+  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
+  Logger::logln("MESH", "Enrollment request sent", LogLevel::LOG_INFO);
+}
+
+void Mesh::processEnrollmentRequest(const mesh_message& msg) {
+  if (!isMaster) {
+    return;
+  }
+  memcpy(_pendingEnrollmentMac, msg.originMacAddress, 6);
+  memcpy(_pendingEnrollmentPubKey, msg.enrollmentPublicKey, 32);
+  _pendingEnrollmentRelay = true;
+  Logger::logln("MESH", "Enrollment request received, deferring relay to loop()",
+                LogLevel::LOG_INFO);
+}
+```
+
+- [ ] **Step 13: Write the failing enrollment tests**
+
+In `tests/unit/test_mesh_logic.cpp`, add the following test fixture and two tests after the existing `DrainRecvQueueTest` block (before the final `}` of the file):
+
+```cpp
+// ─── EnrollmentTest ──────────────────────────────────────────────────────────
+
+class EnrollmentTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    resetEspNowMockState();
+    resetEEPROMMockState();
+    espNowSentPackets.clear();
+  }
+};
+
+TEST_F(EnrollmentTest, SendsSingleEspNowMessage) {
+  Mesh mesh;
+  static constexpr uint8_t kPubKey[32] = {
+    0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
+    0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10,
+    0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,
+    0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F,0x20
+  };
+  memcpy(mesh.devicePublicKey, kPubKey, 32);
+
+  mesh.sendEnrollmentRequest();
+
+  ASSERT_EQ(espNowSentPackets.size(), 1u)
+      << "Expected exactly 1 ESP-NOW packet (was 3 with old chunking)";
+  const auto& pkt = espNowSentPackets[0];
+  ASSERT_GE(pkt.data.size(), sizeof(mesh_message));
+  const mesh_message* sent = reinterpret_cast<const mesh_message*>(pkt.data.data());
+  EXPECT_EQ(sent->messageType, MESH_TYPE_ENROLLMENT);
+  EXPECT_EQ(memcmp(sent->enrollmentPublicKey, kPubKey, 32), 0)
+      << "Full public key must be present in a single message";
+}
+
+TEST_F(EnrollmentTest, ProcessSingleMessageSetsKey) {
+  Mesh mesh;
+  mesh.isMaster = true;
+
+  mesh_message msg = {};
+  msg.messageType = MESH_TYPE_ENROLLMENT;
+  static constexpr uint8_t kMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  static constexpr uint8_t kKey[32] = {
+    0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
+    0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,0x10,
+    0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,
+    0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F,0x20
+  };
+  memcpy(msg.originMacAddress, kMac, 6);
+  memcpy(msg.enrollmentPublicKey, kKey, 32);
+
+  mesh.processEnrollmentRequest(msg);
+
+  EXPECT_TRUE(mesh._pendingEnrollmentRelay);
+  EXPECT_EQ(memcmp(mesh._pendingEnrollmentMac, kMac, 6), 0);
+  EXPECT_EQ(memcmp(mesh._pendingEnrollmentPubKey, kKey, 32), 0)
+      << "Full 32-byte key must be copied without chunk reassembly";
+}
+```
+
+- [ ] **Step 14: Update kPayload in existing test**
+
+In `tests/unit/test_mesh_logic.cpp` line 350, change:
+```cpp
+// Before:
+  static constexpr uint8_t kPayload[12] = {0x01,0x02,0x03,0,0,0,0,0,0,0,0,0};
+// After:
+  static constexpr uint8_t kPayload[64] = {0x01,0x02,0x03};
+```
+
+(Zero-initialisation fills the remaining 61 bytes with 0x00.)
+
+- [ ] **Step 15: Run tests to verify they fail before build**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+cmake -B tests/build -S tests && cmake --build tests/build && ctest --test-dir tests/build --output-on-failure
+```
+
+Expected: compilation succeeds. The two new `EnrollmentTest` tests should PASS immediately (the real implementations are already added to `mesh_logic_impl.cpp`). If they FAIL, check for compilation errors first.
+
+Expected total: **49/49 tests pass** (47 existing + 2 new enrollment tests).
+
+- [ ] **Step 16: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes \
+  add main/proto/mesh.options \
+      main/src/Mesh/serialization/mesh.pb.h \
+      main/src/Mesh/serialization/mesh.pb.c \
+      main/src/Mesh/Mesh.h \
+      main/src/Mesh/Mesh.cpp \
+      main/src/Adapter/Adapter.h \
+      main/src/Adapter/Adapter.cpp \
+      main/src/Adapter/PIR_Adapter/PIR_Adapter.h \
+      main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp \
+      main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp \
+      tests/mocks/firmware_stubs.cpp \
+      tests/mocks/mesh_logic_impl.cpp \
+      tests/unit/test_mesh_logic.cpp
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes \
+  commit -m "feat(firmware): proto v2 — data[64], PROTO_VERSION 2, single-message enrollment"
+```
+
+---
+
+### Task 2: Server — MaxDataLength 64 + proto version guard v2
+
+**Scope:** Update `MaxDataLength = 12` → `64`, bump the proto version guard from v1 to v2, add tests that cover both changes.
+
+**Files:**
+- Modify: `server/orchestrator/mesh/constants.go`
+- Modify: `server/orchestrator/mesh/server.go` (two proto-version check lines)
+- Modify: `server/orchestrator/mesh/server_test.go` (add proto version guard test)
+
+**Interfaces:**
+- Consumes: nothing from Task 1
+- Produces: `MaxDataLength = 64`; `handleMessage` drops v1 messages; `handleMessage` processes v2 messages
+
+---
+
+- [ ] **Step 1: Write the failing proto version guard test**
+
+In `server/orchestrator/mesh/server_test.go`, add the following test after `TestSetTxPowerPreset_InvalidPreset_ReturnsError`:
+
+```go
+func TestHandleMessage_ProtoVersionGuard(t *testing.T) {
+	ms := newTestMeshServer(t)
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+
+	// Build a health report payload that would register a node if processed.
+	healthData := make([]byte, 12)
+	healthData[0] = byte(OpHealthReport)
+	healthData[1] = byte(AdapterTypePIR)
+	copy(healthData[2:8], mac)
+	// bytes 8-11: uptime = 0 (zero value)
+
+	// v1 message: current guard accepts v1 — after fix it must drop v1.
+	v1msg := &MeshMessage{
+		ProtoVersion:     1,
+		MessageType:      MessageTypeAdapterData,
+		DataType:         AdapterTypeSerial,
+		Data:             healthData,
+		OriginMacAddress: mac,
+	}
+	if err := ms.handleMessage(v1msg); err != nil {
+		t.Fatalf("handleMessage(v1) returned unexpected error: %v", err)
+	}
+	if _, ok := ms.GetNodeRegistry().GetNode(mac); ok {
+		t.Error("v1 message should be dropped — node must not be registered")
+	}
+
+	// v2 message: must be accepted and processed.
+	v2msg := &MeshMessage{
+		ProtoVersion:     2,
+		MessageType:      MessageTypeAdapterData,
+		DataType:         AdapterTypeSerial,
+		Data:             healthData,
+		OriginMacAddress: mac,
+	}
+	if err := ms.handleMessage(v2msg); err != nil {
+		t.Fatalf("handleMessage(v2) returned unexpected error: %v", err)
+	}
+	if _, ok := ms.GetNodeRegistry().GetNode(mac); !ok {
+		t.Error("v2 message must be processed — node should be registered after health report")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify the test fails**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestHandleMessage_ProtoVersionGuard -v
+```
+
+Expected: `TestHandleMessage_ProtoVersionGuard` FAIL — the v1 message currently passes the guard (the guard accepts v1), so the node IS registered, failing the "must not be registered" assertion.
+
+- [ ] **Step 3: Update MaxDataLength in constants.go**
+
+In `server/orchestrator/mesh/constants.go` line 48:
+```go
+// Before:
+const MaxDataLength = 12
+// After:
+const MaxDataLength = 64
+```
+
+- [ ] **Step 4: Update proto version guard in server.go**
+
+In `server/orchestrator/mesh/server.go`, update two lines:
+
+Line 249:
+```go
+// Before:
+	if msg.ProtoVersion > 0 && msg.ProtoVersion != 1 {
+		slog.Warn("Unsupported proto version — dropping", "version", msg.ProtoVersion, "origin", fmt.Sprintf("%x", msg.OriginMacAddress))
+		return nil
+	}
+// After:
+	if msg.ProtoVersion > 0 && msg.ProtoVersion != 2 {
+		slog.Warn("Unsupported proto version — dropping", "version", msg.ProtoVersion, "origin", fmt.Sprintf("%x", msg.OriginMacAddress))
+		return nil
+	}
+```
+
+Line 255:
+```go
+// Before:
+	if msg.ProtoVersion == 1 && msg.EpochNum > 0 {
+// After:
+	if msg.ProtoVersion == 2 && msg.EpochNum > 0 {
+```
+
+- [ ] **Step 5: Run to verify the proto version test now passes**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestHandleMessage_ProtoVersionGuard -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full server test suite**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/...
+```
+
+Expected: all tests pass, 0 failures.
+
+Note: `TestSetTxPowerPreset_SendsProtoFrame` builds a `make([]byte, MaxDataLength)` payload. After the constant change to 64, the payload becomes 64 bytes. The test asserts `msg.Data[0] == OpTxPowerSet` and `msg.Data[1] == 1` — both remain valid since Go zero-initialises the remaining bytes. The test should continue to pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer \
+  add server/orchestrator/mesh/constants.go \
+      server/orchestrator/mesh/server.go \
+      server/orchestrator/mesh/server_test.go
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer \
+  commit -m "feat(server): proto v2 — MaxDataLength 64, version guard accepts v2 only"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task | Notes |
+|---|---|---|
+| `mesh_message.data[12]` → `data[64]` | Task 1 step 3–10 | struct + all signatures |
+| `static_assert(sizeof(mesh_message) == 75)` → `== 127` | Task 1 step 3 | ✓ |
+| `mesh.proto` data field `max_size:64` | Task 1 step 1–2 | regenerated from options |
+| `PROTO_VERSION = 2` | Task 1 step 3 | Mesh.h line 38 |
+| Server `MaxDataLength = 64` | Task 2 step 3 | ✓ |
+| Proto version guard drop v1 / accept v2 | Task 2 step 4 | two lines in server.go |
+| Remove 3-chunk enrollment send | Task 1 step 6 | sendEnrollmentRequest |
+| Remove chunk accumulation receive | Task 1 step 7 | processEnrollmentRequest |
+| `ParseHealthReport` bounds check unchanged | not modified | spec says "still uses first 12 bytes, unchanged" — `len(msg.Data) < 12` stays |
+
+**Placeholder scan:** No TBDs. All steps contain exact code.
+
+**Type consistency:**
+- `mesh_message.data[64]` ← used throughout; static_assert confirms 127 bytes
+- `PROTO_VERSION = 2` ← referenced in Mesh.cpp guard and set in Mesh.h
+- `MaxDataLength = 64` ← server; `SetTxPowerPreset` test uses `MaxDataLength` by name (no hardcoded 12)
+- `_pendingEnrollmentRelay / _pendingEnrollmentMac / _pendingEnrollmentPubKey` ← accessed in tests via UNIT_TEST public exposure (Mesh.h:72–79)

--- a/docs/superpowers/plans/nodes-phase4-pir-health.md
+++ b/docs/superpowers/plans/nodes-phase4-pir-health.md
@@ -1,0 +1,542 @@
+# Phase 4 — PIR Health Heartbeat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Non-master PIR nodes send a health packet every 30s through the mesh using opcode `0xB2`; the server parses and registers them via `UpdateNode`.
+
+**Architecture:** Two independent changes — firmware adds a periodic `sendNodeHealth()` call in `PIR_Adapter::loop()` following the existing `Serial_Adapter` pattern; server extends `handleSerialData` with a `0xB2` case and updates `ParseHealthReport`/`IsHealthReport` to accept both opcodes.
+
+**Tech Stack:** C++17 (ESP32 firmware, GTest), Go 1.22 (server, `go test ./...`)
+
+## Global Constraints
+
+- `OP_NODE_HEALTH = 0xB2` — exact opcode, firmware and server
+- Data layout identical to `0xB1`: `[0]=opcode [1]=adapterType(int8) [2..7]=MAC(6B) [8..11]=uptime_sec(uint32 LE)`
+- `dataType` in the mesh message header MUST be `SERIAL_ADAPTER` / `AdapterTypeSerial` — same as 0xB1
+- Health interval: `planetopia::config::HEALTH_REPORT_INTERVAL_MS` (30000 ms) — do not inline the number
+- `adapterTypeToEEPROM(adapter_types::PIR_ADAPTER)` returns `0` — this is `data[1]` on the wire
+- `hopCount` from message header, not from data payload
+- `PROTO_VERSION = 2` must remain unchanged — do not bump
+- Firmware test framework: GTest in `tests/unit/`; mock MAC via `mockDeviceMac[6]` in `tests/mocks/esp_wifi_mock.h`
+- Server module root: `motionSensorServer/server/orchestrator/` — run `go test ./mesh/...` from there
+- No `gh` CLI commands; no ClearScore email in commits (git identity: `49689582+superbrobenji@users.noreply.github.com`)
+- Repos: `Planetopia-nodes` (firmware) and `motionSensorServer` (server), both on `feat/phase4-pir-health`
+
+---
+
+### Task 1: Firmware — PIR node health heartbeat
+
+**Files:**
+- Modify: `main/src/Adapter/PIR_Adapter/PIR_Adapter.h`
+- Modify: `main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp`
+- Modify: `tests/unit/test_pir_adapter.cpp` (create if it does not exist)
+
+**Interfaces:**
+- Consumes: `planetopia::config::HEALTH_REPORT_INTERVAL_MS` from `main/project_config.h:118`
+- Consumes: `AdapterFactory::adapterTypeToEEPROM(adapter_types::PIR_ADAPTER)` → returns `static_cast<uint8_t>(0)` (value 0)
+- Consumes: `mockDeviceMac[6]` from `tests/mocks/esp_wifi_mock.h` (default `{0xAA,0xBB,0xCC,0xDD,0xEE,0xFF}`)
+- Consumes: `advanceMillis(uint32_t)` and `resetMillis()` from `tests/mocks/time_mock.h`
+- Consumes: `getLastSentData()` or equivalent from `tests/mocks/esp_now_mock.h` — check existing API
+- Produces: `PIR_Adapter::sendNodeHealth()` (private, `static void`) — callable from loop
+- Produces: `PIR_Adapter::_lastHealthMillis` (private, `uint32_t`) — persists across loop calls
+
+**Context for implementer:**
+
+`Serial_Adapter` (the pattern to follow) declares `static void sendHealthReport()` and `static uint32_t lastHealthMillis` in the header, then in `loop()`:
+
+```cpp
+if (stateChanged || millis() - lastHealthMillis >= planetopia::config::HEALTH_REPORT_INTERVAL_MS) {
+    lastHealthMillis = static_cast<uint32_t>(millis());
+    sendHealthReport();
+}
+```
+
+`sendHealthReport` body:
+```cpp
+static void readOwnMac(uint8_t out[6]) { esp_wifi_get_mac(WIFI_IF_STA, out); }
+
+void Serial_Adapter::sendHealthReport() {
+    uint8_t data[64] = {0};
+    data[0] = OP_HEALTH_REPORT;                                              // 0xB1
+    data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::SERIAL_ADAPTER);
+    uint8_t mac[6]; readOwnMac(mac); memcpy(&data[2], mac, 6);
+    uint32_t uptimeSec = millis() / 1000;
+    data[8]  = uptimeSec & 0xFF;
+    data[9]  = (uptimeSec >> 8)  & 0xFF;
+    data[10] = (uptimeSec >> 16) & 0xFF;
+    data[11] = (uptimeSec >> 24) & 0xFF;
+    planetopia::mesh::Mesh::transmit(adapter_types::SERIAL_ADAPTER, data);
+}
+```
+
+`PIR_Adapter` MUST send with `dataType = adapter_types::SERIAL_ADAPTER` (same as Serial), `data[0] = 0xB2`, and `data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::PIR_ADAPTER)` (= 0).
+
+`PIR_Adapter` uses `sendDataThroughMesh(adapter_types type, uint8_t data[64])` (instance method) NOT `Mesh::transmit` directly — keep consistent with existing motion send.
+
+The `sendNodeHealth()` helper should be `static` like `sendHealthReport()` to match the existing pattern; `_lastHealthMillis` should be non-static (instance member) since `PIR_Adapter` is not a singleton factory — check how `Serial_Adapter::lastHealthMillis` is declared and match it or use instance member.
+
+**Note on esp_now mock:** the tests in `test_mesh_logic.cpp` use `resetEspNowMock()` and `getLastSentMessage()` (or similar). Grep `tests/mocks/esp_now_mock.h` for the available helpers before writing the test assertion.
+
+- [ ] **Step 1: Check existing test file and esp_now_mock helpers**
+
+  ```bash
+  # From Planetopia-nodes root
+  ls tests/unit/
+  grep -n "getLastSent\|lastSent\|sentMessages\|capturedMessages" tests/mocks/esp_now_mock.h tests/mocks/esp_now_mock.cpp
+  ```
+
+  Expected: know the function name to retrieve the last sent ESP-NOW packet.
+
+- [ ] **Step 2: Write the failing test**
+
+  Create `tests/unit/test_pir_adapter.cpp` (or append to existing if it already exists):
+
+  ```cpp
+  #include <gtest/gtest.h>
+  #include "Adapter/PIR_Adapter/PIR_Adapter.h"
+  #include "Adapter/AdapterFactory.h"
+  #include "esp_now_mock.h"
+  #include "esp_wifi_mock.h"
+  #include "time_mock.h"
+  #include "EEPROM.h"
+
+  using namespace planetopia::adapter;
+
+  class PIRHealthTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+      EEPROM.reset();
+      resetMillis();
+      resetEspNowMock();
+    }
+  };
+
+  TEST_F(PIRHealthTest, SendsNodeHealthAfter30s) {
+    PIR_Adapter pir(2);
+
+    // Wire a no-op transmit so sendDataThroughMesh doesn't crash
+    pir.setTransmitFn([](adapter_types t, const uint8_t data[64]) {
+      // captured via esp_now_mock or a local lambda capture
+    });
+
+    // Advance past 30s threshold
+    advanceMillis(30001);
+    pir.loop();
+
+    // Retrieve last sent packet — replace getLastSentData() with actual mock helper name
+    const auto& sent = getLastSentData();  // adjust to actual mock API
+    ASSERT_GE(sent.size(), 12u);
+    EXPECT_EQ(sent[0], 0xB2);             // OP_NODE_HEALTH
+    EXPECT_EQ(sent[1], 0x00);             // PIR_ADAPTER = 0
+    // MAC bytes 2..7 should match mockDeviceMac
+    uint8_t expectedMac[6] = {0xAA,0xBB,0xCC,0xDD,0xEE,0xFF};
+    EXPECT_EQ(memcmp(&sent[2], expectedMac, 6), 0);
+    // uptime: 30001ms / 1000 = 30s
+    uint32_t uptime = sent[8] | (sent[9]<<8) | (sent[10]<<16) | (sent[11]<<24);
+    EXPECT_EQ(uptime, 30u);
+  }
+
+  TEST_F(PIRHealthTest, DoesNotSendNodeHealthBefore30s) {
+    PIR_Adapter pir(2);
+    pir.setTransmitFn([](adapter_types, const uint8_t[64]) {});
+
+    advanceMillis(29999);
+    pir.loop();
+
+    // Confirm no health packet was sent (adapt assertion to mock API)
+    EXPECT_FALSE(wasHealthPacketSent());  // adjust to actual mock API
+  }
+  ```
+
+  **Before committing this test:** adjust `getLastSentData()` and `wasHealthPacketSent()` to the actual helper names found in step 1.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+  cmake -B build -S . && cmake --build build 2>&1 | tail -20
+  ./build/tests/unit/test_pir_adapter --gtest_filter="PIRHealthTest.*" 2>&1 | tail -20
+  ```
+
+  Expected: compile error or linker error (method not yet defined) or FAIL.
+
+- [ ] **Step 4: Add `_lastHealthMillis` member and `sendNodeHealth()` declaration to header**
+
+  File: `main/src/Adapter/PIR_Adapter/PIR_Adapter.h`
+
+  Add to `private:` block after `bool _initialized;`:
+
+  ```cpp
+  uint32_t _lastHealthMillis;
+  static void sendNodeHealth();
+  ```
+
+  Add to constructor initializer list in `PIR_Adapter.cpp`:
+  Change the constructor to include `_lastHealthMillis(0)`:
+
+  ```cpp
+  PIR_Adapter::PIR_Adapter(int pin)
+      : Adapter(pin), _pir(pin), _cooldownSeconds(3), _lastTrigger(0), _timerActive(false),
+        _motionSent(false), _interruptEnabled(false), _initialized(false), _lastHealthMillis(0) {
+    _adapterType = adapter_types::PIR_ADAPTER;
+  }
+  ```
+
+- [ ] **Step 5: Implement `sendNodeHealth()` and add 30s timer to `loop()`**
+
+  File: `main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp`
+
+  Add after the existing includes:
+  ```cpp
+  #include "src/Adapter/AdapterFactory.h"
+  #include <esp_wifi.h>
+  ```
+
+  Add before `PIR_Adapter::loop()`:
+  ```cpp
+  static void readOwnMac(uint8_t out[6]) {
+    esp_wifi_get_mac(WIFI_IF_STA, out);
+  }
+
+  void PIR_Adapter::sendNodeHealth() {
+    uint8_t data[64] = {0};
+    data[0] = 0xB2;  // OP_NODE_HEALTH
+    data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::PIR_ADAPTER);
+    uint8_t mac[6];
+    readOwnMac(mac);
+    memcpy(&data[2], mac, 6);
+    uint32_t uptimeSec = millis() / 1000;
+    data[8]  = uptimeSec & 0xFF;
+    data[9]  = (uptimeSec >> 8)  & 0xFF;
+    data[10] = (uptimeSec >> 16) & 0xFF;
+    data[11] = (uptimeSec >> 24) & 0xFF;
+    if (instance)
+      instance->sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, data);
+  }
+  ```
+
+  In `PIR_Adapter::loop()`, add at the end of the function body (before the closing `}`):
+  ```cpp
+  if (now - _lastHealthMillis >= planetopia::config::HEALTH_REPORT_INTERVAL_MS) {
+    _lastHealthMillis = now;
+    sendNodeHealth();
+  }
+  ```
+
+  Full updated `loop()` for reference:
+  ```cpp
+  void PIR_Adapter::loop() {
+    if (!_initialized)
+      return;
+
+    uint32_t now = millis();
+
+    if (_pir.isMotionDetected()) {
+      _lastTrigger = now;
+      _timerActive = true;
+      _motionSent = false;
+      _pir.clearMotion();
+    }
+
+    if (_timerActive && !_motionSent) {
+      Logger::logln("PIR_Adapter", "MOTION DETECTED!", LogLevel::LOG_INFO);
+      _motionSent = true;
+      uint8_t data[64] = {1};
+      PIR_Adapter::sendDataTrampoline(_adapterType, data);
+    }
+
+    if (_timerActive && (now - _lastTrigger > (_cooldownSeconds * 1000U))) {
+      Logger::logln("PIR_Adapter", "Cooldown ended. Re-arming sensor.", LogLevel::LOG_DEBUG);
+      _timerActive = false;
+      _motionSent = false;
+
+      if (!_pir.attachInterrupt(PIR_Adapter::detectMotionTrampoline, RISING)) {
+        planetopia::err::fail(planetopia::core::ErrorTypeDigit::HARDWARE,
+                              planetopia::core::ModuleDigit::ADAPTER, 2,
+                              "PIR_Adapter: Could not re-attach interrupt (possible hardware error)");
+        return;
+      }
+      _interruptEnabled = true;
+    }
+
+    if (now - _lastHealthMillis >= planetopia::config::HEALTH_REPORT_INTERVAL_MS) {
+      _lastHealthMillis = now;
+      sendNodeHealth();
+    }
+  }
+  ```
+
+- [ ] **Step 6: Run tests and verify they pass**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+  cmake --build build && ./build/tests/unit/test_pir_adapter --gtest_filter="PIRHealthTest.*" -v
+  ```
+
+  Expected: all PIRHealthTest cases PASS.
+
+- [ ] **Step 7: Run full firmware test suite**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+  ctest --test-dir build --output-on-failure
+  ```
+
+  Expected: all tests pass; no regressions.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes add \
+    main/src/Adapter/PIR_Adapter/PIR_Adapter.h \
+    main/src/Adapter/PIR_Adapter/PIR_Adapter.cpp \
+    tests/unit/test_pir_adapter.cpp
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes commit -m "feat(pir): send node health heartbeat every 30s (0xB2)"
+  ```
+
+---
+
+### Task 2: Server — handle `OpNodeHealth` (0xB2)
+
+**Files:**
+- Modify: `server/orchestrator/mesh/constants.go`
+- Modify: `server/orchestrator/mesh/message_builder.go`
+- Modify: `server/orchestrator/mesh/server.go`
+- Modify: `server/orchestrator/mesh/mesh_test.go`
+- Modify: `server/orchestrator/mesh/server_test.go`
+
+**Interfaces:**
+- Consumes (from Task 1): the wire format `[0x B2][adapterType uint8][6B MAC][4B uptime LE]` with `DataType == AdapterTypeSerial`
+- Produces: `OpNodeHealth byte = 0xB2` in `constants.go`
+- Produces: `ParseHealthReport` accepts both `OpHealthReport(0xB1)` and `OpNodeHealth(0xB2)`
+- Produces: `IsHealthReport` returns true for both opcodes
+- Produces: `handleSerialData` case `OpNodeHealth` → calls `handleHealthReport` (reuse existing handler)
+
+**Context for implementer:**
+
+Current `ParseHealthReport` in `server/orchestrator/mesh/message_builder.go` (lines ~91-133):
+```go
+func (mb *MessageBuilder) ParseHealthReport(msg *MeshMessage) (*HealthReport, error) {
+    if msg.DataType != AdapterTypeSerial { return nil, ... }
+    if len(msg.Data) < 12 { return nil, ... }
+    if msg.Data[0] != OpHealthReport { return nil, fmt.Errorf("message is not a health report, opcode: 0x%02x", msg.Data[0]) }
+    adapterType := int32(int8(msg.Data[1]))
+    mac := make([]byte, MACAddressLength); copy(mac, msg.Data[2:8])
+    uptime := binary.LittleEndian.Uint32(msg.Data[8:12])
+    return &HealthReport{MAC: mac, AdapterType: adapterType, Uptime: uptime, HopCount: msg.HopCount, OriginMAC: msg.OriginMacAddress}, nil
+}
+
+func (mb *MessageBuilder) IsHealthReport(msg *MeshMessage) bool {
+    return msg.DataType == AdapterTypeSerial && len(msg.Data) >= 1 && msg.Data[0] == OpHealthReport
+}
+```
+
+The fix for `ParseHealthReport`: change the opcode guard from `!= OpHealthReport` to check for either opcode:
+```go
+if msg.Data[0] != OpHealthReport && msg.Data[0] != OpNodeHealth {
+    return nil, fmt.Errorf("message is not a health report, opcode: 0x%02x", msg.Data[0])
+}
+```
+
+`IsHealthReport` similarly:
+```go
+func (mb *MessageBuilder) IsHealthReport(msg *MeshMessage) bool {
+    return msg.DataType == AdapterTypeSerial &&
+        len(msg.Data) >= 1 &&
+        (msg.Data[0] == OpHealthReport || msg.Data[0] == OpNodeHealth)
+}
+```
+
+`handleSerialData` switch addition — add case alongside existing `OpHealthReport`:
+```go
+case OpNodeHealth:
+    return ms.handleHealthReport(msg)
+```
+
+`logMessageToKafka` at line ~628 calls `IsHealthReport` — after updating `IsHealthReport` it will automatically enrich 0xB2 messages too; no separate change needed there.
+
+- [ ] **Step 1: Write failing tests**
+
+  In `server/orchestrator/mesh/mesh_test.go`, add inside the existing `TestMessageBuilder` func (after the existing `ParseHealthReport` sub-test):
+
+  ```go
+  t.Run("ParseHealthReport_AcceptsNodeHealth_0xB2", func(t *testing.T) {
+      data := make([]byte, MaxDataLength)
+      data[0] = OpNodeHealth  // 0xB2
+      data[1] = byte(AdapterTypePIR)
+      mac := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+      copy(data[2:8], mac)
+      data[8] = 0x1E // 30 seconds
+      data[9] = 0x00
+      data[10] = 0x00
+      data[11] = 0x00
+
+      msg := &MeshMessage{
+          MessageType: MessageTypeAdapterData,
+          DataType:    AdapterTypeSerial,
+          Data:        data,
+          HopCount:    3,
+      }
+
+      report, err := builder.ParseHealthReport(msg)
+      if err != nil {
+          t.Fatalf("Expected no error for 0xB2, got %v", err)
+      }
+      if !bytes.Equal(report.MAC, mac) {
+          t.Errorf("MAC mismatch: got %x", report.MAC)
+      }
+      if report.AdapterType != AdapterTypePIR {
+          t.Errorf("AdapterType: got %d, want %d", report.AdapterType, AdapterTypePIR)
+      }
+      if report.Uptime != 30 {
+          t.Errorf("Uptime: got %d, want 30", report.Uptime)
+      }
+      if report.HopCount != 3 {
+          t.Errorf("HopCount: got %d, want 3", report.HopCount)
+      }
+  })
+
+  t.Run("IsHealthReport_TrueFor_0xB2", func(t *testing.T) {
+      data := make([]byte, MaxDataLength)
+      data[0] = OpNodeHealth
+      msg := &MeshMessage{DataType: AdapterTypeSerial, Data: data}
+      if !builder.IsHealthReport(msg) {
+          t.Error("IsHealthReport should return true for 0xB2")
+      }
+  })
+  ```
+
+  In `server/orchestrator/mesh/server_test.go`, add after `TestHandleMessage_ProtoVersionGuard`:
+
+  ```go
+  func TestHandleNodeHealth_RegistersNode(t *testing.T) {
+      ms := newTestMeshServer(t)
+      mac := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01}
+
+      data := make([]byte, MaxDataLength)
+      data[0] = byte(OpNodeHealth) // 0xB2
+      data[1] = byte(AdapterTypePIR)
+      copy(data[2:8], mac)
+      data[8]  = 60  // uptime = 60s
+      data[9]  = 0
+      data[10] = 0
+      data[11] = 0
+
+      msg := &MeshMessage{
+          ProtoVersion:     2,
+          MessageType:      MessageTypeAdapterData,
+          DataType:         AdapterTypeSerial,
+          Data:             data,
+          OriginMacAddress: mac,
+          HopCount:         2,
+      }
+
+      if err := ms.handleMessage(msg); err != nil {
+          t.Fatalf("handleMessage returned error: %v", err)
+      }
+
+      node, ok := ms.GetNodeRegistry().GetNode(mac)
+      if !ok {
+          t.Fatal("node not registered after 0xB2 health report")
+      }
+      if node.AdapterType != AdapterTypePIR {
+          t.Errorf("AdapterType: got %d, want %d", node.AdapterType, AdapterTypePIR)
+      }
+      if node.Uptime != 60 {
+          t.Errorf("Uptime: got %d, want 60", node.Uptime)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  go test ./mesh/... -run "TestMessageBuilder/ParseHealthReport_AcceptsNodeHealth|TestMessageBuilder/IsHealthReport_TrueFor|TestHandleNodeHealth" -v 2>&1 | tail -20
+  ```
+
+  Expected: FAIL — `OpNodeHealth` undefined / opcode guard rejects 0xB2.
+
+- [ ] **Step 3: Add `OpNodeHealth` constant**
+
+  File: `server/orchestrator/mesh/constants.go`
+
+  In the Serial Control Opcodes block, add after `OpHealthReport`:
+  ```go
+  OpNodeHealth    byte = 0xB2 // Non-serial node → server health status
+  ```
+
+- [ ] **Step 4: Update `ParseHealthReport` and `IsHealthReport`**
+
+  File: `server/orchestrator/mesh/message_builder.go`
+
+  Change:
+  ```go
+  if msg.Data[0] != OpHealthReport {
+      return nil, fmt.Errorf("message is not a health report, opcode: 0x%02x", msg.Data[0])
+  }
+  ```
+  To:
+  ```go
+  if msg.Data[0] != OpHealthReport && msg.Data[0] != OpNodeHealth {
+      return nil, fmt.Errorf("message is not a health report, opcode: 0x%02x", msg.Data[0])
+  }
+  ```
+
+  Change `IsHealthReport`:
+  ```go
+  func (mb *MessageBuilder) IsHealthReport(msg *MeshMessage) bool {
+      return msg.DataType == AdapterTypeSerial &&
+          len(msg.Data) >= 1 &&
+          (msg.Data[0] == OpHealthReport || msg.Data[0] == OpNodeHealth)
+  }
+  ```
+
+- [ ] **Step 5: Add `OpNodeHealth` case in `handleSerialData`**
+
+  File: `server/orchestrator/mesh/server.go`
+
+  Change the switch in `handleSerialData` from:
+  ```go
+  switch opcode {
+  case OpHealthReport:
+      return ms.handleHealthReport(msg)
+  default:
+  ```
+  To:
+  ```go
+  switch opcode {
+  case OpHealthReport, OpNodeHealth:
+      return ms.handleHealthReport(msg)
+  default:
+  ```
+
+- [ ] **Step 6: Run targeted tests**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  go test ./mesh/... -run "TestMessageBuilder/ParseHealthReport_AcceptsNodeHealth|TestMessageBuilder/IsHealthReport_TrueFor|TestHandleNodeHealth" -v 2>&1 | tail -20
+  ```
+
+  Expected: all three sub-tests PASS.
+
+- [ ] **Step 7: Run full server test suite**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  go test ./mesh/... -v 2>&1 | tail -30
+  ```
+
+  Expected: all tests pass; no regressions.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/constants.go \
+    server/orchestrator/mesh/message_builder.go \
+    server/orchestrator/mesh/server.go \
+    server/orchestrator/mesh/mesh_test.go \
+    server/orchestrator/mesh/server_test.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit -m "feat(server): handle OP_NODE_HEALTH (0xB2) from PIR nodes"
+  ```

--- a/docs/superpowers/plans/nodes-phase5-node-identity.md
+++ b/docs/superpowers/plans/nodes-phase5-node-identity.md
@@ -1,0 +1,867 @@
+# Phase 5 — Node Identity (Logical ID + 7-seg Display) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Server assigns a persistent logical node ID (1–255) at enrollment. The ID is stored in EEPROM and shown on the 7-seg display. Display reflects enrollment state.
+
+**Architecture:** Three sequential tasks — (1) firmware EEPROM field + opcode handler for ID assignment, (2) firmware 7-seg display state machine in main.ino, (3) server NodeInfo extension + approval API + OP_NODE_ID_SET frame send. Tasks 1 and 2 are firmware-only; Task 3 is server-only and can be written independently.
+
+**Tech Stack:** C++17 (ESP32 firmware, GTest), Go 1.22 (server, `go test ./...`)
+
+## Global Constraints
+
+- `OP_NODE_ID_SET = 0xC0` — exact opcode value, firmware and server
+- **Wire format deviation from spec:** spec states `[0xC0][1B nodeId]`; actual format is `[0xC0][6B targetMAC][1B nodeId]` (following `OP_CONFIG_SET` pattern — targetMAC allows unicast targeting; use `0xFF×6` for broadcast)
+- `NODE_ID` EEPROM address: `496` (1 byte); EEPROM comment update: "Total used: 497 bytes"
+- Node IDs 1–255; `0` means "not yet assigned"
+- `PROTO_VERSION = 2` unchanged
+- Server auto-assigns next free ID when `nodeId == 0` in approval request
+- `UpdateNode()` must NOT overwrite NodeID/Name/Zone once assigned (sticky fields)
+- Unenrolled display: `setSegments({0x40,0x40,0x40,0x40})` flashing 500ms
+- Enrolled no-ID display: `show(0, false)` → `   0`
+- Enrolled sensor: `show(nodeId, false)` → right-aligned e.g. `  07`
+- Master: `showWithDP(nodeId, false)` → same number + decimal point on last digit
+- No `gh` CLI; git identity `49689582+superbrobenji@users.noreply.github.com`
+- Firmware repo: `Planetopia-nodes`, branch `feat/phase5-node-identity`
+- Server repo: `motionSensorServer`, branch `feat/phase5-node-identity`
+- Server module root: `motionSensorServer/server/orchestrator/`
+
+---
+
+### Task 1: Firmware — NODE_ID EEPROM + OP_NODE_ID_SET opcode handler
+
+**Files:**
+- Modify: `main/src/persistence/EEPROM_Manager.h` — add `NODE_ID = 496` address, update layout comment, declare `loadNodeId()`/`saveNodeId()`
+- Modify: `main/src/persistence/EEPROM_Manager.cpp` — implement `loadNodeId()`/`saveNodeId()`
+- Modify: `main/src/Adapter/Adapter.cpp` — handle `OP_NODE_ID_SET` in `onMeshData` base class
+- Modify: `main/src/Adapter/Serial_Adapter/Serial_Adapter.h` — add `OP_NODE_ID_SET = 0xC0` constant
+- Modify: `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp` — handle `OP_NODE_ID_SET` in `handleCompleteFrame` opcode block for master
+- Modify: `tests/unit/test_eeprom_manager.cpp` — add NODE_ID tests
+- Modify: `tests/unit/test_mesh_logic.cpp` OR create `tests/unit/test_pir_adapter.cpp` addition — OP_NODE_ID_SET opcode dispatch
+
+**Interfaces:**
+- Produces: `EEPROM_Manager::loadNodeId() → uint8_t`
+- Produces: `EEPROM_Manager::saveNodeId(uint8_t nodeId)`
+- Produces: `Serial_Adapter::OP_NODE_ID_SET = 0xC0`
+
+**Context for implementer:**
+
+The EEPROM layout currently ends at 495 (TX_POWER_PRESET). Address 496 is free. The layout comment in `EEPROM_Manager.h` says "Total used: 496 bytes — fits in 512"; after this change it becomes 497 bytes.
+
+`saveNodeId`/`loadNodeId` follow the same pattern as `saveTxPowerPreset`/`loadTxPowerPreset`:
+```cpp
+void EEPROM_Manager::saveNodeId(uint8_t nodeId) {
+  if (!ensureInitialized()) return;
+  EEPROM.write(EEPROM_ADDRESSES::NODE_ID, nodeId);
+  markDirty();
+  logOperation("saveNodeId");
+}
+
+uint8_t EEPROM_Manager::loadNodeId() {
+  if (!ensureInitialized()) return 0;
+  return EEPROM.read(EEPROM_ADDRESSES::NODE_ID);
+}
+```
+A freshly erased EEPROM reads `0xFF` from unwritten bytes. Treat `0xFF` as "unset" → return `0`. Adjust:
+```cpp
+uint8_t raw = EEPROM.read(EEPROM_ADDRESSES::NODE_ID);
+return (raw == 0xFF) ? 0 : raw;
+```
+
+**OP_NODE_ID_SET in `Adapter::onMeshData`** (follows `OP_CONFIG_SET` pattern in `Adapter.cpp`):
+```cpp
+static constexpr uint8_t OP_NODE_ID_SET = 0xC0;  // [C0][6B targetMAC][1B nodeId]
+// ... inside the SERIAL_ADAPTER block, alongside OP_CONFIG_SET:
+if (op == OP_NODE_ID_SET && len(message.data) >= 8) {
+    uint8_t ownMac[6];
+    esp_wifi_get_mac(WIFI_IF_STA, ownMac);
+    bool allFF = true;
+    for (int i = 0; i < 6; ++i) {
+        if (message.data[1 + i] != 0xFF) { allFF = false; break; }
+    }
+    bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
+    if (isTarget) {
+        uint8_t nodeId = message.data[7];
+        planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+        Logger::logln("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
+    }
+}
+```
+Note: `message.data` is `uint8_t[64]`; no bounds check needed beyond opcode guard since `len >= 8` is guaranteed by `data[64]` size.
+
+**OP_NODE_ID_SET in `Serial_Adapter::handleCompleteFrame`** (for master node, mirrors OP_CONFIG_SET block at line ~447):
+```cpp
+} else if (op == OP_NODE_ID_SET) {
+    if (msg.data[0] == OP_NODE_ID_SET) {  // redundant but explicit
+        uint8_t myMac[6];
+        readOwnMac(myMac);
+        bool allFF = true;
+        for (int i = 0; i < 6; ++i)
+            if (msg.data[1 + i] != 0xFF) { allFF = false; break; }
+        bool isTarget = allFF || (memcmp(&msg.data[1], myMac, 6) == 0);
+        if (isTarget) {
+            uint8_t nodeId = msg.data[7];
+            planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+            Logger::logln("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
+        }
+    }
+}
+```
+
+**Testing `OP_NODE_ID_SET`:** The opcode flows through mesh (adapter data), which is tested in `test_mesh_logic.cpp`. The EEPROM save is tested in `test_eeprom_manager.cpp`. For the opcode dispatch, write a test in `test_pir_adapter.cpp` that creates a PIR_Adapter, injects a mesh message with `dataType=SERIAL_ADAPTER, data[0]=0xC0, data[1..6]=mockDeviceMac, data[7]=42`, calls `adapter->onMeshData(message)`, then asserts `EEPROM_Manager::getInstance().loadNodeId() == 42`.
+
+- [ ] **Step 1: Add `NODE_ID` address and layout comment update to `EEPROM_Manager.h`**
+
+  Add to the address namespace block after `TX_POWER_PRESET`:
+  ```cpp
+  constexpr uint16_t NODE_ID = 496; // 1 byte: logical node ID assigned by server (0 = unset)
+  ```
+
+  Update the layout comment block:
+  ```
+  // 495   TX_POWER_PRESET  (1 byte) — TxPowerPreset enum value (0=SHORT_RANGE 1=INDOOR 2=OUTDOOR)
+  // 496   NODE_ID          (1 byte) — logical node ID assigned by server (0 = unset, 0xFF = erased)
+  // Total used: 497 bytes — fits in 512
+  ```
+
+  Add declarations to class body after `saveTxPowerPreset`:
+  ```cpp
+  uint8_t loadNodeId();
+  void saveNodeId(uint8_t nodeId);
+  ```
+
+- [ ] **Step 2: Write the failing EEPROM tests**
+
+  In `tests/unit/test_eeprom_manager.cpp`, add:
+  ```cpp
+  TEST(EEPROM_Manager, NodeId_DefaultIsZero) {
+    EEPROM.reset();
+    auto& em = planetopia::utils::EEPROM_Manager::getInstance();
+    em.init();
+    EXPECT_EQ(em.loadNodeId(), 0u);
+  }
+
+  TEST(EEPROM_Manager, NodeId_SaveAndLoad) {
+    EEPROM.reset();
+    auto& em = planetopia::utils::EEPROM_Manager::getInstance();
+    em.init();
+    em.saveNodeId(42);
+    em.forceFlush();
+    EXPECT_EQ(em.loadNodeId(), 42u);
+  }
+
+  TEST(EEPROM_Manager, NodeId_SaveZeroRoundtrips) {
+    EEPROM.reset();
+    auto& em = planetopia::utils::EEPROM_Manager::getInstance();
+    em.init();
+    em.saveNodeId(7);
+    em.saveNodeId(0);
+    em.forceFlush();
+    EXPECT_EQ(em.loadNodeId(), 0u);
+  }
+  ```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+  cmake -B build -S tests && cmake --build build 2>&1 | grep -E "error|FAILED" | head -10
+  ctest --test-dir build --output-on-failure -R EEPROM 2>&1 | tail -10
+  ```
+
+  Expected: compile error or FAIL (loadNodeId not defined).
+
+- [ ] **Step 4: Implement `loadNodeId` and `saveNodeId` in `EEPROM_Manager.cpp`**
+
+  Add after the `saveTxPowerPreset`/`loadTxPowerPreset` block:
+  ```cpp
+  void EEPROM_Manager::saveNodeId(uint8_t nodeId) {
+    if (!ensureInitialized()) return;
+    EEPROM.write(EEPROM_ADDRESSES::NODE_ID, nodeId);
+    markDirty();
+    logOperation("saveNodeId");
+  }
+
+  uint8_t EEPROM_Manager::loadNodeId() {
+    if (!ensureInitialized()) return 0;
+    uint8_t raw = EEPROM.read(EEPROM_ADDRESSES::NODE_ID);
+    return (raw == 0xFF) ? 0 : raw;
+  }
+  ```
+
+- [ ] **Step 5: Run EEPROM tests to verify they pass**
+
+  ```bash
+  cmake --build /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build
+  ctest --test-dir /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build --output-on-failure -R EEPROM 2>&1 | tail -10
+  ```
+
+  Expected: NodeId_DefaultIsZero, NodeId_SaveAndLoad, NodeId_SaveZeroRoundtrips all PASS.
+
+- [ ] **Step 6: Add `OP_NODE_ID_SET` to `Serial_Adapter.h`**
+
+  In the serial control opcodes block, after `OP_HEALTH_REPORT`:
+  ```cpp
+  static constexpr uint8_t OP_NODE_ID_SET = 0xC0; // [C0][6B targetMAC][1B nodeId]
+  ```
+
+- [ ] **Step 7: Write failing OP_NODE_ID_SET dispatch test**
+
+  In `tests/unit/test_pir_adapter.cpp` (or a new `test_adapter_base.cpp`), add a test class. The simplest approach reuses `PIRHealthTest` fixture or a new GTest fixture:
+
+  ```cpp
+  TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
+    PIR_Adapter* pir = new PIR_Adapter(2);
+    pir->setTransmitFn([](adapter_types, const uint8_t[64]) {});
+
+    // Set mockDeviceMac to known value
+    mockDeviceMac[0] = 0x11; mockDeviceMac[1] = 0x22; mockDeviceMac[2] = 0x33;
+    mockDeviceMac[3] = 0x44; mockDeviceMac[4] = 0x55; mockDeviceMac[5] = 0x66;
+
+    planetopia::mesh::mesh_message msg{};
+    msg.dataType = adapter_types::SERIAL_ADAPTER;
+    msg.data[0] = 0xC0; // OP_NODE_ID_SET
+    // target MAC = mockDeviceMac
+    memcpy(&msg.data[1], mockDeviceMac, 6);
+    msg.data[7] = 99; // nodeId
+
+    pir->onMeshData(msg);
+
+    EXPECT_EQ(planetopia::utils::EEPROM_Manager::getInstance().loadNodeId(), 99u);
+    delete pir;
+  }
+
+  TEST_F(PIRHealthTest, OpNodeIdSet_IgnoresMessage_WhenTargetMismatch) {
+    EEPROM.reset();
+    PIR_Adapter* pir = new PIR_Adapter(2);
+    pir->setTransmitFn([](adapter_types, const uint8_t[64]) {});
+
+    mockDeviceMac[0] = 0xAA; mockDeviceMac[1] = 0xBB; mockDeviceMac[2] = 0xCC;
+    mockDeviceMac[3] = 0xDD; mockDeviceMac[4] = 0xEE; mockDeviceMac[5] = 0xFF;
+
+    planetopia::mesh::mesh_message msg{};
+    msg.dataType = adapter_types::SERIAL_ADAPTER;
+    msg.data[0] = 0xC0;
+    uint8_t differentMac[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    memcpy(&msg.data[1], differentMac, 6);
+    msg.data[7] = 55;
+
+    pir->onMeshData(msg);
+
+    EXPECT_EQ(planetopia::utils::EEPROM_Manager::getInstance().loadNodeId(), 0u);
+    delete pir;
+  }
+  ```
+
+- [ ] **Step 8: Run to verify failure**
+
+  ```bash
+  cmake --build /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build
+  ctest --test-dir /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build --output-on-failure -R PIRHealth 2>&1 | tail -10
+  ```
+
+  Expected: OpNodeIdSet tests FAIL (opcode not handled).
+
+- [ ] **Step 9: Implement OP_NODE_ID_SET in `Adapter::onMeshData`**
+
+  File: `main/src/Adapter/Adapter.cpp`
+
+  Inside the `if (message.dataType == adapter_types::SERIAL_ADAPTER)` block, add after the `OP_CONFIG_SET` block and before the `if (_adapterType != adapter_types::SERIAL_ADAPTER) return;` guard:
+
+  ```cpp
+  static constexpr uint8_t OP_NODE_ID_SET = 0xC0;
+  if (op == OP_NODE_ID_SET) {
+    uint8_t ownMac[6];
+    esp_wifi_get_mac(WIFI_IF_STA, ownMac);
+    bool allFF = true;
+    for (int i = 0; i < 6; ++i) {
+      if (message.data[1 + i] != 0xFF) { allFF = false; break; }
+    }
+    bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
+    if (isTarget) {
+      uint8_t nodeId = message.data[7];
+      planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+      Logger::logln("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
+    }
+  }
+  ```
+
+- [ ] **Step 10: Implement OP_NODE_ID_SET in `Serial_Adapter::handleCompleteFrame`**
+
+  File: `main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp`
+
+  In the control opcode block (after `OP_CONFIG_SET` at line ~447), add:
+  ```cpp
+  } else if (op == OP_NODE_ID_SET) {
+    uint8_t myMac[6];
+    readOwnMac(myMac);
+    bool allFF = true;
+    for (int i = 0; i < 6; ++i)
+      if (msg.data[1 + i] != 0xFF) { allFF = false; break; }
+    bool isTarget = allFF || (memcmp(&msg.data[1], myMac, 6) == 0);
+    if (isTarget) {
+      uint8_t nodeId = msg.data[7];
+      planetopia::utils::EEPROM_Manager::getInstance().saveNodeId(nodeId);
+      Logger::logln("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
+    }
+  }
+  ```
+
+- [ ] **Step 11: Run all tests**
+
+  ```bash
+  cmake --build /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build
+  ctest --test-dir /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build --output-on-failure 2>&1 | tail -10
+  ```
+
+  Expected: all tests pass (including new EEPROM + PIRHealth opcode tests).
+
+- [ ] **Step 12: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes add \
+    main/src/persistence/EEPROM_Manager.h \
+    main/src/persistence/EEPROM_Manager.cpp \
+    main/src/Adapter/Adapter.cpp \
+    main/src/Adapter/Serial_Adapter/Serial_Adapter.h \
+    main/src/Adapter/Serial_Adapter/Serial_Adapter.cpp \
+    tests/unit/test_eeprom_manager.cpp \
+    tests/unit/test_pir_adapter.cpp
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes commit \
+    -m "feat(firmware): NODE_ID EEPROM field + OP_NODE_ID_SET (0xC0) handler"
+  ```
+
+---
+
+### Task 2: Firmware — SevenSegDisplay DP + main.ino display states
+
+**Files:**
+- Modify: `main/src/hardware/output/SevenSegDisplay.h` — add `showWithDP(int value, bool leadingZeros = false)` declaration
+- Modify: `main/src/hardware/output/SevenSegDisplay.cpp` — implement `showWithDP`
+- Modify: `main/main.ino` — add display state machine in `loop()`
+
+**Interfaces:**
+- Consumes (from Task 1): `EEPROM_Manager::loadNodeId() → uint8_t`
+- Consumes: `mesh.isEnrolled() → bool`, `mesh.getIsMaster() → bool`
+- Produces: `SevenSegDisplay::showWithDP(int value, bool leadingZeros)`
+
+**Context for implementer:**
+
+`SevenSegDisplay::show(int value, bool leadingZeros)` computes 4 segment bytes and calls `setSegments(segs)`. `showWithDP` is identical but ORs `0x80` (DP bit) into `segs[3]` before `setSegments`. Implement by copying the logic from `show` and adding the OR:
+
+```cpp
+void SevenSegDisplay::showWithDP(int value, bool leadingZeros) {
+  bool negative = value < 0;
+  int v = negative ? -value : value;
+  if (v > 9999) v = 9999;
+
+  int digits[4];
+  for (int i = 3; i >= 0; --i) { digits[i] = v % 10; v /= 10; }
+
+  if (negative) {
+    for (int i = 0; i < 4; ++i) {
+      if (digits[i] != 0 || i == 3) { digits[i] = -1; break; }
+    }
+  }
+
+  uint8_t segs[4];
+  for (int i = 0; i < 4; ++i) {
+    if (!leadingZeros && digits[i] == 0 && i < 3 && !negative)
+      segs[i] = 0x00;
+    else
+      segs[i] = encodeDigit(digits[i]);
+  }
+  segs[3] |= 0x80; // decimal point on last digit
+  setSegments(segs);
+}
+```
+
+**Display state machine in `main.ino` `loop()`:**
+
+Add at the START of `loop()` (before any adapter->loop() calls), guarded by `ENABLE_SEVSEG_DISPLAY`:
+
+```cpp
+if (planetopia::config::ENABLE_SEVSEG_DISPLAY) {
+  static uint32_t lastDisplayToggleMs = 0;
+  static bool dashVisible = false;
+
+  bool enrolled = mesh.isEnrolled() || mesh.getIsMaster(); // master is always "enrolled"
+  uint8_t nodeId = planetopia::utils::EEPROM_Manager::getInstance().loadNodeId();
+
+  if (!enrolled) {
+    // Unenrolled: flash "----" at 500ms
+    if (millis() - lastDisplayToggleMs >= 500) {
+      lastDisplayToggleMs = static_cast<uint32_t>(millis());
+      dashVisible = !dashVisible;
+      if (dashVisible) {
+        static const uint8_t dashes[4] = {0x40, 0x40, 0x40, 0x40};
+        sevenSeg.setSegments(dashes);
+      } else {
+        sevenSeg.clear();
+      }
+    }
+  } else if (nodeId == 0) {
+    // Enrolled, no ID: "   0"
+    sevenSeg.show(0, false);
+  } else if (mesh.getIsMaster()) {
+    // Master with ID: right-aligned nodeId + DP on last digit
+    sevenSeg.showWithDP(static_cast<int>(nodeId), false);
+  } else {
+    // Sensor node with ID: right-aligned nodeId
+    sevenSeg.show(static_cast<int>(nodeId), false);
+  }
+}
+```
+
+Place this block AFTER the existing `mesh.loop()` call and BEFORE `adapter->loop()`. The display update is cheap and synchronous; 1ms delay at end of loop() is unaffected.
+
+Note on `mesh.isEnrolled()`: this returns false for the master node (master is never "enrolled" in the client sense). Master is always "active" so treat `getIsMaster()` as "enrolled" for display purposes.
+
+**Tests:** `SevenSegDisplay::showWithDP` calls `setSegments` which requires GPIO/hardware. No unit tests exist for SevenSegDisplay (hardware-only class). Verify by:
+1. Building the firmware (`cmake --build build`) confirms no compile errors
+2. Manual observation on device — document in task report
+
+- [ ] **Step 1: Add `showWithDP` declaration to `SevenSegDisplay.h`**
+
+  After the existing `show` declaration:
+  ```cpp
+  // Like show() but with a decimal point on the rightmost digit.
+  void showWithDP(int value, bool leadingZeros = false);
+  ```
+
+- [ ] **Step 2: Implement `showWithDP` in `SevenSegDisplay.cpp`**
+
+  Add after the existing `show` implementation (line ~179):
+  ```cpp
+  void SevenSegDisplay::showWithDP(int value, bool leadingZeros) {
+    bool negative = value < 0;
+    int v = negative ? -value : value;
+    if (v > 9999) v = 9999;
+
+    int digits[4];
+    for (int i = 3; i >= 0; --i) {
+      digits[i] = v % 10;
+      v /= 10;
+    }
+
+    if (negative) {
+      for (int i = 0; i < 4; ++i) {
+        if (digits[i] != 0 || i == 3) {
+          digits[i] = -1;
+          break;
+        }
+      }
+    }
+
+    uint8_t segs[4];
+    for (int i = 0; i < 4; ++i) {
+      if (!leadingZeros && digits[i] == 0 && i < 3 && !negative)
+        segs[i] = 0x00;
+      else
+        segs[i] = encodeDigit(digits[i]);
+    }
+    segs[3] |= 0x80; // DP bit on last digit
+    setSegments(segs);
+  }
+  ```
+
+- [ ] **Step 3: Add display state machine to `main.ino`**
+
+  In `loop()`, add the display block shown in Context above. Place it after `mesh.loop()` and before `adapter->loop()`.
+
+- [ ] **Step 4: Build to verify no compile errors**
+
+  ```bash
+  cmake --build /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build 2>&1 | grep -E "error:|warning:" | head -20
+  ```
+
+  Expected: clean build, no errors or new warnings.
+
+- [ ] **Step 5: Run full test suite**
+
+  ```bash
+  ctest --test-dir /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/build --output-on-failure 2>&1 | tail -10
+  ```
+
+  Expected: all tests pass (display code is not exercised by unit tests but compile correctness is verified).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes add \
+    main/src/hardware/output/SevenSegDisplay.h \
+    main/src/hardware/output/SevenSegDisplay.cpp \
+    main/main.ino
+  git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes commit \
+    -m "feat(display): 7-seg display states + showWithDP for master node"
+  ```
+
+---
+
+### Task 3: Server — NodeInfo identity fields + ApproveEnrollment + OP_NODE_ID_SET send
+
+**Files:**
+- Modify: `server/orchestrator/mesh/constants.go` — add `OpNodeIdSet byte = 0xC0`
+- Modify: `server/orchestrator/mesh/node_registry.go` — add `NodeID`, `Name`, `Zone` to `NodeInfo` and `persistedNode`; add `AssignNode`, `NextFreeNodeID` methods; update `UpdateNode` (don't overwrite sticky fields); update `Persist`/`Load`
+- Modify: `server/orchestrator/mesh/server.go` — change `ApproveEnrollment` to accept `ApprovalParams`; after JOIN_ACK send `OP_NODE_ID_SET` frame; call `AssignNode`
+- Modify: `server/orchestrator/mesh/api.go` — add `ApprovalRequest` struct; update `approveEnrollment` to parse body
+- Modify: `server/orchestrator/mesh/server_enrollment_test.go` — update existing `ApproveEnrollment` callers for new signature; add new tests
+- Modify: `server/orchestrator/mesh/mesh_test.go` — add `NodeRegistry` sub-tests for NodeID/Name/Zone and `NextFreeNodeID`
+
+**Interfaces:**
+- Produces: `NodeInfo.NodeID uint8`, `NodeInfo.Name string`, `NodeInfo.Zone string`
+- Produces: `NodeRegistry.AssignNode(mac []byte, nodeId uint8, name, zone string)`
+- Produces: `NodeRegistry.NextFreeNodeID() uint8` — returns lowest unused 1-255; returns 0 if all taken
+- Produces: `MeshServer.ApproveEnrollment(macStr string, params ApprovalParams) error`
+- Produces: `ApprovalParams{NodeID uint8, Name string, Zone string}` — NodeID 0 means auto-assign
+
+**Context for implementer:**
+
+**`NodeInfo` and `persistedNode` additions:**
+```go
+type NodeInfo struct {
+    MAC         []byte    `json:"mac"`
+    MACString   string    `json:"macString"`
+    AdapterType int32     `json:"adapterType"`
+    Uptime      uint32    `json:"uptime"`
+    LastSeen    time.Time `json:"lastSeen"`
+    HopCount    uint32    `json:"hopCount"`
+    NodeID      uint8     `json:"nodeId,omitempty"`
+    Name        string    `json:"name,omitempty"`
+    Zone        string    `json:"zone,omitempty"`
+}
+
+type persistedNode struct {
+    MAC         string    `json:"mac"`
+    AdapterType int32     `json:"adapterType"`
+    Uptime      uint32    `json:"uptime"`
+    LastSeen    time.Time `json:"lastSeen"`
+    HopCount    uint32    `json:"hopCount"`
+    NodeID      uint8     `json:"nodeId,omitempty"`
+    Name        string    `json:"name,omitempty"`
+    Zone        string    `json:"zone,omitempty"`
+}
+```
+
+**`UpdateNode` — sticky fields:** After this change, `UpdateNode` must NOT overwrite `NodeID`/`Name`/`Zone` for existing nodes:
+```go
+// existing fields update:
+node.AdapterType = adapterType
+node.Uptime = uptime
+node.LastSeen = time.Now()
+node.HopCount = hopCount
+// NodeID, Name, Zone are sticky — only AssignNode may set them
+```
+
+**`AssignNode`:**
+```go
+func (nr *NodeRegistry) AssignNode(mac []byte, nodeId uint8, name, zone string) {
+    nr.mu.Lock()
+    defer nr.mu.Unlock()
+    macStr := macToString(mac)
+    node, exists := nr.nodes[macStr]
+    if !exists {
+        node = &NodeInfo{
+            MAC:       make([]byte, len(mac)),
+            MACString: macStr,
+        }
+        copy(node.MAC, mac)
+        nr.nodes[macStr] = node
+    }
+    node.NodeID = nodeId
+    node.Name = name
+    node.Zone = zone
+}
+```
+
+**`NextFreeNodeID`:**
+```go
+func (nr *NodeRegistry) NextFreeNodeID() uint8 {
+    nr.mu.RLock()
+    defer nr.mu.RUnlock()
+    used := make(map[uint8]bool)
+    for _, n := range nr.nodes {
+        if n.NodeID > 0 {
+            used[n.NodeID] = true
+        }
+    }
+    for id := uint8(1); id <= 255; id++ {
+        if !used[id] {
+            return id
+        }
+    }
+    return 0 // all 255 IDs in use
+}
+```
+
+**`ApprovalParams` and updated `ApproveEnrollment`:**
+```go
+type ApprovalParams struct {
+    NodeID uint8
+    Name   string
+    Zone   string
+}
+
+func (ms *MeshServer) ApproveEnrollment(macStr string, params ApprovalParams) error {
+    node, err := ms.authRegistry.Approve(macStr)
+    if err != nil {
+        return err
+    }
+
+    // Auto-assign nodeId if not provided
+    nodeId := params.NodeID
+    if nodeId == 0 {
+        nodeId = ms.nodeRegistry.NextFreeNodeID()
+        if nodeId == 0 {
+            slog.Warn("All node IDs in use; node will have ID 0", "mac", macStr)
+        }
+    }
+
+    // Assign in node registry (creates entry if not yet seen)
+    ms.nodeRegistry.AssignNode(node.MAC[:], nodeId, params.Name, params.Zone)
+
+    if ms.serialComm != nil {
+        // Send JOIN_ACK
+        ackMsg := &MeshMessage{
+            MessageType:      MessageTypeJoinAck,
+            TargetMacAddress: node.MAC[:],
+            PublicKey:        node.PublicKey[:],
+        }
+        if err := ms.serialComm.WriteFrame(ackMsg); err != nil {
+            slog.Warn("Failed to send JOIN_ACK", "mac", macStr, "error", err)
+        }
+
+        // Send OP_NODE_ID_SET immediately after JOIN_ACK
+        if nodeId > 0 {
+            payload := make([]byte, MaxDataLength)
+            payload[0] = OpNodeIdSet     // 0xC0
+            copy(payload[1:7], node.MAC[:]) // target MAC
+            payload[7] = nodeId
+            idMsg := &MeshMessage{
+                MessageType: MessageTypeSerialCmdBroadcast,
+                DataType:    AdapterTypeSerial,
+                Data:        payload,
+            }
+            if err := ms.serialComm.WriteFrame(idMsg); err != nil {
+                slog.Warn("Failed to send OP_NODE_ID_SET", "mac", macStr, "nodeId", nodeId, "error", err)
+            }
+        }
+    }
+
+    slog.Info("Enrollment approved", "mac", macStr, "nodeId", nodeId, "name", params.Name)
+    if ms.authPath != "" {
+        return ms.authRegistry.Persist(ms.authPath)
+    }
+    return nil
+}
+```
+
+**`approveEnrollment` API handler** — parse body, pass params:
+```go
+type ApprovalRequest struct {
+    NodeID uint8  `json:"nodeId"`
+    Name   string `json:"name"`
+    Zone   string `json:"zone"`
+}
+
+func (api *APIServer) approveEnrollment(w http.ResponseWriter, r *http.Request) {
+    mac := mux.Vars(r)["mac"]
+    var req ApprovalRequest
+    if r.Body != nil {
+        _ = json.NewDecoder(r.Body).Decode(&req) // body is optional; ignore decode errors
+    }
+    params := mesh.ApprovalParams{NodeID: req.NodeID, Name: req.Name, Zone: req.Zone}
+    if err := api.meshServer.ApproveEnrollment(mac, params); err != nil {
+        api.writeError(w, http.StatusBadRequest, err.Error())
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{
+        Success: true,
+        Message: fmt.Sprintf("Enrollment approved for %s", mac),
+    })
+}
+```
+
+**Existing test updates:** `TestApproveEnrollment_SendsJoinAckWithPubKey`, `TestApproveEnrollment_UnknownMAC_ReturnsError`, and `TestApproveEnrollment_NilSerialComm_Succeeds` all call `ms.ApproveEnrollment(macStr)`. Update to `ms.ApproveEnrollment(macStr, ApprovalParams{})` (zero params = auto-assign).
+
+`TestApproveEnrollment_SendsJoinAckWithPubKey` also calls `decodeWrittenFrame` — after the change, TWO frames are written (JOIN_ACK + OP_NODE_ID_SET). The test currently reads one frame. Update to read both:
+```go
+// First frame: JOIN_ACK
+joinAck := decodeWrittenFrame(t, mockPort)
+// ... existing assertions on joinAck ...
+
+// Second frame: OP_NODE_ID_SET
+nodeIdMsg := decodeWrittenFrame(t, mockPort)
+if nodeIdMsg.Data[0] != byte(OpNodeIdSet) {
+    t.Errorf("second frame opcode = 0x%02x, want 0x%02x", nodeIdMsg.Data[0], OpNodeIdSet)
+}
+```
+
+Also update `Load` to populate `NodeID`/`Name`/`Zone` from persisted entries — add to the `Load` loop:
+```go
+nr.nodes[e.MAC] = &NodeInfo{
+    MAC:         mac,
+    MACString:   e.MAC,
+    AdapterType: e.AdapterType,
+    Uptime:      e.Uptime,
+    LastSeen:    e.LastSeen,
+    HopCount:    e.HopCount,
+    NodeID:      e.NodeID,
+    Name:        e.Name,
+    Zone:        e.Zone,
+}
+```
+
+- [ ] **Step 1: Write failing tests**
+
+  In `server/orchestrator/mesh/mesh_test.go`, add inside `TestNodeRegistry`:
+  ```go
+  t.Run("AssignNode_SetsIdentityFields", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+      registry.AssignNode(mac, 7, "entrance-left", "lobby")
+      node, ok := registry.GetNode(mac)
+      if !ok { t.Fatal("node not found after AssignNode") }
+      if node.NodeID != 7 { t.Errorf("NodeID: got %d, want 7", node.NodeID) }
+      if node.Name != "entrance-left" { t.Errorf("Name: got %q", node.Name) }
+      if node.Zone != "lobby" { t.Errorf("Zone: got %q", node.Zone) }
+  })
+
+  t.Run("UpdateNode_DoesNotOverwriteAssignedFields", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      mac := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+      registry.AssignNode(mac, 3, "stage-left", "main")
+      registry.UpdateNode(mac, AdapterTypePIR, 1000, 2)
+      node, ok := registry.GetNode(mac)
+      if !ok { t.Fatal("node not found") }
+      if node.NodeID != 3 { t.Errorf("NodeID overwritten: got %d, want 3", node.NodeID) }
+      if node.Name != "stage-left" { t.Errorf("Name overwritten: got %q", node.Name) }
+  })
+
+  t.Run("NextFreeNodeID_ReturnsOne_WhenEmpty", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      if id := registry.NextFreeNodeID(); id != 1 {
+          t.Errorf("NextFreeNodeID: got %d, want 1", id)
+      }
+  })
+
+  t.Run("NextFreeNodeID_SkipsUsedIds", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      registry.AssignNode([]byte{0x01, 0, 0, 0, 0, 0}, 1, "", "")
+      registry.AssignNode([]byte{0x02, 0, 0, 0, 0, 0}, 2, "", "")
+      if id := registry.NextFreeNodeID(); id != 3 {
+          t.Errorf("NextFreeNodeID: got %d, want 3", id)
+      }
+  })
+  ```
+
+  In `server/orchestrator/mesh/server_enrollment_test.go`, add:
+  ```go
+  func TestApproveEnrollment_SendsNodeIdSet_AfterJoinAck(t *testing.T) {
+      ms := newTestMeshServer(t)
+      mockPort := NewMockSerialPort()
+      ms.serialComm = NewSerialComm(mockPort)
+
+      macStr, _ := enrollTestNode(t, ms)
+
+      params := ApprovalParams{NodeID: 7, Name: "test-node", Zone: "lobby"}
+      if err := ms.ApproveEnrollment(macStr, params); err != nil {
+          t.Fatalf("ApproveEnrollment returned error: %v", err)
+      }
+
+      // First frame: JOIN_ACK
+      _ = decodeWrittenFrame(t, mockPort)
+
+      // Second frame: OP_NODE_ID_SET
+      idMsg := decodeWrittenFrame(t, mockPort)
+      if idMsg.Data[0] != byte(OpNodeIdSet) {
+          t.Errorf("second frame opcode = 0x%02x, want 0x%02x", idMsg.Data[0], OpNodeIdSet)
+      }
+      if idMsg.Data[7] != 7 {
+          t.Errorf("nodeId in frame = %d, want 7", idMsg.Data[7])
+      }
+  }
+
+  func TestApproveEnrollment_AutoAssignsNodeId_WhenZero(t *testing.T) {
+      ms := newTestMeshServer(t)
+      macStr, _ := enrollTestNode(t, ms)
+
+      params := ApprovalParams{} // NodeID = 0 → auto-assign
+      if err := ms.ApproveEnrollment(macStr, params); err != nil {
+          t.Fatalf("ApproveEnrollment returned error: %v", err)
+      }
+
+      wantMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF} // from enrollTestNode
+      node, ok := ms.GetNodeRegistry().GetNode(wantMAC)
+      if !ok { t.Fatal("node not registered") }
+      if node.NodeID == 0 {
+          t.Error("NodeID should be auto-assigned (>0)")
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestNodeRegistry|TestApproveEnrollment" -v 2>&1 | tail -20
+  ```
+
+  Expected: compile errors (AssignNode/NextFreeNodeID not defined; ApproveEnrollment wrong arity).
+
+- [ ] **Step 3: Add `OpNodeIdSet` to `constants.go`**
+
+  After `OpNodeHealth`:
+  ```go
+  OpNodeIdSet    byte = 0xC0 // Server → node: assign logical ID; data: [C0][6B targetMAC][1B nodeId]
+  ```
+
+- [ ] **Step 4: Update `NodeInfo`, `persistedNode`, add `AssignNode`/`NextFreeNodeID`, fix `UpdateNode` and `Load` in `node_registry.go`**
+
+  Apply all changes described in Context above.
+
+- [ ] **Step 5: Add `ApprovalParams` and update `ApproveEnrollment` in `server.go`**
+
+  Apply changes described in Context above.
+
+- [ ] **Step 6: Update `approveEnrollment` handler in `api.go`**
+
+  Add `ApprovalRequest` struct and body parsing as shown in Context.
+
+- [ ] **Step 7: Update existing enrollment tests for new signature**
+
+  Update all `ms.ApproveEnrollment(macStr)` calls to `ms.ApproveEnrollment(macStr, ApprovalParams{})`.
+  Update `TestApproveEnrollment_SendsJoinAckWithPubKey` to read two frames.
+
+- [ ] **Step 8: Run targeted tests to verify they pass**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... \
+    -run "TestNodeRegistry|TestApproveEnrollment" -v 2>&1 | tail -20
+  ```
+
+  Expected: all targeted tests PASS.
+
+- [ ] **Step 9: Run full server test suite**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok github.com/superbrobenji/motionServer/mesh` with no failures.
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/constants.go \
+    server/orchestrator/mesh/node_registry.go \
+    server/orchestrator/mesh/server.go \
+    server/orchestrator/mesh/api.go \
+    server/orchestrator/mesh/server_enrollment_test.go \
+    server/orchestrator/mesh/mesh_test.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit \
+    -m "feat(server): node identity — NodeID/Name/Zone, ApproveEnrollment params, OP_NODE_ID_SET"
+  ```

--- a/docs/superpowers/plans/nodes-phase6-artist-api.md
+++ b/docs/superpowers/plans/nodes-phase6-artist-api.md
@@ -1,0 +1,1881 @@
+# Phase 6 — Artist API (/api/v1/) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a clean JSON abstraction layer at `/api/v1/` that hides mesh internals (MAC addresses, adapter type integers, opcodes, protobuf) from artists.
+
+**Architecture:** Four sequential server-only tasks: (1) EventBroker + NodeRegistry helpers + MeshServer event wiring as the pub/sub foundation, (2) ZoneRegistry + `/api/v1/zones` CRUD, (3) `/api/v1/nodes` CRUD + command endpoints with type translation, (4) SSE event stream + `/api/v1/events`, `/api/v1/status`, `/api/v1/enrollments`. All existing routes remain untouched.
+
+**Tech Stack:** Go 1.22, `github.com/gorilla/mux`, `text/event-stream` SSE, JSON file persistence
+
+## Global Constraints
+
+- All new routes under `/api/v1/` prefix; existing `/nodes`, `/api/enrollments/`, `/health/request`, etc. stay at their current paths
+- Same `AuthMiddleware(apiKey)` Bearer token protection on all `/api/v1/` routes
+- Type mapping (exact): `"pir"` ↔ `AdapterTypePIR (0)`, `"led"` ↔ `AdapterTypeLED (2)`, `"serial"` ↔ `AdapterTypeSerial (3)`, anything else → `"unknown"` (reading) / 400 (writing)
+- Node external ID = `NodeID uint8` (1–255); never MAC in `/api/v1/nodes/{id}` routes
+- Online threshold = 75 seconds: `time.Since(node.LastSeen) <= 75*time.Second`
+- SSE event types (exact strings): `"motion"`, `"node_online"`, `"node_offline"`, `"enrolled"`, `"health"`
+- SSE wire format per event: `"event: <type>\ndata: <json>\n\n"` (standard SSE; two trailing newlines)
+- Zone ID = zone name lowercased, spaces replaced with hyphens (`"Main Hall"` → `"main-hall"`); enforced on creation; used in URL paths
+- `EventBroker` client channel buffer size = 32 events; dropped (non-blocking send) when full
+- `healthTimeout` on `MeshServer` = 75s (existing field — do not change)
+- Go test command: `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1` from `motionSensorServer/server/orchestrator/`
+- Repo: `motionSensorServer`, branch `feat/phase6-artist-api`
+- No `gh` CLI; commit author local config already set to `49689582+superbrobenji@users.noreply.github.com`
+
+---
+
+### Task 1: EventBroker + NodeRegistry helpers + MeshServer event wiring
+
+**Files:**
+- Create: `server/orchestrator/mesh/event_broker.go`
+- Modify: `server/orchestrator/mesh/node_registry.go` — add `GetNodeByID`, `GetNodesByZone`
+- Modify: `server/orchestrator/mesh/server.go` — add `eventBroker`, `nodeOnlineState`, `GetEventBroker()`, `GetHealthTimeout()`, `SendNodeData()`, offline detector goroutine, publish calls in message handlers
+
+**Interfaces:**
+- Produces: `NewEventBroker() *EventBroker`
+- Produces: `(*EventBroker).Subscribe() chan Event`
+- Produces: `(*EventBroker).Unsubscribe(ch chan Event)`
+- Produces: `(*EventBroker).Publish(e Event)`
+- Produces: `Event{Type EventType; Data json.RawMessage; Timestamp time.Time}`
+- Produces: `EventType` constants: `EventMotion`, `EventNodeOnline`, `EventNodeOffline`, `EventEnrolled`, `EventHealth`
+- Produces: `(*NodeRegistry).GetNodeByID(nodeId uint8) (*NodeInfo, bool)`
+- Produces: `(*NodeRegistry).GetNodesByZone(zone string) []*NodeInfo`
+- Produces: `(*MeshServer).GetEventBroker() *EventBroker`
+- Produces: `(*MeshServer).GetHealthTimeout() time.Duration`
+- Produces: `(*MeshServer).SendNodeData(mac []byte, dataType int32, data []byte) error`
+
+**Context for implementer:**
+
+The existing server already sends events to Kafka (`eventStore`). The `EventBroker` is an additional in-process pub/sub bus for HTTP SSE clients — it does NOT replace Kafka. Add it alongside existing event publishing.
+
+**`event_broker.go` — full implementation:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "sync"
+    "time"
+)
+
+// EventType is a named SSE event category.
+type EventType string
+
+const (
+    EventMotion      EventType = "motion"
+    EventNodeOnline  EventType = "node_online"
+    EventNodeOffline EventType = "node_offline"
+    EventEnrolled    EventType = "enrolled"
+    EventHealth      EventType = "health"
+)
+
+// Event is a single SSE message sent to subscribers.
+type Event struct {
+    Type      EventType       `json:"type"`
+    Data      json.RawMessage `json:"data"`
+    Timestamp time.Time       `json:"timestamp"`
+}
+
+// EventBroker is an in-process pub/sub bus. Publish is non-blocking; slow
+// subscribers lose events silently rather than blocking the mesh message loop.
+type EventBroker struct {
+    mu      sync.RWMutex
+    clients map[chan Event]struct{}
+}
+
+// NewEventBroker returns an initialised EventBroker.
+func NewEventBroker() *EventBroker {
+    return &EventBroker{clients: make(map[chan Event]struct{})}
+}
+
+// Subscribe returns a buffered channel that receives future events.
+func (b *EventBroker) Subscribe() chan Event {
+    ch := make(chan Event, 32)
+    b.mu.Lock()
+    b.clients[ch] = struct{}{}
+    b.mu.Unlock()
+    return ch
+}
+
+// Unsubscribe removes and closes a subscriber channel.
+func (b *EventBroker) Unsubscribe(ch chan Event) {
+    b.mu.Lock()
+    delete(b.clients, ch)
+    b.mu.Unlock()
+    close(ch)
+}
+
+// Publish sends e to all subscribers. Drops the event for any subscriber
+// whose buffer is full (non-blocking).
+func (b *EventBroker) Publish(e Event) {
+    b.mu.RLock()
+    defer b.mu.RUnlock()
+    for ch := range b.clients {
+        select {
+        case ch <- e:
+        default:
+        }
+    }
+}
+```
+
+**`node_registry.go` additions** (add after existing `GetAllNodes`):
+```go
+// GetNodeByID returns the node assigned the given logical ID, or false.
+func (nr *NodeRegistry) GetNodeByID(nodeId uint8) (*NodeInfo, bool) {
+    nr.mu.RLock()
+    defer nr.mu.RUnlock()
+    for _, n := range nr.nodes {
+        if n.NodeID == nodeId {
+            copy := *n
+            return &copy, true
+        }
+    }
+    return nil, false
+}
+
+// GetNodesByZone returns all nodes assigned to the named zone.
+func (nr *NodeRegistry) GetNodesByZone(zone string) []*NodeInfo {
+    nr.mu.RLock()
+    defer nr.mu.RUnlock()
+    var result []*NodeInfo
+    for _, n := range nr.nodes {
+        if n.Zone == zone {
+            copy := *n
+            result = append(result, &copy)
+        }
+    }
+    return result
+}
+```
+
+**`server.go` additions:**
+
+Add to `MeshServer` struct (after `currentTxPreset uint8`):
+```go
+eventBroker     *EventBroker
+nodeOnlineState map[string]bool // keyed by MACString; true = was online last check
+```
+
+Initialise in `NewMeshServer` (or wherever the struct is built):
+```go
+eventBroker:     NewEventBroker(),
+nodeOnlineState: make(map[string]bool),
+```
+
+New methods on `MeshServer`:
+```go
+func (ms *MeshServer) GetEventBroker() *EventBroker { return ms.eventBroker }
+func (ms *MeshServer) GetHealthTimeout() time.Duration { return ms.healthTimeout }
+
+// SendNodeData sends a serial command frame to a specific node MAC.
+func (ms *MeshServer) SendNodeData(mac []byte, dataType int32, data []byte) error {
+    payload := make([]byte, MaxDataLength)
+    copy(payload, data)
+    msg := &MeshMessage{
+        ProtoVersion: 2,
+        MessageType:  MessageTypeSerialCmdBroadcast,
+        DataType:     int32(dataType),
+        Data:         payload,
+    }
+    copy(msg.TargetMacAddress, mac)
+    return ms.serialComm.WriteFrame(msg)
+}
+```
+
+**Publish helpers** (add to server.go):
+```go
+func (ms *MeshServer) publishEvent(eventType EventType, data interface{}) {
+    raw, err := json.Marshal(data)
+    if err != nil {
+        return
+    }
+    ms.eventBroker.Publish(Event{Type: eventType, Data: raw, Timestamp: time.Now()})
+}
+
+// called from handlePIRData after existing Kafka publish:
+func (ms *MeshServer) publishMotionEvent(node *NodeInfo) {
+    ms.publishEvent(EventMotion, map[string]interface{}{
+        "nodeId":    node.NodeID,
+        "name":      node.Name,
+        "zone":      node.Zone,
+        "hopCount":  node.HopCount,
+        "timestamp": time.Now().UTC().Format(time.RFC3339),
+    })
+}
+
+// called from handleHealthData / handleSerialData after UpdateNode:
+func (ms *MeshServer) publishHealthEvent(node *NodeInfo) {
+    online := time.Since(node.LastSeen) <= ms.healthTimeout
+    ms.publishEvent(EventHealth, map[string]interface{}{
+        "nodeId":  node.NodeID,
+        "name":    node.Name,
+        "online":  online,
+        "uptime":  node.Uptime,
+        "hopCount": node.HopCount,
+    })
+    ms.mu.Lock()
+    defer ms.mu.Unlock()
+    if !ms.nodeOnlineState[node.MACString] {
+        ms.nodeOnlineState[node.MACString] = true
+        ms.publishEvent(EventNodeOnline, map[string]interface{}{
+            "nodeId": node.NodeID,
+            "name":   node.Name,
+        })
+    }
+}
+
+// called from ApproveEnrollment after JOIN_ACK:
+func (ms *MeshServer) publishEnrolledEvent(node *NodeInfo, adapterTypeStr string) {
+    ms.publishEvent(EventEnrolled, map[string]interface{}{
+        "nodeId": node.NodeID,
+        "name":   node.Name,
+        "type":   adapterTypeStr,
+    })
+}
+```
+
+**Offline detector** (add to server.go):
+```go
+func (ms *MeshServer) offlineDetectorLoop() {
+    ticker := time.NewTicker(30 * time.Second)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ticker.C:
+            ms.checkOfflineNodes()
+        case <-ms.ctx.Done():
+            return
+        }
+    }
+}
+
+func (ms *MeshServer) checkOfflineNodes() {
+    nodes := ms.nodeRegistry.GetAllNodes()
+    ms.mu.Lock()
+    defer ms.mu.Unlock()
+    for _, node := range nodes {
+        if time.Since(node.LastSeen) > ms.healthTimeout {
+            if ms.nodeOnlineState[node.MACString] {
+                ms.nodeOnlineState[node.MACString] = false
+                ms.publishEvent(EventNodeOffline, map[string]interface{}{
+                    "nodeId":   node.NodeID,
+                    "name":     node.Name,
+                    "lastSeen": node.LastSeen.UTC().Format(time.RFC3339),
+                })
+            }
+        }
+    }
+}
+```
+
+Start the goroutine in `Start()` alongside existing goroutines:
+```go
+ms.wg.Add(1)
+go func() {
+    defer ms.wg.Done()
+    ms.offlineDetectorLoop()
+}()
+```
+
+Wire publish calls into existing handlers:
+- In `handlePIRData` (after existing Kafka publish): `ms.publishMotionEvent(node)` where node is fetched from registry after UpdateNode
+- In the `OpHealthReport`/`OpNodeHealth` case of `handleSerialData` (after UpdateNode): `ms.publishHealthEvent(node)`
+- In `ApproveEnrollment` (after `AssignNode`): `ms.publishEnrolledEvent(node, "pir")` — use `GetAdapterTypeName` / type string from params if available (pass type string into publish)
+
+For `publishEnrolledEvent`, `ApproveEnrollment` doesn't know the adapter type string. Add an `AdapterTypeStr` field to `ApprovalParams`:
+```go
+type ApprovalParams struct {
+    NodeID          uint8
+    Name            string
+    Zone            string
+    AdapterTypeStr  string // "pir", "led", etc. — for SSE enrolled event; empty = "unknown"
+}
+```
+The v1 enrollment handler sets this; the existing `/api/enrollments/{mac}/approve` handler passes `ApprovalParams{}` (empty = "unknown"), which is backward-compatible.
+
+- [ ] **Step 1: Write EventBroker tests**
+
+  Create `server/orchestrator/mesh/event_broker_test.go`:
+  ```go
+  package mesh
+
+  import (
+      "testing"
+      "time"
+  )
+
+  func TestEventBroker_SubscribeReceivesPublished(t *testing.T) {
+      b := NewEventBroker()
+      ch := b.Subscribe()
+      defer b.Unsubscribe(ch)
+
+      raw := []byte(`{"nodeId":7}`)
+      b.Publish(Event{Type: EventMotion, Data: raw, Timestamp: time.Now()})
+
+      select {
+      case e := <-ch:
+          if e.Type != EventMotion {
+              t.Errorf("Type: got %q, want %q", e.Type, EventMotion)
+          }
+      case <-time.After(100 * time.Millisecond):
+          t.Fatal("no event received within 100ms")
+      }
+  }
+
+  func TestEventBroker_UnsubscribedChannelClosed(t *testing.T) {
+      b := NewEventBroker()
+      ch := b.Subscribe()
+      b.Unsubscribe(ch)
+      _, open := <-ch
+      if open {
+          t.Error("channel should be closed after Unsubscribe")
+      }
+  }
+
+  func TestEventBroker_FullBufferDropsEvent(t *testing.T) {
+      b := NewEventBroker()
+      ch := b.Subscribe()
+      defer b.Unsubscribe(ch)
+
+      // Fill buffer (size 32) + 1 extra — must not block
+      done := make(chan struct{})
+      go func() {
+          for i := 0; i < 33; i++ {
+              b.Publish(Event{Type: EventHealth, Data: []byte(`{}`), Timestamp: time.Now()})
+          }
+          close(done)
+      }()
+
+      select {
+      case <-done:
+      case <-time.After(500 * time.Millisecond):
+          t.Fatal("Publish blocked on full buffer")
+      }
+
+      if len(ch) != 32 {
+          t.Errorf("buffer has %d events, want 32", len(ch))
+      }
+  }
+
+  func TestEventBroker_MultipleSubscribers(t *testing.T) {
+      b := NewEventBroker()
+      ch1 := b.Subscribe()
+      ch2 := b.Subscribe()
+      defer b.Unsubscribe(ch1)
+      defer b.Unsubscribe(ch2)
+
+      b.Publish(Event{Type: EventNodeOnline, Data: []byte(`{}`), Timestamp: time.Now()})
+
+      for i, ch := range []chan Event{ch1, ch2} {
+          select {
+          case e := <-ch:
+              if e.Type != EventNodeOnline {
+                  t.Errorf("subscriber %d: type %q, want %q", i, e.Type, EventNodeOnline)
+              }
+          case <-time.After(100 * time.Millisecond):
+              t.Errorf("subscriber %d: no event received", i)
+          }
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run EventBroker tests to verify they fail**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestEventBroker -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile error (EventBroker not defined).
+
+- [ ] **Step 3: Create `event_broker.go`**
+
+  Write the full implementation shown in Context above to `server/orchestrator/mesh/event_broker.go`.
+
+- [ ] **Step 4: Run EventBroker tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestEventBroker -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok ... (all 4 pass)`.
+
+- [ ] **Step 5: Write NodeRegistry helper tests**
+
+  In `server/orchestrator/mesh/mesh_test.go`, add to `TestNodeRegistry`:
+  ```go
+  t.Run("GetNodeByID_ReturnsNode_WhenExists", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+      registry.AssignNode(mac, 7, "entrance-left", "lobby")
+      node, ok := registry.GetNodeByID(7)
+      if !ok { t.Fatal("expected node, got nothing") }
+      if node.NodeID != 7 { t.Errorf("NodeID: %d, want 7", node.NodeID) }
+      if node.Name != "entrance-left" { t.Errorf("Name: %q", node.Name) }
+  })
+
+  t.Run("GetNodeByID_ReturnsFalse_WhenMissing", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      if _, ok := registry.GetNodeByID(99); ok {
+          t.Error("expected false for unknown ID")
+      }
+  })
+
+  t.Run("GetNodesByZone_ReturnsOnlyZoneNodes", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      registry.AssignNode([]byte{0x01, 0, 0, 0, 0, 0}, 1, "a", "lobby")
+      registry.AssignNode([]byte{0x02, 0, 0, 0, 0, 0}, 2, "b", "lobby")
+      registry.AssignNode([]byte{0x03, 0, 0, 0, 0, 0}, 3, "c", "stage")
+      nodes := registry.GetNodesByZone("lobby")
+      if len(nodes) != 2 { t.Errorf("len: %d, want 2", len(nodes)) }
+      for _, n := range nodes {
+          if n.Zone != "lobby" { t.Errorf("unexpected zone %q", n.Zone) }
+      }
+  })
+
+  t.Run("GetNodesByZone_ReturnsEmpty_WhenNoMatch", func(t *testing.T) {
+      registry := NewNodeRegistry()
+      registry.AssignNode([]byte{0x01, 0, 0, 0, 0, 0}, 1, "a", "lobby")
+      nodes := registry.GetNodesByZone("nowhere")
+      if len(nodes) != 0 { t.Errorf("len: %d, want 0", len(nodes)) }
+  })
+  ```
+
+- [ ] **Step 6: Run to verify failure**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestNodeRegistry -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile error (methods not defined).
+
+- [ ] **Step 7: Add `GetNodeByID` and `GetNodesByZone` to `node_registry.go`**
+
+  Add both methods shown in Context above after the existing `GetAllNodes` method.
+
+- [ ] **Step 8: Run NodeRegistry tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestNodeRegistry -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 9: Write MeshServer event-wiring tests**
+
+  In `server/orchestrator/mesh/server_test.go`, add:
+  ```go
+  func TestMeshServer_PublishesMotionEvent_OnPIRData(t *testing.T) {
+      ms := newTestMeshServer(t)
+      ch := ms.GetEventBroker().Subscribe()
+      defer ms.GetEventBroker().Unsubscribe(ch)
+
+      mac := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x02}
+      ms.nodeRegistry.AssignNode(mac, 5, "stage-left", "stage")
+
+      data := make([]byte, MaxDataLength)
+      data[0] = byte(AdapterTypePIR)
+      copy(data[1:7], mac)
+      msg := &MeshMessage{
+          ProtoVersion:     2,
+          MessageType:      MessageTypeAdapterData,
+          DataType:         AdapterTypePIR,
+          Data:             data,
+          OriginMacAddress: mac,
+      }
+      if err := ms.handleMessage(msg); err != nil {
+          t.Fatalf("handleMessage: %v", err)
+      }
+
+      select {
+      case e := <-ch:
+          if e.Type != EventMotion {
+              t.Errorf("event type: %q, want %q", e.Type, EventMotion)
+          }
+      case <-time.After(200 * time.Millisecond):
+          t.Fatal("no motion event within 200ms")
+      }
+  }
+
+  func TestMeshServer_PublishesNodeOnline_OnFirstHealthReport(t *testing.T) {
+      ms := newTestMeshServer(t)
+      ch := ms.GetEventBroker().Subscribe()
+      defer ms.GetEventBroker().Unsubscribe(ch)
+
+      mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01}
+      data := make([]byte, MaxDataLength)
+      data[0] = byte(OpHealthReport)
+      data[1] = byte(AdapterTypePIR)
+      copy(data[2:8], mac)
+      msg := &MeshMessage{
+          ProtoVersion:     2,
+          MessageType:      MessageTypeAdapterData,
+          DataType:         AdapterTypeSerial,
+          Data:             data,
+          OriginMacAddress: mac,
+      }
+      if err := ms.handleMessage(msg); err != nil {
+          t.Fatalf("handleMessage: %v", err)
+      }
+
+      var gotOnline bool
+      for {
+          select {
+          case e := <-ch:
+              if e.Type == EventNodeOnline { gotOnline = true }
+          case <-time.After(200 * time.Millisecond):
+              if !gotOnline { t.Error("no node_online event") }
+              return
+          }
+          if gotOnline { return }
+      }
+  }
+
+  func TestMeshServer_CheckOfflineNodes_PublishesOfflineEvent(t *testing.T) {
+      ms := newTestMeshServer(t)
+      ch := ms.GetEventBroker().Subscribe()
+      defer ms.GetEventBroker().Unsubscribe(ch)
+
+      mac := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01}
+      ms.nodeRegistry.AssignNode(mac, 3, "old-node", "lobby")
+      macStr := macToString(mac)
+
+      // mark as previously online
+      ms.mu.Lock()
+      ms.nodeOnlineState[macStr] = true
+      // set LastSeen 80s ago — exceeds 75s threshold
+      ms.nodeRegistry.nodes[macStr].LastSeen = time.Now().Add(-80 * time.Second)
+      ms.mu.Unlock()
+
+      ms.checkOfflineNodes()
+
+      select {
+      case e := <-ch:
+          if e.Type != EventNodeOffline {
+              t.Errorf("event type: %q, want %q", e.Type, EventNodeOffline)
+          }
+      case <-time.After(100 * time.Millisecond):
+          t.Fatal("no node_offline event")
+      }
+  }
+  ```
+
+- [ ] **Step 10: Run to verify failure**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestMeshServer_Publish|TestMeshServer_Check" -count=1 2>&1 | tail -10
+  ```
+
+  Expected: compile errors (eventBroker field, methods not defined).
+
+- [ ] **Step 11: Modify `server.go` with all EventBroker additions**
+
+  Apply all changes described in Context above:
+  1. Add fields to `MeshServer` struct
+  2. Initialise in constructor
+  3. Add `GetEventBroker`, `GetHealthTimeout`, `SendNodeData` methods
+  4. Add `publishEvent`, `publishMotionEvent`, `publishHealthEvent`, `publishEnrolledEvent` helpers
+  5. Add `offlineDetectorLoop` and `checkOfflineNodes`
+  6. Start offline detector goroutine in `Start()`
+  7. Add `AdapterTypeStr` field to `ApprovalParams`
+  8. Wire publish calls into `handlePIRData`, health handler, `ApproveEnrollment`
+
+  For step 8, find the exact locations:
+  - `handlePIRData`: after `ms.eventStore.LogEvent(...)` or the equivalent Kafka publish, add:
+    ```go
+    if node, ok := ms.nodeRegistry.GetNode(mac); ok {
+        ms.publishMotionEvent(node)
+    }
+    ```
+  - Health handler (the `OpHealthReport`/`OpNodeHealth` case): after `ms.nodeRegistry.UpdateNode(...)`, add:
+    ```go
+    if node, ok := ms.nodeRegistry.GetNode(originMAC); ok {
+        ms.publishHealthEvent(node)
+    }
+    ```
+  - `ApproveEnrollment`: after `ms.nodeRegistry.AssignNode(...)`, add:
+    ```go
+    if node, ok := ms.nodeRegistry.GetNode(node.MAC[:]); ok {
+        typeStr := params.AdapterTypeStr
+        if typeStr == "" { typeStr = "unknown" }
+        ms.publishEnrolledEvent(node, typeStr)
+    }
+    ```
+
+- [ ] **Step 12: Run targeted tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestEventBroker|TestNodeRegistry|TestMeshServer_Publish|TestMeshServer_Check" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 13: Run full test suite**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok github.com/superbrobenji/motionServer/mesh`.
+
+- [ ] **Step 14: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/event_broker.go \
+    server/orchestrator/mesh/event_broker_test.go \
+    server/orchestrator/mesh/node_registry.go \
+    server/orchestrator/mesh/server.go \
+    server/orchestrator/mesh/mesh_test.go \
+    server/orchestrator/mesh/server_test.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit \
+    -m "feat(server): EventBroker pub/sub, NodeRegistry helpers, MeshServer event wiring"
+  ```
+
+---
+
+### Task 2: ZoneRegistry + /api/v1/zones
+
+**Files:**
+- Create: `server/orchestrator/mesh/zone_registry.go`
+- Create: `server/orchestrator/mesh/api_v1_zones.go`
+- Modify: `server/orchestrator/mesh/server.go` — add `zoneRegistry` field, `GetZoneRegistry()`, `SetZoneRegistryPath()`
+- Modify: `server/orchestrator/mesh/api.go` — register `/api/v1/zones` routes
+
+**Interfaces:**
+- Consumes (from Task 1): `(*NodeRegistry).GetNodesByZone(zone string) []*NodeInfo`, `(*MeshServer).SendNodeData(mac []byte, dataType int32, data []byte) error`
+- Produces: `NewZoneRegistry() *ZoneRegistry`
+- Produces: `(*ZoneRegistry).Add(name string) (*ZoneV1, error)` — error if name already exists
+- Produces: `(*ZoneRegistry).Get(id string) (*ZoneV1, bool)`
+- Produces: `(*ZoneRegistry).List() []*ZoneV1`
+- Produces: `(*ZoneRegistry).Update(id, newName string) (*ZoneV1, bool)`
+- Produces: `(*ZoneRegistry).Delete(id string) bool`
+- Produces: `(*ZoneRegistry).Persist(path string) error`
+- Produces: `(*ZoneRegistry).Load(path string) error`
+- Produces: `(*MeshServer).GetZoneRegistry() *ZoneRegistry`
+- Produces: `(*MeshServer).SetZoneRegistryPath(path string)`
+- Produces: `ZoneV1{ID string; Name string}` — shared response struct
+
+**Context for implementer:**
+
+Zone ID = `strings.ToLower(strings.ReplaceAll(name, " ", "-"))`. All spaces become hyphens, all uppercase becomes lowercase. Example: `"Main Hall"` → `"main-hall"`. ID is derived once at creation and never changes (the ID is used in URLs).
+
+`ZoneRegistry` persists as a JSON array of `ZoneV1`. Use the same pattern as `NodeRegistry.Persist`/`Load`. Start the periodic persist loop from `MeshServer.Start()` only if `zoneRegistryPath != ""`.
+
+Zone command: `POST /api/v1/zones/{id}/command {"action":"trigger","params":{}}`. Fan-out: find all nodes in zone via `GetNodesByZone(id)`, send command to each. Use `data[0] = 0xD0` as the trigger opcode placeholder. Return 404 if zone not found, 200 with `{"success":true,"data":{"sent":N}}` where N = number of nodes commanded.
+
+**`zone_registry.go`:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+    "strings"
+    "sync"
+)
+
+// ZoneV1 is the artist-facing zone representation.
+type ZoneV1 struct {
+    ID   string `json:"id"`
+    Name string `json:"name"`
+}
+
+// ZoneRegistry stores artist-defined zones.
+type ZoneRegistry struct {
+    mu    sync.RWMutex
+    zones map[string]*ZoneV1 // keyed by ID
+}
+
+// NewZoneRegistry returns an empty ZoneRegistry.
+func NewZoneRegistry() *ZoneRegistry {
+    return &ZoneRegistry{zones: make(map[string]*ZoneV1)}
+}
+
+// zoneSlug derives the URL-safe ID from a zone name.
+func zoneSlug(name string) string {
+    return strings.ReplaceAll(strings.ToLower(name), " ", "-")
+}
+
+// Add creates a zone. Returns an error if the derived ID is already taken.
+func (zr *ZoneRegistry) Add(name string) (*ZoneV1, error) {
+    id := zoneSlug(name)
+    zr.mu.Lock()
+    defer zr.mu.Unlock()
+    if _, exists := zr.zones[id]; exists {
+        return nil, fmt.Errorf("zone %q already exists", id)
+    }
+    z := &ZoneV1{ID: id, Name: name}
+    zr.zones[id] = z
+    copy := *z
+    return &copy, nil
+}
+
+// Get returns a zone by ID.
+func (zr *ZoneRegistry) Get(id string) (*ZoneV1, bool) {
+    zr.mu.RLock()
+    defer zr.mu.RUnlock()
+    z, ok := zr.zones[id]
+    if !ok { return nil, false }
+    copy := *z
+    return &copy, true
+}
+
+// List returns all zones (unordered).
+func (zr *ZoneRegistry) List() []*ZoneV1 {
+    zr.mu.RLock()
+    defer zr.mu.RUnlock()
+    result := make([]*ZoneV1, 0, len(zr.zones))
+    for _, z := range zr.zones {
+        copy := *z
+        result = append(result, &copy)
+    }
+    return result
+}
+
+// Update renames a zone. The ID never changes.
+func (zr *ZoneRegistry) Update(id, newName string) (*ZoneV1, bool) {
+    zr.mu.Lock()
+    defer zr.mu.Unlock()
+    z, ok := zr.zones[id]
+    if !ok { return nil, false }
+    z.Name = newName
+    copy := *z
+    return &copy, true
+}
+
+// Delete removes a zone by ID. Returns false if not found.
+func (zr *ZoneRegistry) Delete(id string) bool {
+    zr.mu.Lock()
+    defer zr.mu.Unlock()
+    _, ok := zr.zones[id]
+    delete(zr.zones, id)
+    return ok
+}
+
+// Persist writes the registry to a JSON file.
+func (zr *ZoneRegistry) Persist(path string) error {
+    zr.mu.RLock()
+    zones := make([]*ZoneV1, 0, len(zr.zones))
+    for _, z := range zr.zones { zones = append(zones, z) }
+    zr.mu.RUnlock()
+    data, err := json.MarshalIndent(zones, "", "  ")
+    if err != nil { return err }
+    return os.WriteFile(path, data, 0644)
+}
+
+// Load reads zones from a JSON file. Non-existent file is a no-op.
+func (zr *ZoneRegistry) Load(path string) error {
+    data, err := os.ReadFile(path)
+    if os.IsNotExist(err) { return nil }
+    if err != nil { return err }
+    var zones []*ZoneV1
+    if err := json.Unmarshal(data, &zones); err != nil { return err }
+    zr.mu.Lock()
+    defer zr.mu.Unlock()
+    for _, z := range zones {
+        zr.zones[z.ID] = z
+    }
+    return nil
+}
+```
+
+**server.go additions:**
+
+Add to `MeshServer` struct:
+```go
+zoneRegistry     *ZoneRegistry
+zoneRegistryPath string
+```
+
+Initialise in constructor:
+```go
+zoneRegistry: NewZoneRegistry(),
+```
+
+Add methods:
+```go
+func (ms *MeshServer) GetZoneRegistry() *ZoneRegistry { return ms.zoneRegistry }
+
+func (ms *MeshServer) SetZoneRegistryPath(path string) {
+    ms.zoneRegistryPath = path
+    if path != "" {
+        _ = ms.zoneRegistry.Load(path)
+    }
+}
+```
+
+In `Stop()`, add zone persistence (after node registry persist):
+```go
+if ms.zoneRegistryPath != "" {
+    _ = ms.zoneRegistry.Persist(ms.zoneRegistryPath)
+}
+```
+
+**`api_v1_zones.go`:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "github.com/gorilla/mux"
+)
+
+func (api *APIServer) v1GetZones(w http.ResponseWriter, r *http.Request) {
+    zones := api.meshServer.GetZoneRegistry().List()
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: zones})
+}
+
+func (api *APIServer) v1CreateZone(w http.ResponseWriter, r *http.Request) {
+    var body struct{ Name string `json:"name"` }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+        api.writeError(w, http.StatusBadRequest, "name is required")
+        return
+    }
+    zone, err := api.meshServer.GetZoneRegistry().Add(body.Name)
+    if err != nil {
+        api.writeError(w, http.StatusConflict, err.Error())
+        return
+    }
+    api.writeJSON(w, http.StatusCreated, APIResponse{Success: true, Data: zone})
+}
+
+func (api *APIServer) v1UpdateZone(w http.ResponseWriter, r *http.Request) {
+    id := mux.Vars(r)["id"]
+    var body struct{ Name string `json:"name"` }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+        api.writeError(w, http.StatusBadRequest, "name is required")
+        return
+    }
+    zone, ok := api.meshServer.GetZoneRegistry().Update(id, body.Name)
+    if !ok {
+        api.writeError(w, http.StatusNotFound, "zone not found")
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: zone})
+}
+
+func (api *APIServer) v1DeleteZone(w http.ResponseWriter, r *http.Request) {
+    id := mux.Vars(r)["id"]
+    if !api.meshServer.GetZoneRegistry().Delete(id) {
+        api.writeError(w, http.StatusNotFound, "zone not found")
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Message: "zone deleted"})
+}
+
+func (api *APIServer) v1ZoneCommand(w http.ResponseWriter, r *http.Request) {
+    id := mux.Vars(r)["id"]
+    if _, ok := api.meshServer.GetZoneRegistry().Get(id); !ok {
+        api.writeError(w, http.StatusNotFound, "zone not found")
+        return
+    }
+    var body struct {
+        Action string                 `json:"action"`
+        Params map[string]interface{} `json:"params"`
+    }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Action == "" {
+        api.writeError(w, http.StatusBadRequest, "action is required")
+        return
+    }
+    if body.Action != "trigger" {
+        api.writeError(w, http.StatusNotImplemented, "action not supported")
+        return
+    }
+    nodes := api.meshServer.GetNodeRegistry().GetNodesByZone(id)
+    payload := make([]byte, MaxDataLength)
+    payload[0] = 0xD0 // trigger placeholder opcode
+    sent := 0
+    for _, node := range nodes {
+        if err := api.meshServer.SendNodeData(node.MAC, int32(AdapterTypeSerial), payload); err == nil {
+            sent++
+        }
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: map[string]int{"sent": sent}})
+}
+```
+
+**Route registration in `api.go`** `setupRoutes()` (add after existing route block):
+```go
+// /api/v1/zones
+api.router.Handle("/api/v1/zones", middleware(http.HandlerFunc(api.v1GetZones))).Methods("GET")
+api.router.Handle("/api/v1/zones", middleware(http.HandlerFunc(api.v1CreateZone))).Methods("POST")
+api.router.Handle("/api/v1/zones/{id}", middleware(http.HandlerFunc(api.v1UpdateZone))).Methods("PATCH")
+api.router.Handle("/api/v1/zones/{id}", middleware(http.HandlerFunc(api.v1DeleteZone))).Methods("DELETE")
+api.router.Handle("/api/v1/zones/{id}/command", middleware(http.HandlerFunc(api.v1ZoneCommand))).Methods("POST")
+```
+
+Where `middleware` is the existing auth+instrument wrapper (match the pattern already used in `setupRoutes`).
+
+- [ ] **Step 1: Write ZoneRegistry tests**
+
+  In `server/orchestrator/mesh/mesh_test.go`, add:
+  ```go
+  func TestZoneRegistry_AddAndGet(t *testing.T) {
+      zr := NewZoneRegistry()
+      zone, err := zr.Add("Main Hall")
+      if err != nil { t.Fatalf("Add: %v", err) }
+      if zone.ID != "main-hall" { t.Errorf("ID: %q, want %q", zone.ID, "main-hall") }
+      if zone.Name != "Main Hall" { t.Errorf("Name: %q", zone.Name) }
+  }
+
+  func TestZoneRegistry_Add_DuplicateReturnsError(t *testing.T) {
+      zr := NewZoneRegistry()
+      if _, err := zr.Add("lobby"); err != nil { t.Fatal(err) }
+      if _, err := zr.Add("lobby"); err == nil { t.Error("expected error for duplicate") }
+      // "Lobby" and "lobby" both map to "lobby" — also duplicate
+      if _, err := zr.Add("Lobby"); err == nil { t.Error("expected error for case-variant duplicate") }
+  }
+
+  func TestZoneRegistry_List(t *testing.T) {
+      zr := NewZoneRegistry()
+      zr.Add("lobby")
+      zr.Add("stage")
+      zones := zr.List()
+      if len(zones) != 2 { t.Errorf("len: %d, want 2", len(zones)) }
+  }
+
+  func TestZoneRegistry_Update(t *testing.T) {
+      zr := NewZoneRegistry()
+      zr.Add("lobby")
+      z, ok := zr.Update("lobby", "Lobby Area")
+      if !ok { t.Fatal("Update returned false") }
+      if z.Name != "Lobby Area" { t.Errorf("Name: %q", z.Name) }
+      if z.ID != "lobby" { t.Errorf("ID changed: %q", z.ID) }
+  }
+
+  func TestZoneRegistry_Delete(t *testing.T) {
+      zr := NewZoneRegistry()
+      zr.Add("lobby")
+      if !zr.Delete("lobby") { t.Error("Delete returned false") }
+      if _, ok := zr.Get("lobby"); ok { t.Error("zone still present after delete") }
+      if zr.Delete("lobby") { t.Error("second delete should return false") }
+  }
+
+  func TestZoneRegistry_PersistAndLoad(t *testing.T) {
+      path := t.TempDir() + "/zones.json"
+      zr := NewZoneRegistry()
+      zr.Add("lobby")
+      zr.Add("stage")
+      if err := zr.Persist(path); err != nil { t.Fatalf("Persist: %v", err) }
+      zr2 := NewZoneRegistry()
+      if err := zr2.Load(path); err != nil { t.Fatalf("Load: %v", err) }
+      zones := zr2.List()
+      if len(zones) != 2 { t.Errorf("len after load: %d, want 2", len(zones)) }
+  }
+  ```
+
+- [ ] **Step 2: Run to verify failure**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestZoneRegistry -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile error.
+
+- [ ] **Step 3: Create `zone_registry.go`**
+
+  Write the full implementation above.
+
+- [ ] **Step 4: Run ZoneRegistry tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestZoneRegistry -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5: Write zone HTTP handler tests**
+
+  Create `server/orchestrator/mesh/api_v1_zones_test.go`:
+  ```go
+  package mesh
+
+  import (
+      "bytes"
+      "encoding/json"
+      "net/http"
+      "net/http/httptest"
+      "testing"
+  )
+
+  func newV1TestServer(t *testing.T) (*APIServer, *MeshServer) {
+      t.Helper()
+      ms := newTestMeshServer(t)
+      api := NewAPIServer(ms, "test-key", nil)
+      return api, ms
+  }
+
+  func v1Request(t *testing.T, api *APIServer, method, path string, body interface{}) *httptest.ResponseRecorder {
+      t.Helper()
+      var bodyBytes []byte
+      if body != nil {
+          var err error
+          bodyBytes, err = json.Marshal(body)
+          if err != nil { t.Fatalf("marshal body: %v", err) }
+      }
+      req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+      req.Header.Set("Authorization", "Bearer test-key")
+      if body != nil { req.Header.Set("Content-Type", "application/json") }
+      w := httptest.NewRecorder()
+      api.ServeHTTP(w, req)
+      return w
+  }
+
+  func TestV1Zones_CreateAndList(t *testing.T) {
+      api, _ := newV1TestServer(t)
+
+      w := v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      if w.Code != http.StatusCreated { t.Fatalf("create: %d, want 201", w.Code) }
+
+      w = v1Request(t, api, "GET", "/api/v1/zones", nil)
+      if w.Code != http.StatusOK { t.Fatalf("list: %d", w.Code) }
+      var resp APIResponse
+      json.NewDecoder(w.Body).Decode(&resp)
+      if !resp.Success { t.Error("expected success:true") }
+  }
+
+  func TestV1Zones_CreateDuplicate_Returns409(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      w := v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      if w.Code != http.StatusConflict { t.Errorf("got %d, want 409", w.Code) }
+  }
+
+  func TestV1Zones_Update(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      w := v1Request(t, api, "PATCH", "/api/v1/zones/lobby", map[string]string{"name": "Lobby Area"})
+      if w.Code != http.StatusOK { t.Fatalf("update: %d", w.Code) }
+  }
+
+  func TestV1Zones_Delete(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      w := v1Request(t, api, "DELETE", "/api/v1/zones/lobby", nil)
+      if w.Code != http.StatusOK { t.Fatalf("delete: %d", w.Code) }
+      w = v1Request(t, api, "DELETE", "/api/v1/zones/lobby", nil)
+      if w.Code != http.StatusNotFound { t.Errorf("second delete: %d, want 404", w.Code) }
+  }
+
+  func TestV1Zones_Command_UnknownZone_Returns404(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      w := v1Request(t, api, "POST", "/api/v1/zones/nowhere/command",
+          map[string]interface{}{"action": "trigger", "params": map[string]interface{}{}})
+      if w.Code != http.StatusNotFound { t.Errorf("got %d, want 404", w.Code) }
+  }
+
+  func TestV1Zones_Command_UnsupportedAction_Returns501(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      v1Request(t, api, "POST", "/api/v1/zones", map[string]string{"name": "lobby"})
+      w := v1Request(t, api, "POST", "/api/v1/zones/lobby/command",
+          map[string]interface{}{"action": "explode", "params": map[string]interface{}{}})
+      if w.Code != http.StatusNotImplemented { t.Errorf("got %d, want 501", w.Code) }
+  }
+  ```
+
+- [ ] **Step 6: Run to verify failure**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run TestV1Zones -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile errors (handlers not defined / routes not registered).
+
+- [ ] **Step 7: Create `api_v1_zones.go`; add zone fields to `server.go`; register routes in `api.go`**
+
+  Apply all three changes from Context above.
+
+- [ ] **Step 8: Run targeted tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestZoneRegistry|TestV1Zones" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 9: Run full suite**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok`.
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/zone_registry.go \
+    server/orchestrator/mesh/api_v1_zones.go \
+    server/orchestrator/mesh/api_v1_zones_test.go \
+    server/orchestrator/mesh/server.go \
+    server/orchestrator/mesh/api.go \
+    server/orchestrator/mesh/mesh_test.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit \
+    -m "feat(server): ZoneRegistry + /api/v1/zones CRUD and command endpoints"
+  ```
+
+---
+
+### Task 3: /api/v1/nodes endpoints + shared v1 types
+
+**Files:**
+- Create: `server/orchestrator/mesh/api_v1_types.go` — `NodeV1`, type translation helpers
+- Create: `server/orchestrator/mesh/api_v1_nodes.go` — all 5 node handlers
+- Modify: `server/orchestrator/mesh/api.go` — register `/api/v1/nodes` routes
+
+**Interfaces:**
+- Consumes (from Task 1): `(*NodeRegistry).GetNodeByID(uint8) (*NodeInfo, bool)`, `(*MeshServer).SendNodeData(mac []byte, dataType int32, data []byte) error`, `(*MeshServer).GetHealthTimeout() time.Duration`
+- Consumes (from Task 2): `ZoneV1` type (already in zone_registry.go)
+- Produces: `NodeV1{ID uint8; Name string; Zone string; Type string; Online bool; HopCount uint32; Uptime uint32; LastSeen time.Time}` — the artist-facing node response struct
+- Produces: `adapterTypeToString(t int32) string` — translates int to "pir"/"led"/"serial"/"unknown"
+- Produces: `adapterTypeFromString(s string) (int32, bool)` — translates "pir"/"led" to int; false if unknown
+
+**Context for implementer:**
+
+**`api_v1_types.go`:**
+```go
+package mesh
+
+import "time"
+
+// NodeV1 is the artist-facing node representation.
+type NodeV1 struct {
+    ID       uint8     `json:"id"`
+    Name     string    `json:"name"`
+    Zone     string    `json:"zone"`
+    Type     string    `json:"type"`
+    Online   bool      `json:"online"`
+    HopCount uint32    `json:"hopCount"`
+    Uptime   uint32    `json:"uptime"`
+    LastSeen time.Time `json:"lastSeen"`
+}
+
+// adapterTypeToString converts an internal adapter type to the artist-facing string.
+func adapterTypeToString(t int32) string {
+    switch t {
+    case AdapterTypePIR:    return "pir"
+    case AdapterTypeLED:    return "led"
+    case AdapterTypeSerial: return "serial"
+    default:                return "unknown"
+    }
+}
+
+// adapterTypeFromString converts an artist-facing type string to an internal adapter type.
+// Returns false if the string is not a writable type.
+func adapterTypeFromString(s string) (int32, bool) {
+    switch s {
+    case "pir": return AdapterTypePIR, true
+    case "led": return AdapterTypeLED, true
+    default:    return 0, false
+    }
+}
+
+// nodeToV1 converts an internal NodeInfo to the artist-facing NodeV1.
+func nodeToV1(n *NodeInfo, timeout time.Duration) NodeV1 {
+    return NodeV1{
+        ID:       n.NodeID,
+        Name:     n.Name,
+        Zone:     n.Zone,
+        Type:     adapterTypeToString(n.AdapterType),
+        Online:   time.Since(n.LastSeen) <= timeout,
+        HopCount: n.HopCount,
+        Uptime:   n.Uptime,
+        LastSeen: n.LastSeen,
+    }
+}
+```
+
+**`api_v1_nodes.go`:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "net/http"
+    "strconv"
+
+    "github.com/gorilla/mux"
+)
+
+func (api *APIServer) v1GetNodes(w http.ResponseWriter, r *http.Request) {
+    timeout := api.meshServer.GetHealthTimeout()
+    nodes := api.meshServer.GetNodeRegistry().GetAllNodes()
+    result := make([]NodeV1, 0, len(nodes))
+    for _, n := range nodes {
+        if n.NodeID > 0 { // only include nodes with assigned IDs
+            result = append(result, nodeToV1(n, timeout))
+        }
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: result})
+}
+
+func (api *APIServer) v1GetNode(w http.ResponseWriter, r *http.Request) {
+    id, err := parseNodeID(mux.Vars(r)["id"])
+    if err != nil {
+        api.writeError(w, http.StatusBadRequest, "invalid node id")
+        return
+    }
+    node, ok := api.meshServer.GetNodeRegistry().GetNodeByID(id)
+    if !ok {
+        api.writeError(w, http.StatusNotFound, "node not found")
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: nodeToV1(node, api.meshServer.GetHealthTimeout())})
+}
+
+func (api *APIServer) v1UpdateNode(w http.ResponseWriter, r *http.Request) {
+    id, err := parseNodeID(mux.Vars(r)["id"])
+    if err != nil {
+        api.writeError(w, http.StatusBadRequest, "invalid node id")
+        return
+    }
+    node, ok := api.meshServer.GetNodeRegistry().GetNodeByID(id)
+    if !ok {
+        api.writeError(w, http.StatusNotFound, "node not found")
+        return
+    }
+
+    var body struct {
+        Name *string `json:"name"`
+        Zone *string `json:"zone"`
+        Type *string `json:"type"`
+    }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+        api.writeError(w, http.StatusBadRequest, "invalid request body")
+        return
+    }
+
+    name := node.Name
+    zone := node.Zone
+    if body.Name != nil { name = *body.Name }
+    if body.Zone != nil { zone = *body.Zone }
+
+    api.meshServer.GetNodeRegistry().AssignNode(node.MAC, node.NodeID, name, zone)
+
+    if body.Type != nil {
+        adapterType, ok := adapterTypeFromString(*body.Type)
+        if !ok {
+            api.writeError(w, http.StatusBadRequest, "unknown type: "+*body.Type)
+            return
+        }
+        if err := api.meshServer.ConfigureNode(node.MAC, adapterType); err != nil {
+            api.writeError(w, http.StatusInternalServerError, "failed to configure node")
+            return
+        }
+    }
+
+    updated, _ := api.meshServer.GetNodeRegistry().GetNodeByID(id)
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: nodeToV1(updated, api.meshServer.GetHealthTimeout())})
+}
+
+func (api *APIServer) v1DeleteNode(w http.ResponseWriter, r *http.Request) {
+    id, err := parseNodeID(mux.Vars(r)["id"])
+    if err != nil {
+        api.writeError(w, http.StatusBadRequest, "invalid node id")
+        return
+    }
+    node, ok := api.meshServer.GetNodeRegistry().GetNodeByID(id)
+    if !ok {
+        api.writeError(w, http.StatusNotFound, "node not found")
+        return
+    }
+    api.meshServer.GetNodeRegistry().RemoveNode(node.MAC)
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Message: "node removed"})
+}
+
+func (api *APIServer) v1NodeCommand(w http.ResponseWriter, r *http.Request) {
+    id, err := parseNodeID(mux.Vars(r)["id"])
+    if err != nil {
+        api.writeError(w, http.StatusBadRequest, "invalid node id")
+        return
+    }
+    node, ok := api.meshServer.GetNodeRegistry().GetNodeByID(id)
+    if !ok {
+        api.writeError(w, http.StatusNotFound, "node not found")
+        return
+    }
+    var body struct {
+        Action string                 `json:"action"`
+        Params map[string]interface{} `json:"params"`
+    }
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Action == "" {
+        api.writeError(w, http.StatusBadRequest, "action is required")
+        return
+    }
+    if body.Action != "trigger" {
+        api.writeError(w, http.StatusNotImplemented, "action not supported")
+        return
+    }
+    payload := make([]byte, MaxDataLength)
+    payload[0] = 0xD0 // trigger placeholder opcode
+    if err := api.meshServer.SendNodeData(node.MAC, int32(AdapterTypeSerial), payload); err != nil {
+        api.writeError(w, http.StatusInternalServerError, "failed to send command")
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true})
+}
+
+// parseNodeID converts a URL path segment to a uint8 node ID (1-255).
+func parseNodeID(s string) (uint8, error) {
+    n, err := strconv.ParseUint(s, 10, 8)
+    if err != nil || n == 0 { return 0, fmt.Errorf("invalid node id") }
+    return uint8(n), nil
+}
+```
+
+Note: add `"fmt"` to the imports in `api_v1_nodes.go`.
+
+**Route registration in `api.go`** `setupRoutes()`:
+```go
+// /api/v1/nodes
+api.router.Handle("/api/v1/nodes", middleware(http.HandlerFunc(api.v1GetNodes))).Methods("GET")
+api.router.Handle("/api/v1/nodes/{id}", middleware(http.HandlerFunc(api.v1GetNode))).Methods("GET")
+api.router.Handle("/api/v1/nodes/{id}", middleware(http.HandlerFunc(api.v1UpdateNode))).Methods("PATCH")
+api.router.Handle("/api/v1/nodes/{id}", middleware(http.HandlerFunc(api.v1DeleteNode))).Methods("DELETE")
+api.router.Handle("/api/v1/nodes/{id}/command", middleware(http.HandlerFunc(api.v1NodeCommand))).Methods("POST")
+```
+
+- [ ] **Step 1: Write node type translation tests**
+
+  In `server/orchestrator/mesh/mesh_test.go`, add:
+  ```go
+  func TestAdapterTypeTranslation(t *testing.T) {
+      cases := []struct{ t int32; s string }{
+          {AdapterTypePIR, "pir"},
+          {AdapterTypeLED, "led"},
+          {AdapterTypeSerial, "serial"},
+          {AdapterTypeUnknown, "unknown"},
+          {999, "unknown"},
+      }
+      for _, c := range cases {
+          if got := adapterTypeToString(c.t); got != c.s {
+              t.Errorf("adapterTypeToString(%d) = %q, want %q", c.t, got, c.s)
+          }
+      }
+      if v, ok := adapterTypeFromString("pir"); !ok || v != AdapterTypePIR {
+          t.Errorf("adapterTypeFromString(pir): got %d,%v", v, ok)
+      }
+      if _, ok := adapterTypeFromString("serial"); ok {
+          t.Error("serial should not be writable via type string")
+      }
+      if _, ok := adapterTypeFromString("unknown"); ok {
+          t.Error("unknown should not be writable")
+      }
+  }
+  ```
+
+- [ ] **Step 2: Write node HTTP handler tests**
+
+  Create `server/orchestrator/mesh/api_v1_nodes_test.go`:
+  ```go
+  package mesh
+
+  import (
+      "encoding/json"
+      "net/http"
+      "testing"
+  )
+
+  func setupNodeForV1Test(t *testing.T, ms *MeshServer) {
+      t.Helper()
+      mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+      ms.nodeRegistry.AssignNode(mac, 7, "entrance-left", "lobby")
+      ms.nodeRegistry.UpdateNode(mac, AdapterTypePIR, 3600, 2)
+  }
+
+  func TestV1Nodes_GetAll_ReturnsAssignedNodes(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "GET", "/api/v1/nodes", nil)
+      if w.Code != http.StatusOK { t.Fatalf("status: %d", w.Code) }
+      var resp APIResponse
+      json.NewDecoder(w.Body).Decode(&resp)
+      if !resp.Success { t.Error("expected success") }
+  }
+
+  func TestV1Nodes_GetAll_ExcludesUnassignedNodes(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      // Register node with UpdateNode only — no NodeID assigned
+      mac := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+      ms.nodeRegistry.UpdateNode(mac, AdapterTypePIR, 100, 1)
+      w := v1Request(t, api, "GET", "/api/v1/nodes", nil)
+      var resp APIResponse
+      json.NewDecoder(w.Body).Decode(&resp)
+      data, _ := json.Marshal(resp.Data)
+      var nodes []NodeV1
+      json.Unmarshal(data, &nodes)
+      if len(nodes) != 0 { t.Errorf("got %d nodes, want 0 (unassigned excluded)", len(nodes)) }
+  }
+
+  func TestV1Nodes_GetByID_ReturnsNode(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "GET", "/api/v1/nodes/7", nil)
+      if w.Code != http.StatusOK { t.Fatalf("status: %d", w.Code) }
+  }
+
+  func TestV1Nodes_GetByID_Returns404_WhenMissing(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      w := v1Request(t, api, "GET", "/api/v1/nodes/99", nil)
+      if w.Code != http.StatusNotFound { t.Errorf("got %d, want 404", w.Code) }
+  }
+
+  func TestV1Nodes_Update_ChangesNameAndZone(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "PATCH", "/api/v1/nodes/7",
+          map[string]string{"name": "stage-right", "zone": "stage"})
+      if w.Code != http.StatusOK { t.Fatalf("status: %d", w.Code) }
+      node, _ := ms.nodeRegistry.GetNodeByID(7)
+      if node.Name != "stage-right" { t.Errorf("Name: %q", node.Name) }
+      if node.Zone != "stage" { t.Errorf("Zone: %q", node.Zone) }
+  }
+
+  func TestV1Nodes_Update_UnknownType_Returns400(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "PATCH", "/api/v1/nodes/7", map[string]string{"type": "toaster"})
+      if w.Code != http.StatusBadRequest { t.Errorf("got %d, want 400", w.Code) }
+  }
+
+  func TestV1Nodes_Delete_RemovesNode(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "DELETE", "/api/v1/nodes/7", nil)
+      if w.Code != http.StatusOK { t.Fatalf("delete: %d", w.Code) }
+      if _, ok := ms.nodeRegistry.GetNodeByID(7); ok { t.Error("node still exists after delete") }
+  }
+
+  func TestV1Nodes_Command_UnsupportedAction_Returns501(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      setupNodeForV1Test(t, ms)
+      w := v1Request(t, api, "POST", "/api/v1/nodes/7/command",
+          map[string]interface{}{"action": "explode", "params": map[string]interface{}{}})
+      if w.Code != http.StatusNotImplemented { t.Errorf("got %d, want 501", w.Code) }
+  }
+  ```
+
+- [ ] **Step 3: Run to verify failure**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestAdapterType|TestV1Nodes" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile errors.
+
+- [ ] **Step 4: Create `api_v1_types.go` and `api_v1_nodes.go`; register routes in `api.go`**
+
+  Write both files from Context above. Register the 5 node routes in `setupRoutes()`.
+
+- [ ] **Step 5: Run targeted tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestAdapterType|TestV1Nodes" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 6: Run full suite**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok`.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/api_v1_types.go \
+    server/orchestrator/mesh/api_v1_nodes.go \
+    server/orchestrator/mesh/api_v1_nodes_test.go \
+    server/orchestrator/mesh/api.go \
+    server/orchestrator/mesh/mesh_test.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit \
+    -m "feat(server): /api/v1/nodes CRUD + command endpoints, type translation helpers"
+  ```
+
+---
+
+### Task 4: SSE endpoint + /api/v1/events + status + enrollments
+
+**Files:**
+- Create: `server/orchestrator/mesh/api_v1_events.go` — SSE handler
+- Create: `server/orchestrator/mesh/api_v1_status.go` — `/api/v1/status` handler
+- Create: `server/orchestrator/mesh/api_v1_enrollments.go` — `/api/v1/enrollments/*` handlers
+- Modify: `server/orchestrator/mesh/api.go` — register all remaining `/api/v1/` routes
+
+**Interfaces:**
+- Consumes (from Task 1): `(*MeshServer).GetEventBroker() *EventBroker`, `(*EventBroker).Subscribe() chan Event`, `(*EventBroker).Unsubscribe(ch chan Event)`
+- Consumes (from Task 3): `adapterTypeFromString(s string) (int32, bool)` — used in v1 approve to map type → adapterType
+
+**Context for implementer:**
+
+**SSE format** (exact, per spec):
+```
+event: motion
+data: {"nodeId":7,"name":"entrance-left","zone":"lobby","hopCount":2,"timestamp":"2026-06-29T14:32:00Z"}
+
+```
+(blank line between events is part of the `\n\n` in the format string)
+
+**`api_v1_events.go`:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+)
+
+func (api *APIServer) v1Events(w http.ResponseWriter, r *http.Request) {
+    flusher, ok := w.(http.Flusher)
+    if !ok {
+        http.Error(w, "streaming not supported", http.StatusInternalServerError)
+        return
+    }
+    w.Header().Set("Content-Type", "text/event-stream")
+    w.Header().Set("Cache-Control", "no-cache")
+    w.Header().Set("Connection", "keep-alive")
+    w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering if behind proxy
+
+    ch := api.meshServer.GetEventBroker().Subscribe()
+    defer api.meshServer.GetEventBroker().Unsubscribe(ch)
+
+    for {
+        select {
+        case event, open := <-ch:
+            if !open { return }
+            data, err := json.Marshal(event.Data)
+            if err != nil { continue }
+            fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, data)
+            flusher.Flush()
+        case <-r.Context().Done():
+            return
+        }
+    }
+}
+```
+
+**`api_v1_status.go`:**
+```go
+package mesh
+
+import "net/http"
+
+func (api *APIServer) v1Status(w http.ResponseWriter, r *http.Request) {
+    timeout := api.meshServer.GetHealthTimeout()
+    allNodes := api.meshServer.GetNodeRegistry().GetAllNodes()
+    total := 0
+    online := 0
+    for _, n := range allNodes {
+        if n.NodeID > 0 {
+            total++
+            // import "time" for time.Since
+            if isOnline(n, timeout) { online++ }
+        }
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{
+        Success: true,
+        Data: map[string]interface{}{
+            "nodes": map[string]int{
+                "total":   total,
+                "online":  online,
+                "offline": total - online,
+            },
+            "mesh": map[string]bool{
+                "masterOnline": api.meshServer.IsRunning(),
+            },
+        },
+    })
+}
+```
+
+Add helper at bottom of `api_v1_status.go`:
+```go
+import "time"
+
+func isOnline(n *NodeInfo, timeout time.Duration) bool {
+    return time.Since(n.LastSeen) <= timeout
+}
+```
+
+**`api_v1_enrollments.go`:**
+```go
+package mesh
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "github.com/gorilla/mux"
+)
+
+func (api *APIServer) v1GetPendingEnrollments(w http.ResponseWriter, r *http.Request) {
+    pending := api.meshServer.GetPendingEnrollments()
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: pending})
+}
+
+func (api *APIServer) v1GetAllEnrollments(w http.ResponseWriter, r *http.Request) {
+    all := api.meshServer.GetAuthRegistry().GetAll()
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Data: all})
+}
+
+func (api *APIServer) v1ApproveEnrollment(w http.ResponseWriter, r *http.Request) {
+    mac := mux.Vars(r)["mac"]
+    var body struct {
+        Name   string `json:"name"`
+        Zone   string `json:"zone"`
+        Type   string `json:"type"`
+        NodeID uint8  `json:"nodeId"`
+    }
+    if r.Body != nil {
+        _ = json.NewDecoder(r.Body).Decode(&body) // body optional
+    }
+    params := ApprovalParams{
+        NodeID:         body.NodeID,
+        Name:           body.Name,
+        Zone:           body.Zone,
+        AdapterTypeStr: body.Type,
+    }
+    if err := api.meshServer.ApproveEnrollment(mac, params); err != nil {
+        api.writeError(w, http.StatusBadRequest, err.Error())
+        return
+    }
+    if body.Type != "" {
+        if adapterType, ok := adapterTypeFromString(body.Type); ok {
+            // look up node by MAC to get the []byte form
+            // ApproveEnrollment has already assigned the node; find it
+            registry := api.meshServer.GetAuthRegistry()
+            if node, err := registry.Get(mac); err == nil {
+                _ = api.meshServer.ConfigureNode(node.MAC[:], adapterType)
+            }
+        }
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Message: "enrollment approved"})
+}
+
+func (api *APIServer) v1RejectEnrollment(w http.ResponseWriter, r *http.Request) {
+    mac := mux.Vars(r)["mac"]
+    if err := api.meshServer.RejectEnrollment(mac); err != nil {
+        api.writeError(w, http.StatusBadRequest, err.Error())
+        return
+    }
+    api.writeJSON(w, http.StatusOK, APIResponse{Success: true, Message: "enrollment rejected"})
+}
+```
+
+Note: `api.meshServer.GetAuthRegistry().Get(mac)` — check if `nodeauth.Registry` has a `Get(mac string) (*nodeauth.NodeAuth, error)` method. If not, use `GetAll()` and filter by MAC string. Use whichever pattern already exists in the auth registry.
+
+**Route registration in `api.go`** `setupRoutes()`:
+```go
+// /api/v1/events
+api.router.Handle("/api/v1/events", middleware(http.HandlerFunc(api.v1Events))).Methods("GET")
+
+// /api/v1/status
+api.router.Handle("/api/v1/status", middleware(http.HandlerFunc(api.v1Status))).Methods("GET")
+
+// /api/v1/enrollments
+api.router.Handle("/api/v1/enrollments/pending", middleware(http.HandlerFunc(api.v1GetPendingEnrollments))).Methods("GET")
+api.router.Handle("/api/v1/enrollments", middleware(http.HandlerFunc(api.v1GetAllEnrollments))).Methods("GET")
+api.router.Handle("/api/v1/enrollments/{mac}/approve", middleware(http.HandlerFunc(api.v1ApproveEnrollment))).Methods("POST")
+api.router.Handle("/api/v1/enrollments/{mac}/reject", middleware(http.HandlerFunc(api.v1RejectEnrollment))).Methods("POST")
+```
+
+**Testing SSE:** Use a `testFlusher` wrapper to capture streamed output:
+```go
+// testFlusher wraps httptest.ResponseRecorder and implements http.Flusher.
+type testFlusher struct {
+    *httptest.ResponseRecorder
+}
+func (tf *testFlusher) Flush() {}
+```
+
+For the SSE test:
+1. Create a `testFlusher`
+2. Run `api.v1Events(tf, req)` in a goroutine (it blocks until context cancels)
+3. Publish an event via `broker.Publish(...)`
+4. Cancel the request context to exit the handler
+5. Assert the body contains `"event: motion"` and `"data: "`
+
+```go
+func TestV1Events_StreamsEventToClient(t *testing.T) {
+    api, ms := newV1TestServer(t)
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    req := httptest.NewRequest("GET", "/api/v1/events", nil).WithContext(ctx)
+    req.Header.Set("Authorization", "Bearer test-key")
+    tf := &testFlusher{httptest.NewRecorder()}
+
+    done := make(chan struct{})
+    go func() {
+        defer close(done)
+        api.v1Events(tf, req)
+    }()
+
+    // Give handler time to subscribe
+    time.Sleep(10 * time.Millisecond)
+
+    raw, _ := json.Marshal(map[string]interface{}{"nodeId": 7})
+    ms.GetEventBroker().Publish(Event{Type: EventMotion, Data: raw, Timestamp: time.Now()})
+
+    // Give handler time to write
+    time.Sleep(50 * time.Millisecond)
+    cancel()
+    <-done
+
+    body := tf.Body.String()
+    if !strings.Contains(body, "event: motion") {
+        t.Errorf("body missing event line; got: %q", body)
+    }
+    if !strings.Contains(body, "data: ") {
+        t.Errorf("body missing data line; got: %q", body)
+    }
+}
+```
+
+Import `"context"`, `"strings"`, `"time"`, `"encoding/json"`, `"net/http/httptest"` at top of the test file.
+
+- [ ] **Step 1: Write SSE, status, and enrollment tests**
+
+  Create `server/orchestrator/mesh/api_v1_events_test.go`:
+  ```go
+  package mesh
+
+  import (
+      "context"
+      "encoding/json"
+      "net/http"
+      "net/http/httptest"
+      "strings"
+      "testing"
+      "time"
+  )
+
+  type testFlusher struct {
+      *httptest.ResponseRecorder
+  }
+  func (tf *testFlusher) Flush() {}
+
+  func TestV1Events_StreamsEventToClient(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      ctx, cancel := context.WithCancel(context.Background())
+      defer cancel()
+
+      req := httptest.NewRequest("GET", "/api/v1/events", nil).WithContext(ctx)
+      req.Header.Set("Authorization", "Bearer test-key")
+      tf := &testFlusher{httptest.NewRecorder()}
+
+      done := make(chan struct{})
+      go func() {
+          defer close(done)
+          api.v1Events(tf, req)
+      }()
+
+      time.Sleep(10 * time.Millisecond)
+      raw, _ := json.Marshal(map[string]interface{}{"nodeId": 7})
+      ms.GetEventBroker().Publish(Event{Type: EventMotion, Data: raw, Timestamp: time.Now()})
+      time.Sleep(50 * time.Millisecond)
+      cancel()
+      <-done
+
+      body := tf.Body.String()
+      if !strings.Contains(body, "event: motion") {
+          t.Errorf("body missing event line; got: %q", body)
+      }
+      if !strings.Contains(body, "data: ") {
+          t.Errorf("body missing data line; got: %q", body)
+      }
+  }
+
+  func TestV1Events_NonFlusher_Returns500(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      req := httptest.NewRequest("GET", "/api/v1/events", nil)
+      req.Header.Set("Authorization", "Bearer test-key")
+      w := httptest.NewRecorder() // does not implement http.Flusher
+      api.v1Events(w, req)
+      if w.Code != http.StatusInternalServerError {
+          t.Errorf("got %d, want 500", w.Code)
+      }
+  }
+
+  func TestV1Status_ReturnsStructuredStatus(t *testing.T) {
+      api, ms := newV1TestServer(t)
+      mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+      ms.nodeRegistry.AssignNode(mac, 1, "test-node", "lobby")
+      ms.nodeRegistry.UpdateNode(mac, AdapterTypePIR, 100, 1)
+
+      w := v1Request(t, api, "GET", "/api/v1/status", nil)
+      if w.Code != http.StatusOK { t.Fatalf("status: %d", w.Code) }
+      var resp APIResponse
+      json.NewDecoder(w.Body).Decode(&resp)
+      if !resp.Success { t.Error("expected success") }
+  }
+
+  func TestV1Enrollments_GetPending_ReturnsOK(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      w := v1Request(t, api, "GET", "/api/v1/enrollments/pending", nil)
+      if w.Code != http.StatusOK { t.Fatalf("got %d, want 200", w.Code) }
+  }
+
+  func TestV1Enrollments_GetAll_ReturnsOK(t *testing.T) {
+      api, _ := newV1TestServer(t)
+      w := v1Request(t, api, "GET", "/api/v1/enrollments", nil)
+      if w.Code != http.StatusOK { t.Fatalf("got %d, want 200", w.Code) }
+  }
+  ```
+
+- [ ] **Step 2: Run to verify failure**
+
+  ```bash
+  cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer/server/orchestrator
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestV1Events|TestV1Status|TestV1Enrollments" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: compile errors.
+
+- [ ] **Step 3: Create `api_v1_events.go`, `api_v1_status.go`, `api_v1_enrollments.go`; register routes in `api.go`**
+
+  Write all three files from Context above. Check `nodeauth.Registry` for the `Get(mac)` method before writing `v1ApproveEnrollment` — if it doesn't exist, filter `GetAll()` in the handler instead. Add all remaining `/api/v1/` routes to `setupRoutes()`.
+
+- [ ] **Step 4: Run targeted tests to verify they pass**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -run "TestV1Events|TestV1Status|TestV1Enrollments" -count=1 2>&1 | tail -5
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5: Run full test suite**
+
+  ```bash
+  GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 2>&1 | tail -5
+  ```
+
+  Expected: `ok github.com/superbrobenji/motionServer/mesh`.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer add \
+    server/orchestrator/mesh/api_v1_events.go \
+    server/orchestrator/mesh/api_v1_events_test.go \
+    server/orchestrator/mesh/api_v1_status.go \
+    server/orchestrator/mesh/api_v1_enrollments.go \
+    server/orchestrator/mesh/api.go
+  git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer commit \
+    -m "feat(server): /api/v1/events SSE, /api/v1/status, /api/v1/enrollments"
+  ```

--- a/docs/superpowers/plans/nodes-phase7-fixes-cleanup.md
+++ b/docs/superpowers/plans/nodes-phase7-fixes-cleanup.md
@@ -1,0 +1,356 @@
+# Phase 7: Bug Fixes & Firmware Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the JOIN_ACK rejection frame MAC field bug (spec §5.13) and decouple Mesh from Serial_Adapter via callback (spec §5.15).
+
+**Architecture:** Two independent changes — a one-line server fix to send rejection frames to the correct MAC, and a firmware refactor that replaces a static call with a registered callback to eliminate a circular dependency.
+
+**Tech Stack:** Go 1.22 (server), C++17 (firmware), GTest (firmware unit tests), nanopb/protobuf3.
+
+## Pre-Implementation Audit
+
+The following spec sections from §5 were already implemented before Phase 7 and require no changes:
+
+| Spec | Status | Evidence |
+|---|---|---|
+| §5.5 Remove 3-chunk enrollment | **Done** | `Mesh.cpp:984-997` sends single `MESH_TYPE_ENROLLMENT`; `GTest EnrollmentTest::SendsSingleEspNowMessage` passes |
+| §5.12 Online timeout 75s | **Done** | `api.go:267` `GetOnlineNodes(75 * time.Second)` already present |
+| §5.14 Remove EEPROM wipe on WDT | **Done** | `main.ino:104-107` halts without `em.clearAll()` |
+| §5.13 Firmware side (targetMacAddress) | **Done** | `Serial_Adapter.cpp:402` calls `enrollPeer(msg.targetMacAddress, …)`; `decodeMeshMessage` copies `pbMsg.targetMacAddress` at line 281 |
+
+Only §5.13 server-side (rejection frame) and §5.15 remain.
+
+## Global Constraints
+
+- Go module root: `motionSensorServer/server/orchestrator/` — all Go paths relative to this
+- Go test command: `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1`
+- Firmware test command: `cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes && cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure`
+- No `gh` commands. No `ben-clearscore` in git identity.
+- Local git identity: `git config user.email "49689582+superbrobenji@users.noreply.github.com"` (set per-repo before committing)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `mesh/server.go` | Fix `OriginMacAddress` → `TargetMacAddress` in `RejectEnrollment` |
+| `mesh/server_enrollment_test.go` | Add `TestRejectEnrollment_SendsJoinAckToTargetMac` |
+| `main/src/Mesh/Mesh.h` | Add `EnrollmentRelayFn` typedef, `setEnrollmentRelayFn()` declaration, `_enrollmentRelayFn` field, `drainPendingEnrollment()` private declaration |
+| `main/src/Mesh/Mesh.cpp` | Remove `#include Serial_Adapter.h`, add `setEnrollmentRelayFn()` impl, extract drain to `drainPendingEnrollment()`, update `loop()` to call it |
+| `tests/mocks/mesh_logic_impl.cpp` | Add `setEnrollmentRelayFn()` + `drainPendingEnrollment()` implementations (mirrors Mesh.cpp) |
+| `tests/unit/test_mesh_logic.cpp` | Add `EnrollmentRelayCallbackTest` fixture + two tests |
+| `main/main.ino` | Register `Serial_Adapter::relayEnrollmentToServer` as callback after `mesh.init()` |
+
+---
+
+### Task 1: Fix §5.13 — Rejection JOIN_ACK Uses TargetMacAddress
+
+**Files:**
+- Modify: `mesh/server.go:544-548`
+- Test: `mesh/server_enrollment_test.go`
+
+**Interfaces:**
+- Consumes: `enrollTestNode(t, ms)` helper (lines 17-27 of `server_enrollment_test.go`) — returns `(macStr string, pubKey [32]byte)`, MAC is `{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}`
+- Consumes: `decodeWrittenFrame(t, mockPort)` helper (lines 29-45) — decodes one frame from `mockPort.writeOffset`, returns `*MeshMessage`
+- Produces: no new public API
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mesh/server_enrollment_test.go` after line 105:
+
+```go
+func TestRejectEnrollment_SendsJoinAckToTargetMac(t *testing.T) {
+	ms := newTestMeshServer(t)
+	mockPort := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(mockPort)
+
+	macStr, _ := enrollTestNode(t, ms)
+
+	if err := ms.RejectEnrollment(macStr); err != nil {
+		t.Fatalf("RejectEnrollment returned error: %v", err)
+	}
+
+	msg := decodeWrittenFrame(t, mockPort)
+	wantMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	if !bytes.Equal(msg.TargetMacAddress, wantMAC) {
+		t.Errorf("TargetMacAddress = %x, want %x", msg.TargetMacAddress, wantMAC)
+	}
+	if len(msg.OriginMacAddress) != 0 {
+		t.Errorf("OriginMacAddress should be absent in rejection frame, got %x", msg.OriginMacAddress)
+	}
+	if len(msg.PublicKey) != 0 {
+		t.Errorf("PublicKey should be absent (rejection signal), got %x", msg.PublicKey)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestRejectEnrollment_SendsJoinAckToTargetMac
+```
+
+Expected: FAIL — `TargetMacAddress = [], want [aabbccddeeff]` (currently uses `OriginMacAddress`).
+
+- [ ] **Step 3: Apply the fix in `mesh/server.go`**
+
+Find `RejectEnrollment` (around line 542). Change:
+
+```go
+// BEFORE:
+rejectMsg := &MeshMessage{
+    MessageType:      MessageTypeJoinAck,
+    OriginMacAddress: mac[:],
+    // PublicKey intentionally absent — rejection signal
+}
+```
+
+To:
+
+```go
+// AFTER:
+rejectMsg := &MeshMessage{
+    MessageType:      MessageTypeJoinAck,
+    TargetMacAddress: mac[:],
+    // PublicKey intentionally absent — rejection signal
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mesh/server.go mesh/server_enrollment_test.go
+git commit -m "fix: rejection JOIN_ACK uses TargetMacAddress (spec §5.13)"
+```
+
+---
+
+### Task 2: Decouple Mesh from Serial_Adapter via Callback (§5.15)
+
+**Files:**
+- Modify: `main/src/Mesh/Mesh.h`
+- Modify: `main/src/Mesh/Mesh.cpp`
+- Modify: `tests/mocks/mesh_logic_impl.cpp`
+- Test: `tests/unit/test_mesh_logic.cpp`
+- Modify: `main/main.ino`
+
+**Interfaces:**
+- Consumes: `Mesh::_pendingEnrollmentRelay`, `_pendingEnrollmentMac[6]`, `_pendingEnrollmentPubKey[32]` — existing private fields in Mesh.h:189-192
+- Consumes: `Mesh::drainRecvQueue()` at Mesh.h:206 — existing private drain method, same pattern to follow
+- Produces:
+  - `typedef void (*EnrollmentRelayFn)(const uint8_t mac[6], const uint8_t pubKey[32])` — in `Mesh.h`
+  - `void Mesh::setEnrollmentRelayFn(EnrollmentRelayFn fn)` — public method
+  - `void Mesh::drainPendingEnrollment()` — private method; called from `loop()`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_mesh_logic.cpp` after the existing `EnrollmentTest` fixture (after line 567):
+
+```cpp
+// ---- EnrollmentRelayCallbackTest ----
+
+static const uint8_t* g_capturedMac = nullptr;
+static const uint8_t* g_capturedKey = nullptr;
+
+static void captureRelayFn(const uint8_t mac[6], const uint8_t pubKey[32]) {
+  g_capturedMac = mac;
+  g_capturedKey = pubKey;
+}
+
+class EnrollmentRelayCallbackTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    g_capturedMac = nullptr;
+    g_capturedKey = nullptr;
+    EEPROM.reset();
+  }
+};
+
+TEST_F(EnrollmentRelayCallbackTest, DrainCallsRegisteredCallback) {
+  Mesh mesh;
+  mesh.isMaster = true;
+  mesh.setEnrollmentRelayFn(captureRelayFn);
+
+  static constexpr uint8_t kMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  static constexpr uint8_t kKey[32] = {
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+      0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+      0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20};
+
+  memcpy(mesh._pendingEnrollmentMac, kMac, 6);
+  memcpy(mesh._pendingEnrollmentPubKey, kKey, 32);
+  mesh._pendingEnrollmentRelay = true;
+
+  mesh.drainPendingEnrollment();
+
+  EXPECT_FALSE(mesh._pendingEnrollmentRelay) << "flag must clear after drain";
+  ASSERT_NE(g_capturedMac, nullptr) << "callback was not called";
+  EXPECT_EQ(memcmp(g_capturedMac, kMac, 6), 0) << "wrong MAC passed to callback";
+  EXPECT_EQ(memcmp(g_capturedKey, kKey, 32), 0) << "wrong pubKey passed to callback";
+}
+
+TEST_F(EnrollmentRelayCallbackTest, DrainWithNoCallbackClearsFlag) {
+  Mesh mesh;
+  mesh.isMaster = true;
+  // No callback registered.
+
+  mesh._pendingEnrollmentRelay = true;
+  mesh.drainPendingEnrollment();
+
+  EXPECT_FALSE(mesh._pendingEnrollmentRelay) << "flag must clear even with no callback";
+  EXPECT_EQ(g_capturedMac, nullptr) << "callback must not fire when unregistered";
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail to compile**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+cmake -B build -S . && cmake --build build 2>&1 | head -30
+```
+
+Expected: compile error — `setEnrollmentRelayFn` and `drainPendingEnrollment` not declared.
+
+- [ ] **Step 3: Update `main/src/Mesh/Mesh.h`**
+
+Add after the `setIsMaster` public method block (find the public enrollment methods section around line 255):
+
+```cpp
+// Enrollment relay callback — registered by Serial_Adapter owner (main.ino).
+// Called from loop() when a pending enrollment is ready to relay to the server.
+typedef void (*EnrollmentRelayFn)(const uint8_t mac[6], const uint8_t pubKey[32]);
+void setEnrollmentRelayFn(EnrollmentRelayFn fn);
+```
+
+Add in the private section (after `_pendingEnrollmentPubKey[32]{}` at line 192):
+
+```cpp
+EnrollmentRelayFn _enrollmentRelayFn = nullptr;
+```
+
+Add in the private methods section (after `void drainRecvQueue();` at line 206):
+
+```cpp
+void drainPendingEnrollment();
+```
+
+- [ ] **Step 4: Update `main/src/Mesh/Mesh.cpp`**
+
+**4a.** Remove line 6:
+```cpp
+// DELETE THIS LINE:
+#include "src/Adapter/Serial_Adapter/Serial_Adapter.h" // for relayEnrollmentToServer
+```
+
+**4b.** Add `setEnrollmentRelayFn` implementation. Place it near the other setter methods in Mesh.cpp:
+
+```cpp
+void Mesh::setEnrollmentRelayFn(EnrollmentRelayFn fn) {
+  _enrollmentRelayFn = fn;
+}
+```
+
+**4c.** Extract the enrollment drain into `drainPendingEnrollment()`. Find the loop drain block (around lines 1082-1087):
+
+```cpp
+// BEFORE (in loop()):
+if (_pendingEnrollmentRelay) {
+    _pendingEnrollmentRelay = false;
+    planetopia::adapter::Serial_Adapter::relayEnrollmentToServer(_pendingEnrollmentMac,
+                                                                 _pendingEnrollmentPubKey);
+}
+```
+
+**4c-i.** Add the new method (place before `loop()`):
+
+```cpp
+void Mesh::drainPendingEnrollment() {
+  if (!_pendingEnrollmentRelay) return;
+  _pendingEnrollmentRelay = false;
+  if (_enrollmentRelayFn) {
+    _enrollmentRelayFn(_pendingEnrollmentMac, _pendingEnrollmentPubKey);
+  }
+}
+```
+
+**4c-ii.** Replace the old drain block in `loop()` with a single call:
+
+```cpp
+// AFTER (in loop()):
+drainPendingEnrollment();
+```
+
+- [ ] **Step 5: Update `tests/mocks/mesh_logic_impl.cpp`**
+
+The mock implementation mirrors Mesh.cpp methods for host compilation. Add at the end of the file (before the closing `}` namespace braces):
+
+```cpp
+void Mesh::setEnrollmentRelayFn(EnrollmentRelayFn fn) {
+  _enrollmentRelayFn = fn;
+}
+
+void Mesh::drainPendingEnrollment() {
+  if (!_pendingEnrollmentRelay) return;
+  _pendingEnrollmentRelay = false;
+  if (_enrollmentRelayFn) {
+    _enrollmentRelayFn(_pendingEnrollmentMac, _pendingEnrollmentPubKey);
+  }
+}
+```
+
+- [ ] **Step 6: Register callback in `main/main.ino`**
+
+After `mesh.init()` (line 230), add:
+
+```cpp
+mesh.setEnrollmentRelayFn(Serial_Adapter::relayEnrollmentToServer);
+```
+
+The full context:
+
+```cpp
+if (!mesh.init()) {
+    // ... fatal error handling
+}
+
+mesh.setEnrollmentRelayFn(Serial_Adapter::relayEnrollmentToServer);
+
+// Nodes must always receive — modem sleep drops ESP-NOW packets without AP sync
+esp_wifi_set_ps(WIFI_PS_NONE);
+```
+
+- [ ] **Step 7: Build and run firmware tests**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests PASS, including the two new `EnrollmentRelayCallbackTest` tests.
+
+- [ ] **Step 8: Verify Serial_Adapter.h is no longer included from Mesh.cpp**
+
+```bash
+grep -n "Serial_Adapter" /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes/main/src/Mesh/Mesh.cpp
+```
+
+Expected: no output.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+git add main/src/Mesh/Mesh.h main/src/Mesh/Mesh.cpp tests/mocks/mesh_logic_impl.cpp tests/unit/test_mesh_logic.cpp main/main.ino
+git commit -m "refactor: decouple Mesh from Serial_Adapter via EnrollmentRelayFn callback (spec §5.15)"
+```

--- a/docs/superpowers/plans/nodes-phase8-hotswap.md
+++ b/docs/superpowers/plans/nodes-phase8-hotswap.md
@@ -1,0 +1,597 @@
+# Phase 8: Node Hotswap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow a failed node to be physically replaced by a new ESP32 that inherits the original's logical ID, name, zone, and adapter type — without requiring the operator to re-enter any of that information.
+
+**Architecture:** Server-only change. The new ESP32 enrolls normally (firmware is unchanged). When the operator approves with an existing `nodeId`, `ApproveEnrollment` detects the hotswap, inherits all unspecified fields from the old node, marks the old registry entry as `"replaced"`, and sends `OP_CONFIG_SET` with the inherited adapter type. The old entry's `nodeId` is cleared so it no longer appears in API responses (the existing `NodeID > 0` filter in `v1GetNodes` handles exclusion automatically).
+
+**Tech Stack:** Go 1.22, gorilla/mux, nanopb/protobuf3 serial frames.
+
+## Global Constraints
+
+- Go module root: `motionSensorServer/server/orchestrator/` — all paths relative to this
+- Go test command: `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1`
+- `AdapterTypeUnknown int32 = -1` (not 0 — `AdapterTypePIR = 0` is a valid real type)
+- MAC keys in `NodeRegistry.nodes` are colon-separated lowercase (from `macToString`: `"aa:bb:cc:dd:ee:ff"`)
+- MAC strings in `authRegistry` / URL paths are no-colon lowercase (from `enrollTestNode`: `"aabbccddeeff"`)
+- No `gh` commands. No `ben-clearscore` in git identity.
+- Set per-repo before committing: `git config user.email "49689582+superbrobenji@users.noreply.github.com"` and `git config user.name "superbrobenji"`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `mesh/node_registry.go` | Add `Status`/`ReplacedBy` to `NodeInfo` + `persistedNode`; update `Persist`/`Load`; add `MarkReplaced()` |
+| `mesh/mesh_test.go` | Add 3 tests for `MarkReplaced` |
+| `mesh/server.go` | Add hotswap detection + field inheritance + `MarkReplaced` call + OP_CONFIG_SET send in `ApproveEnrollment`; add `bytes` import |
+| `mesh/server_enrollment_test.go` | Add `enrollTestNodeWithMAC` helper + 3 hotswap tests for `ApproveEnrollment` |
+| `mesh/api_v1_nodes_test.go` | Add 1 integration test: hotswap approval → old node excluded from GET /api/v1/nodes |
+
+---
+
+### Task 1: Add Status/ReplacedBy fields and MarkReplaced to NodeRegistry
+
+**Files:**
+- Modify: `mesh/node_registry.go`
+- Test: `mesh/mesh_test.go`
+
+**Interfaces:**
+- Produces: `func (nr *NodeRegistry) MarkReplaced(mac []byte, replacedByMACStr string)` — sets `Status = "replaced"`, `ReplacedBy = replacedByMACStr`, `NodeID = 0` on the node with the given MAC; no-op if MAC not found
+
+- [ ] **Step 1: Write three failing tests in `mesh/mesh_test.go`**
+
+Add after the existing node registry tests (search for `TestGetOnlineNodes` to find the right area):
+
+```go
+func TestMarkReplaced_SetsStatusAndClearsNodeID(t *testing.T) {
+	nr := NewNodeRegistry()
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	nr.AssignNode(mac, 7, "entrance-left", "lobby")
+
+	nr.MarkReplaced(mac, "11:22:33:44:55:66")
+
+	node, ok := nr.GetNode(mac)
+	if !ok {
+		t.Fatal("node must still exist in registry after MarkReplaced")
+	}
+	if node.Status != "replaced" {
+		t.Errorf("Status = %q, want %q", node.Status, "replaced")
+	}
+	if node.ReplacedBy != "11:22:33:44:55:66" {
+		t.Errorf("ReplacedBy = %q, want %q", node.ReplacedBy, "11:22:33:44:55:66")
+	}
+	if node.NodeID != 0 {
+		t.Errorf("NodeID = %d, want 0 after replacement", node.NodeID)
+	}
+}
+
+func TestMarkReplaced_ReplacedNodeNotReturnedByGetNodeByID(t *testing.T) {
+	nr := NewNodeRegistry()
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	nr.AssignNode(mac, 7, "entrance-left", "lobby")
+
+	nr.MarkReplaced(mac, "11:22:33:44:55:66")
+
+	_, ok := nr.GetNodeByID(7)
+	if ok {
+		t.Error("GetNodeByID(7) must not return a replaced node")
+	}
+}
+
+func TestMarkReplaced_PersistsAndLoadsCorrectly(t *testing.T) {
+	nr := NewNodeRegistry()
+	mac := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	nr.AssignNode(mac, 7, "entrance-left", "lobby")
+	nr.MarkReplaced(mac, "11:22:33:44:55:66")
+
+	path := t.TempDir() + "/nodes.json"
+	if err := nr.Persist(path); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	nr2 := NewNodeRegistry()
+	if err := nr2.Load(path); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	node, ok := nr2.GetNode(mac)
+	if !ok {
+		t.Fatal("replaced node must survive Persist/Load round-trip")
+	}
+	if node.Status != "replaced" {
+		t.Errorf("Status after load = %q, want %q", node.Status, "replaced")
+	}
+	if node.ReplacedBy != "11:22:33:44:55:66" {
+		t.Errorf("ReplacedBy after load = %q, want %q", node.ReplacedBy, "11:22:33:44:55:66")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestMarkReplaced
+```
+
+Expected: compile error — `MarkReplaced` not declared.
+
+- [ ] **Step 3: Add Status and ReplacedBy fields to NodeInfo and persistedNode in `mesh/node_registry.go`**
+
+In `NodeInfo` (around line 15), add two new fields after `Zone`:
+
+```go
+type NodeInfo struct {
+	MAC        []byte    `json:"mac"`
+	MACString  string    `json:"macString"`
+	AdapterType int32    `json:"adapterType"`
+	Uptime     uint32    `json:"uptime"`
+	LastSeen   time.Time `json:"lastSeen"`
+	HopCount   uint32    `json:"hopCount"`
+	NodeID     uint8     `json:"nodeId,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Zone       string    `json:"zone,omitempty"`
+	Status     string    `json:"status,omitempty"`
+	ReplacedBy string    `json:"replacedBy,omitempty"`
+}
+```
+
+In `persistedNode` (around line 211), add the same two fields after `Zone`:
+
+```go
+type persistedNode struct {
+	MAC         string    `json:"mac"`
+	AdapterType int32     `json:"adapterType"`
+	Uptime      uint32    `json:"uptime"`
+	LastSeen    time.Time `json:"lastSeen"`
+	HopCount    uint32    `json:"hopCount"`
+	NodeID      uint8     `json:"nodeId,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Zone        string    `json:"zone,omitempty"`
+	Status      string    `json:"status,omitempty"`
+	ReplacedBy  string    `json:"replacedBy,omitempty"`
+}
+```
+
+- [ ] **Step 4: Update Persist to include the new fields**
+
+In `Persist` (around line 223), update the `persistedNode` literal inside the loop:
+
+```go
+entries = append(entries, persistedNode{
+    MAC:         n.MACString,
+    AdapterType: n.AdapterType,
+    Uptime:      n.Uptime,
+    LastSeen:    n.LastSeen,
+    HopCount:    n.HopCount,
+    NodeID:      n.NodeID,
+    Name:        n.Name,
+    Zone:        n.Zone,
+    Status:      n.Status,
+    ReplacedBy:  n.ReplacedBy,
+})
+```
+
+- [ ] **Step 5: Update Load to populate the new fields**
+
+In `Load` (around line 273), update the `NodeInfo` literal inside the loop:
+
+```go
+nr.nodes[e.MAC] = &NodeInfo{
+    MAC:         mac,
+    MACString:   e.MAC,
+    AdapterType: e.AdapterType,
+    Uptime:      e.Uptime,
+    LastSeen:    e.LastSeen,
+    HopCount:    e.HopCount,
+    NodeID:      e.NodeID,
+    Name:        e.Name,
+    Zone:        e.Zone,
+    Status:      e.Status,
+    ReplacedBy:  e.ReplacedBy,
+}
+```
+
+- [ ] **Step 6: Add the MarkReplaced method to `mesh/node_registry.go`**
+
+Add after `RemoveNode`:
+
+```go
+// MarkReplaced marks a node as replaced by a new MAC address.
+// Sets Status = "replaced", ReplacedBy = replacedByMACStr, NodeID = 0
+// so the entry is preserved for audit but excluded from active-node queries.
+func (nr *NodeRegistry) MarkReplaced(mac []byte, replacedByMACStr string) {
+	macStr := macToString(mac)
+	nr.mu.Lock()
+	defer nr.mu.Unlock()
+	node, ok := nr.nodes[macStr]
+	if !ok {
+		return
+	}
+	node.Status = "replaced"
+	node.ReplacedBy = replacedByMACStr
+	node.NodeID = 0
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestMarkReplaced
+```
+
+Expected: all 3 tests PASS.
+
+- [ ] **Step 8: Run full suite to check for regressions**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mesh/node_registry.go mesh/mesh_test.go
+git commit -m "feat: add Status/ReplacedBy to NodeInfo and MarkReplaced method"
+```
+
+---
+
+### Task 2: Hotswap detection and field inheritance in ApproveEnrollment
+
+**Files:**
+- Modify: `mesh/server.go`
+- Test: `mesh/server_enrollment_test.go`
+- Test: `mesh/api_v1_nodes_test.go`
+
+**Interfaces:**
+- Consumes (from Task 1): `func (nr *NodeRegistry) MarkReplaced(mac []byte, replacedByMACStr string)`
+- Consumes: existing `ApproveEnrollment(macStr string, params ApprovalParams) error` — same signature, new behavior when `params.NodeID > 0` and an existing node has that ID
+- Consumes: `ms.messageBuilder.BuildConfigSetMessage(targetMAC []byte, adapterType int32) (*MeshMessage, error)` — already used in codebase
+- Consumes: `enrollTestNode(t, ms)` helper — returns `("aabbccddeeff", pubKey)`, MAC `{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}`
+- Consumes: `decodeWrittenFrame(t, mockPort)` helper — decodes one frame from `mockPort.writeOffset`
+
+- [ ] **Step 1: Add enrollTestNodeWithMAC helper to `mesh/server_enrollment_test.go`**
+
+Add after the existing `enrollTestNode` helper (line 27):
+
+```go
+// enrollTestNodeWithMAC adds a pending enrollment for the given MAC address.
+func enrollTestNodeWithMAC(t *testing.T, ms *MeshServer, mac [6]byte) (macStr string, pubKey [32]byte) {
+	t.Helper()
+	for i := range pubKey {
+		pubKey[i] = byte(i + 1)
+	}
+	if err := ms.authRegistry.AddPending(mac, pubKey); err != nil {
+		t.Fatalf("AddPending failed: %v", err)
+	}
+	return fmt.Sprintf("%02x%02x%02x%02x%02x%02x",
+		mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]), pubKey
+}
+```
+
+This produces no-colon MAC strings (e.g. `"112233445566"`) matching the format expected by `ApproveEnrollment` / `authRegistry`.
+
+Also add `"fmt"` to the import block if not already present.
+
+- [ ] **Step 2: Write three failing tests in `mesh/server_enrollment_test.go`**
+
+Add after line 105:
+
+```go
+func TestApproveEnrollment_HotswapInheritsNameZoneAndMarksReplaced(t *testing.T) {
+	ms := newTestMeshServer(t)
+
+	// Old node: assigned with identity, adapter type known from health report
+	oldMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	ms.nodeRegistry.AssignNode(oldMAC, 7, "entrance-left", "lobby")
+	ms.nodeRegistry.UpdateNode(oldMAC, AdapterTypePIR, 3600, 1)
+
+	// New node sends enrollment request
+	newMacStr, _ := enrollTestNodeWithMAC(t, ms, [6]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})
+
+	// Approve with same nodeId, no explicit overrides
+	if err := ms.ApproveEnrollment(newMacStr, ApprovalParams{NodeID: 7}); err != nil {
+		t.Fatalf("ApproveEnrollment: %v", err)
+	}
+
+	// New node should inherit name and zone from old node
+	newNode, ok := ms.nodeRegistry.GetNodeByID(7)
+	if !ok {
+		t.Fatal("GetNodeByID(7) must return the new node after hotswap")
+	}
+	if newNode.Name != "entrance-left" {
+		t.Errorf("Name = %q, want %q (inherited from old node)", newNode.Name, "entrance-left")
+	}
+	if newNode.Zone != "lobby" {
+		t.Errorf("Zone = %q, want %q (inherited from old node)", newNode.Zone, "lobby")
+	}
+
+	// Old node must be marked replaced and its NodeID cleared
+	oldNode, ok := ms.nodeRegistry.GetNode(oldMAC)
+	if !ok {
+		t.Fatal("old node must still exist in registry after hotswap")
+	}
+	if oldNode.Status != "replaced" {
+		t.Errorf("old node Status = %q, want %q", oldNode.Status, "replaced")
+	}
+	if oldNode.NodeID != 0 {
+		t.Errorf("old node NodeID = %d, want 0 after replacement", oldNode.NodeID)
+	}
+}
+
+func TestApproveEnrollment_HotswapSendsConfigSet(t *testing.T) {
+	ms := newTestMeshServer(t)
+	mockPort := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(mockPort)
+
+	// Old node with PIR adapter type
+	oldMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	ms.nodeRegistry.AssignNode(oldMAC, 7, "entrance-left", "lobby")
+	ms.nodeRegistry.UpdateNode(oldMAC, AdapterTypePIR, 3600, 1)
+
+	newMacStr, _ := enrollTestNodeWithMAC(t, ms, [6]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})
+
+	if err := ms.ApproveEnrollment(newMacStr, ApprovalParams{NodeID: 7}); err != nil {
+		t.Fatalf("ApproveEnrollment: %v", err)
+	}
+
+	_ = decodeWrittenFrame(t, mockPort) // JOIN_ACK
+	_ = decodeWrittenFrame(t, mockPort) // OP_NODE_ID_SET
+	configMsg := decodeWrittenFrame(t, mockPort) // OP_CONFIG_SET
+
+	if len(configMsg.Data) == 0 || configMsg.Data[0] != byte(OpConfigSet) {
+		t.Errorf("3rd frame opcode = 0x%02x, want 0x%02x (OP_CONFIG_SET)",
+			configMsg.Data[0], OpConfigSet)
+	}
+	if configMsg.Data[7] != byte(AdapterTypePIR) {
+		t.Errorf("OP_CONFIG_SET adapter type = %d, want %d (AdapterTypePIR)",
+			configMsg.Data[7], byte(AdapterTypePIR))
+	}
+}
+
+func TestApproveEnrollment_HotswapExplicitOverrideNotInherited(t *testing.T) {
+	ms := newTestMeshServer(t)
+
+	// Old node with known name, zone, type
+	oldMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	ms.nodeRegistry.AssignNode(oldMAC, 7, "entrance-left", "lobby")
+	ms.nodeRegistry.UpdateNode(oldMAC, AdapterTypePIR, 3600, 1)
+
+	newMacStr, _ := enrollTestNodeWithMAC(t, ms, [6]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66})
+
+	// Explicit overrides provided — should NOT inherit from old node
+	if err := ms.ApproveEnrollment(newMacStr, ApprovalParams{
+		NodeID:         7,
+		Name:           "stage-right",
+		Zone:           "stage",
+		AdapterTypeStr: "led",
+	}); err != nil {
+		t.Fatalf("ApproveEnrollment: %v", err)
+	}
+
+	newNode, ok := ms.nodeRegistry.GetNodeByID(7)
+	if !ok {
+		t.Fatal("GetNodeByID(7) must return new node")
+	}
+	if newNode.Name != "stage-right" {
+		t.Errorf("Name = %q, want %q (explicit override)", newNode.Name, "stage-right")
+	}
+	if newNode.Zone != "stage" {
+		t.Errorf("Zone = %q, want %q (explicit override)", newNode.Zone, "stage")
+	}
+}
+```
+
+- [ ] **Step 3: Write the API integration test in `mesh/api_v1_nodes_test.go`**
+
+Add after the existing tests:
+
+```go
+func TestV1Nodes_Hotswap_OldNodeExcludedNewNodePresent(t *testing.T) {
+	api, ms := newV1TestServer(t)
+
+	// Old node enrolled and assigned
+	oldMAC := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+	ms.nodeRegistry.AssignNode(oldMAC, 7, "entrance-left", "lobby")
+	ms.nodeRegistry.UpdateNode(oldMAC, AdapterTypePIR, 3600, 1)
+
+	// New node sends enrollment
+	newMAC := [6]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+	var newPubKey [32]byte
+	for i := range newPubKey {
+		newPubKey[i] = byte(i + 1)
+	}
+	if err := ms.authRegistry.AddPending(newMAC, newPubKey); err != nil {
+		t.Fatalf("AddPending: %v", err)
+	}
+
+	// Approve hotswap via API
+	w := v1Request(t, api, "POST", "/api/v1/enrollments/112233445566/approve",
+		map[string]interface{}{"nodeId": 7})
+	if w.Code != http.StatusOK {
+		t.Fatalf("approve returned %d, want 200", w.Code)
+	}
+
+	// GET /api/v1/nodes — must return exactly one node with id=7
+	w = v1Request(t, api, "GET", "/api/v1/nodes", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/nodes returned %d", w.Code)
+	}
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := json.Marshal(resp.Data)
+	var nodes []NodeV1
+	if err := json.Unmarshal(data, &nodes); err != nil {
+		t.Fatalf("unmarshal nodes: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1 (replaced node must be excluded)", len(nodes))
+	}
+	if nodes[0].ID != 7 {
+		t.Errorf("node ID = %d, want 7", nodes[0].ID)
+	}
+	if nodes[0].Name != "entrance-left" {
+		t.Errorf("Name = %q, want %q (inherited)", nodes[0].Name, "entrance-left")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run "TestApproveEnrollment_Hotswap|TestV1Nodes_Hotswap"
+```
+
+Expected: all FAIL — no hotswap logic in `ApproveEnrollment` yet.
+
+- [ ] **Step 5: Add bytes import to `mesh/server.go`**
+
+In the import block, add `"bytes"`:
+
+```go
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	EventStore "github.com/superbrobenji/motionServer/eventStore"
+	"github.com/superbrobenji/motionServer/nodeauth"
+	"go.bug.st/serial"
+)
+```
+
+- [ ] **Step 6: Add hotswap detection and inheritance in ApproveEnrollment in `mesh/server.go`**
+
+Find `ApproveEnrollment` (around line 465). Replace the section between `node, err := ms.authRegistry.Approve(macStr)` and `ms.nodeRegistry.AssignNode(...)` with this (the full replacement for the nodeId resolution + new hotswap block):
+
+```go
+func (ms *MeshServer) ApproveEnrollment(macStr string, params ApprovalParams) error {
+	node, err := ms.authRegistry.Approve(macStr)
+	if err != nil {
+		return err
+	}
+
+	// Auto-assign nodeId if not provided
+	nodeId := params.NodeID
+	if nodeId == 0 {
+		nodeId = ms.nodeRegistry.NextFreeNodeID()
+		if nodeId == 0 {
+			slog.Warn("All node IDs in use; node will have ID 0", "mac", macStr)
+		}
+	}
+
+	// Hotswap detection: explicit nodeId provided and an existing node already owns it.
+	// Inherit unspecified fields from the old node; the old entry is marked replaced.
+	var hotswapOldMAC []byte
+	var inheritedAdapterType int32 = AdapterTypeUnknown // sentinel: no inheritance
+	if params.NodeID > 0 {
+		if oldNode, ok := ms.nodeRegistry.GetNodeByID(params.NodeID); ok &&
+			!bytes.Equal(oldNode.MAC, node.MAC[:]) {
+			hotswapOldMAC = oldNode.MAC
+			if params.Name == "" {
+				params.Name = oldNode.Name
+			}
+			if params.Zone == "" {
+				params.Zone = oldNode.Zone
+			}
+			if params.AdapterTypeStr == "" && oldNode.AdapterType != AdapterTypeUnknown {
+				inheritedAdapterType = oldNode.AdapterType
+			}
+		}
+	}
+
+	// Assign new node in registry (creates entry if first seen)
+	ms.nodeRegistry.AssignNode(node.MAC[:], nodeId, params.Name, params.Zone)
+
+	// Mark old node replaced after new node is assigned (ensures GetNodeByID uniqueness)
+	if hotswapOldMAC != nil {
+		ms.nodeRegistry.MarkReplaced(hotswapOldMAC, macToString(node.MAC[:]))
+	}
+
+	if registryNode, ok := ms.nodeRegistry.GetNode(node.MAC[:]); ok {
+		typeStr := params.AdapterTypeStr
+		if typeStr == "" {
+			typeStr = "unknown"
+		}
+		ms.publishEnrolledEvent(registryNode, typeStr)
+	}
+
+	if ms.serialComm != nil {
+		// Send JOIN_ACK
+		ackMsg := &MeshMessage{
+			MessageType:      MessageTypeJoinAck,
+			TargetMacAddress: node.MAC[:],
+			PublicKey:        node.PublicKey[:],
+		}
+		if err := ms.serialComm.WriteFrame(ackMsg); err != nil {
+			slog.Warn("Failed to send JOIN_ACK", "mac", macStr, "error", err)
+		}
+
+		// Send OP_NODE_ID_SET immediately after JOIN_ACK
+		if nodeId > 0 {
+			payload := make([]byte, MaxDataLength)
+			payload[0] = OpNodeIdSet
+			copy(payload[1:7], node.MAC[:])
+			payload[7] = nodeId
+			idMsg := &MeshMessage{
+				MessageType: MessageTypeSerialCmdBroadcast,
+				DataType:    AdapterTypeSerial,
+				Data:        payload,
+			}
+			if err := ms.serialComm.WriteFrame(idMsg); err != nil {
+				slog.Warn("Failed to send OP_NODE_ID_SET", "mac", macStr, "nodeId", nodeId, "error", err)
+			}
+		}
+
+		// Send OP_CONFIG_SET when adapter type was inherited from old node
+		if inheritedAdapterType != AdapterTypeUnknown {
+			configMsg, buildErr := ms.messageBuilder.BuildConfigSetMessage(node.MAC[:], inheritedAdapterType)
+			if buildErr != nil {
+				slog.Warn("Failed to build OP_CONFIG_SET for hotswap", "mac", macStr, "error", buildErr)
+			} else if err := ms.serialComm.WriteFrame(configMsg); err != nil {
+				slog.Warn("Failed to send OP_CONFIG_SET on hotswap", "mac", macStr, "error", err)
+			}
+		}
+	}
+
+	slog.Info("Enrollment approved", "mac", macStr, "nodeId", nodeId, "name", params.Name)
+	if ms.authPath != "" {
+		return ms.authRegistry.Persist(ms.authPath)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Run the new tests to verify they pass**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run "TestApproveEnrollment_Hotswap|TestV1Nodes_Hotswap"
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 8: Run full suite to check for regressions**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mesh/server.go mesh/server_enrollment_test.go mesh/api_v1_nodes_test.go
+git commit -m "feat: hotswap detection in ApproveEnrollment — inherit fields, mark replaced, send OP_CONFIG_SET"
+```

--- a/docs/superpowers/plans/nodes-phase9-dual-master.md
+++ b/docs/superpowers/plans/nodes-phase9-dual-master.md
@@ -1,0 +1,1022 @@
+# Phase 9: Dual Master (Backup Master) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow two ESP32 master nodes to run simultaneously — sensor nodes route to whichever has a lower hop count, and the server transparently fails over outgoing commands to the secondary serial port if the primary is silent for 75 seconds.
+
+**Architecture:** Firmware: add `DUAL_MASTER_MODE` runtime flag to `Mesh`; modify `processMasterBeacon` to learn and accept a secondary master MAC via TOFU, suppressing the "multiple masters" warning. EEPROM layout bumps to v3 to persist the secondary MAC. Server: `MeshServer` grows a second `SerialComm`; both read goroutines process into the same registries; `activeOutboundComm()` selects the port that received a frame most recently, falling back to secondary after 75 s of primary silence.
+
+**Tech Stack:** Go 1.22, ESP32 C++ (Arduino-ESP32), nanopb/protobuf3, GTest, mbedTLS, ESP-NOW.
+
+## Global Constraints
+
+- Go module root: `motionSensorServer/server/orchestrator/` — all Go paths relative to this
+- Go test command: `GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1`
+- Firmware test command: `cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure` (run from `Planetopia-nodes/`)
+- `AdapterTypeUnknown int32 = -1`; `AdapterTypePIR int32 = 0`
+- EEPROM total size: 512 bytes; v2 layout ends at address 496 (NODE_ID); v3 adds `KNOWN_MASTER_MAC_SECONDARY` at 497–502; `CURRENT_SCHEMA_VERSION` bumps from 2 to 3
+- Primary failover threshold: exactly 75 seconds (`75 * time.Second`)
+- No `gh` commands. Git identity for every commit: `git config user.email "49689582+superbrobenji@users.noreply.github.com"` + `git config user.name "superbrobenji"` (set per-repo before first commit)
+- clang-format: single-statement `if` bodies on separate lines
+
+---
+
+## File Map
+
+| File | Repo | Change |
+|---|---|---|
+| `mesh/server.go` | motionSensorServer | Add `secondaryPort`, `secondarySerialComm`, frame-time tracking; refactor `messageProcessor`; add `activeOutboundComm()`; route all outgoing writes through it; `SerialStatus()` |
+| `mesh/api_v1_status.go` | motionSensorServer | Add `serial.primary`/`serial.secondary` block |
+| `main.go` | motionSensorServer | Read `SERIAL_PORT_SECONDARY` + `DUAL_MASTER_ENABLED` env vars; pass to config |
+| `mesh/server_test.go` | motionSensorServer | Add `activeOutboundComm` failover tests |
+| `mesh/api_v1_status_test.go` (new) | motionSensorServer | Status endpoint tests |
+| `main/src/persistence/EEPROM_Manager.h` | Planetopia-nodes | Add `KNOWN_MASTER_MAC_SECONDARY = 497`, bump `CURRENT_SCHEMA_VERSION = 3`, declare 3 new methods |
+| `main/src/persistence/EEPROM_Manager.cpp` | Planetopia-nodes | Implement 3 new methods + v2→v3 migration |
+| `tests/unit/test_eeprom_manager.cpp` | Planetopia-nodes | 3 tests for secondary MAC |
+| `main/project_config.h` | Planetopia-nodes | Add `DUAL_MASTER_MODE = false` |
+| `main/src/Mesh/Mesh.h` | Planetopia-nodes | Add `knownMasterMacSecondary`, `hasMasterMacSecondary`, `_dualMasterMode`, `setDualMasterMode()` |
+| `main/src/Mesh/Mesh.cpp` | Planetopia-nodes | Constructor + `loadPersistentState()` secondary MAC |
+| `tests/mocks/firmware_stubs.cpp` | Planetopia-nodes | Add new fields to test constructor |
+| `tests/mocks/mesh_logic_impl.cpp` | Planetopia-nodes | Modify `processMasterBeacon` for dual mode |
+| `tests/unit/test_mesh_logic.cpp` | Planetopia-nodes | 5 dual-master beacon tests |
+
+---
+
+### Task 1: Secondary serial port in MeshServer
+
+**Repo:** `motionSensorServer/server/orchestrator/`
+
+**Files:**
+- Modify: `mesh/server.go`
+- Modify: `mesh/server_test.go`
+
+**Interfaces:**
+- Produces: `func (ms *MeshServer) SerialStatus() (primary bool, secondary bool)` — returns whether primary/secondary comms are active
+- Produces: `func (ms *MeshServer) activeOutboundComm() *SerialComm` — returns the comm to use for outgoing frames
+- Produces: `MeshServerConfig.SerialPortSecondary string` — consumed by Task 2
+
+- [ ] **Step 1: Write three failing tests in `mesh/server_test.go`**
+
+Add after existing tests:
+
+```go
+func TestActiveOutboundComm_ReturnsPrimary_WhenSecondaryNotConfigured(t *testing.T) {
+	ms := newTestMeshServer(t)
+	mock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(mock)
+
+	comm := ms.activeOutboundComm()
+	if comm != ms.serialComm {
+		t.Error("activeOutboundComm() must return primary when no secondary configured")
+	}
+}
+
+func TestActiveOutboundComm_ReturnsPrimary_WhenPrimaryIsRecent(t *testing.T) {
+	ms := newTestMeshServer(t)
+	primaryMock := NewMockSerialPort()
+	secondaryMock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(primaryMock)
+	ms.secondarySerialComm = NewSerialComm(secondaryMock)
+	// Primary received a frame 10 seconds ago — well within the 75s threshold
+	ms.primaryLastFrameAt = time.Now().Add(-10 * time.Second)
+
+	comm := ms.activeOutboundComm()
+	if comm != ms.serialComm {
+		t.Error("activeOutboundComm() must return primary when primary is recent")
+	}
+}
+
+func TestActiveOutboundComm_FailsOverToSecondary_AfterPrimaryTimeout(t *testing.T) {
+	ms := newTestMeshServer(t)
+	primaryMock := NewMockSerialPort()
+	secondaryMock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(primaryMock)
+	ms.secondarySerialComm = NewSerialComm(secondaryMock)
+	// Primary last heard 76 seconds ago — over the 75s threshold
+	ms.primaryLastFrameAt = time.Now().Add(-76 * time.Second)
+
+	comm := ms.activeOutboundComm()
+	if comm != ms.secondarySerialComm {
+		t.Error("activeOutboundComm() must return secondary after primary timeout")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestActiveOutboundComm
+```
+
+Expected: compile error — `secondarySerialComm`, `primaryLastFrameAt`, `activeOutboundComm` not defined.
+
+- [ ] **Step 3: Add new fields to `MeshServer` struct in `mesh/server.go`**
+
+In the `MeshServer` struct, after `serialComm *SerialComm`, add:
+
+```go
+secondaryPort        string
+secondarySerialComm  *SerialComm
+secondaryConnected   bool
+
+frameTimeMu          sync.Mutex // protects primaryLastFrameAt / secondaryLastFrameAt
+primaryLastFrameAt   time.Time
+secondaryLastFrameAt time.Time
+```
+
+- [ ] **Step 4: Add `SerialPortSecondary` to `MeshServerConfig` in `mesh/server.go`**
+
+In `MeshServerConfig`, after `SerialPort string`, add:
+
+```go
+SerialPortSecondary string // empty = single-master mode
+```
+
+- [ ] **Step 5: Populate `secondaryPort` in `NewMeshServer` in `mesh/server.go`**
+
+In the `return &MeshServer{...}` block, after `serialPort: config.SerialPort,`, add:
+
+```go
+secondaryPort: config.SerialPortSecondary,
+```
+
+- [ ] **Step 6: Add `activeOutboundComm()` method to `mesh/server.go`**
+
+Add this method after `Stop()`:
+
+```go
+// activeOutboundComm returns the SerialComm to use for outgoing frames.
+// When a secondary port is configured, switches to secondary if primary has
+// been silent for more than 75 seconds.
+func (ms *MeshServer) activeOutboundComm() *SerialComm {
+	if ms.secondarySerialComm == nil {
+		return ms.serialComm
+	}
+	ms.frameTimeMu.Lock()
+	primaryAge := time.Since(ms.primaryLastFrameAt)
+	ms.frameTimeMu.Unlock()
+	const failoverThreshold = 75 * time.Second
+	if primaryAge > failoverThreshold {
+		return ms.secondarySerialComm
+	}
+	return ms.serialComm
+}
+```
+
+- [ ] **Step 7: Run the three new tests to verify they pass**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestActiveOutboundComm
+```
+
+Expected: all 3 PASS.
+
+- [ ] **Step 8: Refactor `messageProcessor` to accept a comm + label in `mesh/server.go`**
+
+Change the signature from:
+
+```go
+func (ms *MeshServer) messageProcessor() {
+```
+
+to:
+
+```go
+func (ms *MeshServer) messageProcessor(comm *SerialComm, label string) {
+```
+
+Replace all `ms.serialComm` inside `messageProcessor` with `comm`. After the line:
+
+```go
+if consecutiveErrors > 0 {
+```
+
+(when `consecutiveErrors > maxConsecutiveErrors` resets after recovery), find the line that currently reads `SetSerialConnected(false)` (inside the error branch) and update it:
+
+```go
+if label == "primary" {
+    SetSerialConnected(false)
+}
+```
+
+After the successful-read path (immediately after the `consecutiveErrors` reset block), record the frame time:
+
+```go
+ms.frameTimeMu.Lock()
+if label == "primary" {
+    ms.primaryLastFrameAt = time.Now()
+} else {
+    ms.secondaryLastFrameAt = time.Now()
+}
+ms.frameTimeMu.Unlock()
+```
+
+- [ ] **Step 9: Update `Start()` to pass the comm and label, and open secondary if configured**
+
+In `Start()`, change:
+
+```go
+go ms.messageProcessor()
+```
+
+to:
+
+```go
+go ms.messageProcessor(ms.serialComm, "primary")
+```
+
+After that line, add secondary port setup:
+
+```go
+if ms.secondaryPort != "" {
+    secondaryPhysPort, secErr := serial.Open(ms.secondaryPort, mode)
+    if secErr != nil {
+        slog.Warn("Failed to open secondary serial port — continuing single-master",
+            "port", ms.secondaryPort, "error", secErr)
+    } else {
+        ms.secondarySerialComm = NewSerialComm(secondaryPhysPort)
+        ms.secondaryConnected = true
+        ms.wg.Add(1)
+        go ms.messageProcessor(ms.secondarySerialComm, "secondary")
+        slog.Info("Secondary serial port opened", "port", ms.secondaryPort)
+    }
+}
+```
+
+- [ ] **Step 10: Update `Stop()` to close secondary**
+
+In `Stop()`, after `ms.serialComm.Close()`:
+
+```go
+if ms.secondarySerialComm != nil {
+    ms.secondarySerialComm.Close()
+    ms.secondaryConnected = false
+}
+```
+
+- [ ] **Step 11: Route all outgoing `WriteFrame` calls through `activeOutboundComm()`**
+
+In `mesh/server.go`, replace every `ms.serialComm.WriteFrame(` with `ms.activeOutboundComm().WriteFrame(`.
+
+There are occurrences at (approximately) these lines — find them all:
+- `ApproveEnrollment`: three `WriteFrame` calls (JOIN_ACK, OP_NODE_ID_SET, OP_CONFIG_SET)
+- `RejectEnrollment`: one `WriteFrame`
+- `SendMessage`: one `WriteFrame`
+- `broadcastNodeId` (or similar internal method): one `WriteFrame`
+- `RequestHealthReports`: one `WriteFrame`
+
+Keep all `if ms.serialComm != nil` guard checks as-is — they guard against the server not being started, not against failover. Only the `WriteFrame` call itself changes.
+
+- [ ] **Step 12: Add `SerialStatus()` method to `mesh/server.go`**
+
+```go
+// SerialStatus returns the connection state of primary and secondary serial ports.
+func (ms *MeshServer) SerialStatus() (primary bool, secondary bool) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.serialComm != nil, ms.secondaryConnected
+}
+```
+
+- [ ] **Step 13: Run full suite to verify no regressions**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer config user.email "49689582+superbrobenji@users.noreply.github.com"
+git -C /Users/benjamin.swanepoel/projects/personal/motionSensorServer config user.name "superbrobenji"
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer
+git add server/orchestrator/mesh/server.go server/orchestrator/mesh/server_test.go
+git commit -m "feat: add secondary serial port with 75s primary-failover to MeshServer"
+```
+
+---
+
+### Task 2: Status endpoint dual master + main.go env vars
+
+**Repo:** `motionSensorServer/server/orchestrator/`
+
+**Files:**
+- Modify: `mesh/api_v1_status.go`
+- Create: `mesh/api_v1_status_test.go`
+- Modify: `main.go`
+
+**Interfaces:**
+- Consumes (Task 1): `func (ms *MeshServer) SerialStatus() (primary bool, secondary bool)`
+- Consumes (Task 1): `MeshServerConfig.SerialPortSecondary string`
+
+- [ ] **Step 1: Create `mesh/api_v1_status_test.go` with three failing tests**
+
+```go
+package mesh
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestV1Status_SingleMaster_SerialBlockShowsPrimaryOnly(t *testing.T) {
+	api, ms := newV1TestServer(t)
+	mock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(mock)
+	// secondarySerialComm remains nil — single master mode
+
+	w := v1Request(t, api, "GET", "/api/v1/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status returned %d", w.Code)
+	}
+
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := json.Marshal(resp.Data)
+	var status struct {
+		Serial struct {
+			Primary   string `json:"primary"`
+			Secondary string `json:"secondary"`
+		} `json:"serial"`
+	}
+	if err := json.Unmarshal(data, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Serial.Primary != "connected" {
+		t.Errorf("serial.primary = %q, want %q", status.Serial.Primary, "connected")
+	}
+	if status.Serial.Secondary != "not_configured" {
+		t.Errorf("serial.secondary = %q, want %q", status.Serial.Secondary, "not_configured")
+	}
+}
+
+func TestV1Status_DualMaster_SecondaryConnected(t *testing.T) {
+	api, ms := newV1TestServer(t)
+	primaryMock := NewMockSerialPort()
+	secondaryMock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(primaryMock)
+	ms.secondarySerialComm = NewSerialComm(secondaryMock)
+	ms.secondaryConnected = true
+
+	w := v1Request(t, api, "GET", "/api/v1/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status returned %d", w.Code)
+	}
+
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := json.Marshal(resp.Data)
+	var status struct {
+		Serial struct {
+			Primary   string `json:"primary"`
+			Secondary string `json:"secondary"`
+		} `json:"serial"`
+	}
+	if err := json.Unmarshal(data, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Serial.Primary != "connected" {
+		t.Errorf("serial.primary = %q, want %q", status.Serial.Primary, "connected")
+	}
+	if status.Serial.Secondary != "connected" {
+		t.Errorf("serial.secondary = %q, want %q", status.Serial.Secondary, "connected")
+	}
+}
+
+func TestV1Status_DualMaster_SecondaryDisconnected(t *testing.T) {
+	api, ms := newV1TestServer(t)
+	primaryMock := NewMockSerialPort()
+	ms.serialComm = NewSerialComm(primaryMock)
+	// secondarySerialComm is nil but secondaryPort is set — secondary configured but failed to open
+	ms.secondaryPort = "/dev/ttyUSB1"
+	ms.secondaryConnected = false
+
+	w := v1Request(t, api, "GET", "/api/v1/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status returned %d", w.Code)
+	}
+
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, _ := json.Marshal(resp.Data)
+	var status struct {
+		Serial struct {
+			Primary   string `json:"primary"`
+			Secondary string `json:"secondary"`
+		} `json:"serial"`
+	}
+	if err := json.Unmarshal(data, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Serial.Secondary != "disconnected" {
+		t.Errorf("serial.secondary = %q, want %q", status.Serial.Secondary, "disconnected")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestV1Status
+```
+
+Expected: FAIL — response has no `serial` key yet.
+
+- [ ] **Step 3: Update `v1Status` in `mesh/api_v1_status.go`**
+
+Replace the full function body with:
+
+```go
+func (api *APIServer) v1Status(w http.ResponseWriter, r *http.Request) {
+	timeout := api.meshServer.GetHealthTimeout()
+	allNodes := api.meshServer.GetNodeRegistry().GetAllNodes()
+	total := 0
+	online := 0
+	for _, n := range allNodes {
+		if n.NodeID > 0 && n.Status != "replaced" {
+			total++
+			if isOnline(n, timeout) {
+				online++
+			}
+		}
+	}
+
+	primaryConnected, secondaryConnected := api.meshServer.SerialStatus()
+
+	primaryStatus := "disconnected"
+	if primaryConnected {
+		primaryStatus = "connected"
+	}
+
+	secondaryStatus := "not_configured"
+	if api.meshServer.secondaryPort != "" {
+		if secondaryConnected {
+			secondaryStatus = "connected"
+		} else {
+			secondaryStatus = "disconnected"
+		}
+	}
+
+	api.writeJSON(w, http.StatusOK, APIResponse{
+		Success: true,
+		Data: map[string]interface{}{
+			"serial": map[string]string{
+				"primary":   primaryStatus,
+				"secondary": secondaryStatus,
+			},
+			"nodes": map[string]int{
+				"total":   total,
+				"online":  online,
+				"offline": total - online,
+			},
+			"mesh": map[string]bool{
+				"masterOnline": api.meshServer.IsRunning(),
+			},
+		},
+	})
+}
+```
+
+Note: `api.meshServer.secondaryPort` is an unexported field — since `APIServer` is in the same package (`mesh`), this is fine.
+
+- [ ] **Step 4: Run the three status tests to verify they pass**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1 -run TestV1Status
+```
+
+Expected: all 3 PASS.
+
+- [ ] **Step 5: Update `main.go` to read secondary port env vars**
+
+In `main.go`, after the `serialPort` flag declaration (around line 39), add:
+
+```go
+serialPortSecondary := envOrDefault("SERIAL_PORT_SECONDARY", "")
+dualMasterEnabled := os.Getenv("DUAL_MASTER_ENABLED") == "true"
+```
+
+Update `meshConfig` construction to include the secondary port:
+
+```go
+meshConfig := mesh.MeshServerConfig{
+    SerialPort:          *serialPort,
+    SerialPortSecondary: func() string {
+        if dualMasterEnabled && serialPortSecondary != "" {
+            return serialPortSecondary
+        }
+        return ""
+    }(),
+    BaudRate:         *baudRate,
+    HealthTimeout:    30 * time.Second,
+    EventStore:       eventStore,
+    AuthRegistryPath: *authRegistry,
+    NodeRegistryPath: *nodeRegistry,
+}
+```
+
+Also add a log line after the existing `slog.Info("Serial", ...)`:
+
+```go
+if dualMasterEnabled && serialPortSecondary != "" {
+    slog.Info("Secondary serial port", "port", serialPortSecondary)
+}
+```
+
+- [ ] **Step 6: Run full suite to verify no regressions**
+
+```
+GOROOT=/opt/homebrew/Cellar/go/1.26.4/libexec /opt/homebrew/bin/go test ./mesh/... -count=1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/motionSensorServer
+git add server/orchestrator/mesh/api_v1_status.go server/orchestrator/mesh/api_v1_status_test.go server/orchestrator/main.go
+git commit -m "feat: dual master status in GET /api/v1/status; SERIAL_PORT_SECONDARY + DUAL_MASTER_ENABLED env vars"
+```
+
+---
+
+### Task 3: EEPROM layout v3 — secondary master MAC
+
+**Repo:** `Planetopia-nodes/`
+
+**Files:**
+- Modify: `main/src/persistence/EEPROM_Manager.h`
+- Modify: `main/src/persistence/EEPROM_Manager.cpp`
+- Modify: `tests/unit/test_eeprom_manager.cpp`
+
+**Interfaces:**
+- Produces: `bool EEPROM_Manager::loadKnownMasterMacSecondary(uint8_t mac[6])` — returns false if unset (0xFF×6)
+- Produces: `void EEPROM_Manager::saveKnownMasterMacSecondary(const uint8_t mac[6])`
+- Produces: `void EEPROM_Manager::clearKnownMasterMacSecondary()`
+- Produces: `EEPROM_ADDRESSES::KNOWN_MASTER_MAC_SECONDARY = 497`
+
+- [ ] **Step 1: Write three failing tests in `tests/unit/test_eeprom_manager.cpp`**
+
+Add after the existing `KnownMasterMac` tests (search for `clearKnownMasterMac` to find the end of that group):
+
+```cpp
+TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_UnsetReturnsAlFalse) {
+  auto& mgr = EEPROM_Manager::getInstance();
+  mgr.init();
+  uint8_t mac[6] = {};
+  bool found = mgr.loadKnownMasterMacSecondary(mac);
+  EXPECT_FALSE(found) << "Blank EEPROM must report secondary master MAC as unset";
+}
+
+TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_SaveAndLoad_RoundTrip) {
+  auto& mgr = EEPROM_Manager::getInstance();
+  mgr.init();
+  const uint8_t expected[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  mgr.saveKnownMasterMacSecondary(expected);
+
+  uint8_t loaded[6] = {};
+  bool found = mgr.loadKnownMasterMacSecondary(loaded);
+
+  EXPECT_TRUE(found);
+  EXPECT_EQ(memcmp(loaded, expected, 6), 0);
+}
+
+TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_Clear_ResetsToUnset) {
+  auto& mgr = EEPROM_Manager::getInstance();
+  mgr.init();
+  const uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  mgr.saveKnownMasterMacSecondary(mac);
+  mgr.clearKnownMasterMacSecondary();
+
+  uint8_t loaded[6] = {};
+  bool found = mgr.loadKnownMasterMacSecondary(loaded);
+  EXPECT_FALSE(found) << "After clear, secondary master MAC must report unset";
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: compile error — `loadKnownMasterMacSecondary` not declared.
+
+- [ ] **Step 3: Update `EEPROM_Manager.h`**
+
+In the EEPROM layout comment block (around line 12), add after the existing `KNOWN_MASTER_MAC` comment line:
+
+```cpp
+// 497   KNOWN_MASTER_MAC_SECONDARY (6 bytes, ends 502) — TOFU secondary master MAC (0xFF×6 = unset)
+// Total used: 503 bytes — fits in 512
+```
+
+In `namespace EEPROM_ADDRESSES` (around line 32), add after `KNOWN_MASTER_MAC`:
+
+```cpp
+constexpr uint16_t KNOWN_MASTER_MAC_SECONDARY = 497; // 6 bytes: TOFU secondary master MAC (0xFF×6 = unset, ends 502)
+```
+
+In `namespace EEPROM_SIZES`, change:
+
+```cpp
+constexpr uint8_t CURRENT_SCHEMA_VERSION = 2; // Current EEPROM schema version
+```
+
+to:
+
+```cpp
+constexpr uint8_t CURRENT_SCHEMA_VERSION = 3; // Current EEPROM schema version
+```
+
+In the `class EEPROM_Manager` public section, after `clearKnownMasterMac();`, add:
+
+```cpp
+bool loadKnownMasterMacSecondary(uint8_t mac[6]);
+void saveKnownMasterMacSecondary(const uint8_t mac[6]);
+void clearKnownMasterMacSecondary();
+```
+
+- [ ] **Step 4: Update `EEPROM_Manager.cpp` — add v2→v3 migration**
+
+In the migration block in `init()`, find the comment:
+
+```cpp
+// Future: add migration handlers for v2→v3, v3→v4, etc. here
+```
+
+Replace it with:
+
+```cpp
+if (storedVersion <= 2) {
+    // v2→v3 migration: zero-fill the new secondary master MAC slot
+    Logger::logln("EEPROM", "v2→v3 migration: initialising secondary master MAC slot", LogLevel::LOG_INFO);
+    for (uint16_t i = 0; i < 6; ++i) {
+        EEPROM.write(EEPROM_ADDRESSES::KNOWN_MASTER_MAC_SECONDARY + i, 0xFF);
+    }
+}
+```
+
+Also update the blank-EEPROM log message from `"Fresh EEPROM — version 2 written"` to `"Fresh EEPROM — version 3 written"`.
+
+- [ ] **Step 5: Add the three new methods to `EEPROM_Manager.cpp`**
+
+Add after `clearKnownMasterMac()`:
+
+```cpp
+bool EEPROM_Manager::loadKnownMasterMacSecondary(uint8_t mac[6]) {
+  if (!ensureInitialized())
+    return false;
+  for (int i = 0; i < 6; ++i)
+    mac[i] = EEPROM.read(EEPROM_ADDRESSES::KNOWN_MASTER_MAC_SECONDARY + i);
+  bool allFF = true;
+  for (int i = 0; i < 6; ++i) {
+    if (mac[i] != 0xFF) {
+      allFF = false;
+      break;
+    }
+  }
+  return !allFF;
+}
+
+void EEPROM_Manager::saveKnownMasterMacSecondary(const uint8_t mac[6]) {
+  if (!ensureInitialized() || isDevMode)
+    return;
+  for (int i = 0; i < 6; ++i)
+    EEPROM.write(EEPROM_ADDRESSES::KNOWN_MASTER_MAC_SECONDARY + i, mac[i]);
+  EEPROM.commit();
+  logOperation("Known secondary master MAC saved");
+}
+
+void EEPROM_Manager::clearKnownMasterMacSecondary() {
+  if (!ensureInitialized() || isDevMode)
+    return;
+  for (int i = 0; i < 6; ++i)
+    EEPROM.write(EEPROM_ADDRESSES::KNOWN_MASTER_MAC_SECONDARY + i, 0xFF);
+  markDirty();
+}
+```
+
+- [ ] **Step 6: Run tests to verify all three pass**
+
+```
+cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all 3 new tests PASS, no existing tests broken.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes config user.email "49689582+superbrobenji@users.noreply.github.com"
+git -C /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes config user.name "superbrobenji"
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+git add main/src/persistence/EEPROM_Manager.h main/src/persistence/EEPROM_Manager.cpp tests/unit/test_eeprom_manager.cpp
+git commit -m "feat: EEPROM v3 — secondary master MAC at address 497 with v2→v3 migration"
+```
+
+---
+
+### Task 4: DUAL_MASTER_MODE flag + dual beacon acceptance
+
+**Repo:** `Planetopia-nodes/`
+
+**Files:**
+- Modify: `main/project_config.h`
+- Modify: `main/src/Mesh/Mesh.h`
+- Modify: `main/src/Mesh/Mesh.cpp`
+- Modify: `tests/mocks/firmware_stubs.cpp`
+- Modify: `tests/mocks/mesh_logic_impl.cpp`
+- Modify: `tests/unit/test_mesh_logic.cpp`
+
+**Interfaces:**
+- Consumes (Task 3): `EEPROM_Manager::loadKnownMasterMacSecondary`, `saveKnownMasterMacSecondary`
+- Produces: `mesh.setDualMasterMode(bool)` — sets `_dualMasterMode`; used in tests to enable dual mode without recompiling
+
+- [ ] **Step 1: Write five failing tests in `tests/unit/test_mesh_logic.cpp`**
+
+Add after the existing `BeaconRelay_NewerSeq_AllowsRelay` test:
+
+```cpp
+// --- Dual master mode ---
+
+TEST_F(MeshLogicTest, DualMaster_SecondBeaconFromNewMAC_LearnedAsSecondary) {
+  Mesh mesh;
+  mesh.setDualMasterMode(true);
+  const uint8_t primaryMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t secondaryMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+  // Learn primary via first beacon
+  mesh.processMasterBeacon(makeBeacon(primaryMac, 1, 1));
+  ASSERT_TRUE(mesh.hasMasterMac);
+
+  // Second beacon from different MAC — must be learned as secondary
+  mesh.processMasterBeacon(makeBeacon(secondaryMac, 1, 1));
+
+  EXPECT_TRUE(mesh.hasMasterMacSecondary);
+  EXPECT_EQ(memcmp(mesh.knownMasterMacSecondary, secondaryMac, 6), 0);
+  // Primary must still be unchanged
+  EXPECT_EQ(memcmp(mesh.knownMasterMac, primaryMac, 6), 0);
+}
+
+TEST_F(MeshLogicTest, DualMaster_BeaconFromPrimaryMAC_Accepted) {
+  Mesh mesh;
+  mesh.setDualMasterMode(true);
+  const uint8_t primaryMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t secondaryMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+  mesh.processMasterBeacon(makeBeacon(primaryMac, 1, 1));   // learn primary
+  mesh.processMasterBeacon(makeBeacon(secondaryMac, 1, 1)); // learn secondary
+
+  // Beacon from primary — must not be rejected and relayPending must fire
+  mesh.isMaster = false;
+  mesh.relayPending = false;
+  mesh.processMasterBeacon(makeBeacon(primaryMac, 2, 1));
+
+  EXPECT_TRUE(mesh.relayPending) << "Beacon from known primary must set relayPending";
+}
+
+TEST_F(MeshLogicTest, DualMaster_BeaconFromSecondaryMAC_Accepted) {
+  Mesh mesh;
+  mesh.setDualMasterMode(true);
+  const uint8_t primaryMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t secondaryMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+  mesh.processMasterBeacon(makeBeacon(primaryMac, 1, 1));   // learn primary
+  mesh.processMasterBeacon(makeBeacon(secondaryMac, 1, 1)); // learn secondary
+
+  // Beacon from secondary — must not be rejected and relayPending must fire
+  mesh.isMaster = false;
+  mesh.relayPending = false;
+  mesh.processMasterBeacon(makeBeacon(secondaryMac, 2, 1));
+
+  EXPECT_TRUE(mesh.relayPending) << "Beacon from known secondary must set relayPending";
+}
+
+TEST_F(MeshLogicTest, DualMaster_ImpostorMAC_Rejected_WhenBothMastersKnown) {
+  Mesh mesh;
+  mesh.setDualMasterMode(true);
+  const uint8_t primaryMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t secondaryMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+  const uint8_t impostorMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x99};
+
+  mesh.processMasterBeacon(makeBeacon(primaryMac, 1, 1));   // learn primary
+  mesh.processMasterBeacon(makeBeacon(secondaryMac, 1, 1)); // learn secondary
+
+  // Third distinct MAC while both masters fresh — must be rejected
+  size_t sendsBefore = espNowSentPackets.size();
+  mesh.processMasterBeacon(makeBeacon(impostorMac, 1, 2));
+
+  // Neither primary nor secondary should have changed
+  EXPECT_EQ(memcmp(mesh.knownMasterMac, primaryMac, 6), 0);
+  EXPECT_EQ(memcmp(mesh.knownMasterMacSecondary, secondaryMac, 6), 0);
+  EXPECT_EQ(espNowSentPackets.size(), sendsBefore) << "Impostor beacon must not trigger relay";
+}
+
+TEST_F(MeshLogicTest, SingleMaster_SecondBeaconFromNewMAC_Rejected_WhenMasterAlive) {
+  Mesh mesh;
+  // _dualMasterMode defaults to false — no need to set
+  const uint8_t knownMac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01};
+  const uint8_t unknownMac[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+
+  mesh.processMasterBeacon(makeBeacon(knownMac, 1, 1));
+
+  // Second distinct MAC while single master still fresh — must be rejected
+  size_t sendsBefore = espNowSentPackets.size();
+  mesh.processMasterBeacon(makeBeacon(unknownMac, 1, 2));
+
+  EXPECT_EQ(memcmp(mesh.knownMasterMac, knownMac, 6), 0) << "Known master MAC must not change";
+  EXPECT_FALSE(mesh.hasMasterMacSecondary);
+  EXPECT_EQ(espNowSentPackets.size(), sendsBefore);
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: compile errors — `setDualMasterMode`, `hasMasterMacSecondary`, `knownMasterMacSecondary` not defined.
+
+- [ ] **Step 3: Add `DUAL_MASTER_MODE` to `main/project_config.h`**
+
+In `project_config.h`, after `STALE_MASTER_THRESHOLD_MS`, add:
+
+```cpp
+// Enable for deployments with two physically separate master nodes.
+// When false (production default), standard single-master TOFU enforcement applies.
+constexpr bool DUAL_MASTER_MODE = false;
+```
+
+- [ ] **Step 4: Add new fields and methods to `main/src/Mesh/Mesh.h`**
+
+In the private section, after `bool hasMasterMac;`, add:
+
+```cpp
+uint8_t knownMasterMacSecondary[6];
+bool hasMasterMacSecondary;
+bool _dualMasterMode;
+```
+
+In the public section, after `bool getIsMaster() const { return isMaster; }`, add:
+
+```cpp
+void setDualMasterMode(bool value) { _dualMasterMode = value; }
+bool getDualMasterMode() const { return _dualMasterMode; }
+```
+
+- [ ] **Step 5: Update `Mesh.cpp` constructor initializer list**
+
+Find the constructor initializer list in `main/src/Mesh/Mesh.cpp` (around line 175). After `hasMasterMac(false),` add:
+
+```cpp
+knownMasterMacSecondary{}, hasMasterMacSecondary(false),
+_dualMasterMode(planetopia::config::DUAL_MASTER_MODE),
+```
+
+In the constructor body, after `memset(knownMasterMac, 0xFF, 6);`, add:
+
+```cpp
+memset(knownMasterMacSecondary, 0xFF, 6);
+```
+
+- [ ] **Step 6: Update `loadPersistentState()` in `Mesh.cpp`**
+
+In `loadPersistentState()`, after the `hasMasterMac` block, add:
+
+```cpp
+if (_dualMasterMode) {
+    hasMasterMacSecondary =
+        EEPROM_Manager::getInstance().loadKnownMasterMacSecondary(knownMasterMacSecondary);
+    if (hasMasterMacSecondary) {
+        Logger::logln("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
+    }
+}
+```
+
+- [ ] **Step 7: Update the test constructor in `tests/mocks/firmware_stubs.cpp`**
+
+In the `Mesh::Mesh()` initializer list (line 59–65), after `hasMasterMac(false),` add:
+
+```cpp
+knownMasterMacSecondary{}, hasMasterMacSecondary(false), _dualMasterMode(false),
+```
+
+- [ ] **Step 8: Modify `processMasterBeacon` in `tests/mocks/mesh_logic_impl.cpp`**
+
+Replace the TOFU block (from the hop-count guard to the `lastSeenMasterMac` warning block) with:
+
+```cpp
+void Mesh::processMasterBeacon(const mesh_message& msg) {
+  // Guard: drop beacon if hop count would overflow uint8_t or exceed limit
+  if (msg.hopCount >= planetopia::config::MAX_HOPS) {
+    Logger::logln("MESH", "Beacon hop count exceeded MAX_HOPS, dropping relay", LogLevel::LOG_WARN);
+    return;
+  }
+
+  // --- TOFU master MAC enforcement ---
+  bool fromPrimary = hasMasterMac && memcmp(msg.originMacAddress, knownMasterMac, 6) == 0;
+  bool fromSecondary = _dualMasterMode && hasMasterMacSecondary &&
+                       memcmp(msg.originMacAddress, knownMasterMacSecondary, 6) == 0;
+
+  if (!hasMasterMac) {
+    // First beacon ever — TOFU (fallback if JOIN_ACK path not taken, e.g. master node itself)
+    memcpy(knownMasterMac, msg.originMacAddress, 6);
+    hasMasterMac = true;
+    EEPROM_Manager::getInstance().saveKnownMasterMac(knownMasterMac);
+    Logger::logln("MESH", "Master MAC learned from first beacon (TOFU fallback)",
+                  LogLevel::LOG_INFO);
+  } else if (!fromPrimary && !fromSecondary) {
+    // Beacon from unrecognised MAC
+    if (_dualMasterMode && !hasMasterMacSecondary) {
+      // Second master TOFU — learn and save as secondary
+      memcpy(knownMasterMacSecondary, msg.originMacAddress, 6);
+      hasMasterMacSecondary = true;
+      EEPROM_Manager::getInstance().saveKnownMasterMacSecondary(knownMasterMacSecondary);
+      Logger::logln("MESH", "Secondary master MAC learned (TOFU)", LogLevel::LOG_INFO);
+      // fall through to process this beacon as valid
+    } else if (millis() - lastMasterBeaconReceivedMs < STALE_MASTER_THRESHOLD_MS) {
+      // Known master(s) still fresh — reject unknown MAC
+      Logger::logln("MESH", "Beacon from unexpected MAC rejected (master still alive)",
+                    LogLevel::LOG_WARN);
+      return;
+    } else {
+      // All known masters stale — accept as new primary (hotswap)
+      Logger::logln("MESH", "Stale master — accepting new master MAC", LogLevel::LOG_INFO);
+      memcpy(knownMasterMac, msg.originMacAddress, 6);
+      EEPROM_Manager::getInstance().saveKnownMasterMac(knownMasterMac);
+    }
+  }
+
+  if (planetopia::utils::MacAddress(lastSeenMasterMac) !=
+          planetopia::utils::MacAddress(msg.originMacAddress) &&
+      lastSeenMasterMac[0] != 0) {
+    if (_dualMasterMode) {
+      Logger::logln("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
+    } else {
+      Logger::logln("MESH", "WARNING: Multiple masters detected!", LogLevel::LOG_WARN);
+    }
+  }
+  memcpy(lastSeenMasterMac, msg.originMacAddress, 6);
+  lastMasterBeaconReceivedMs = millis();
+
+  uint8_t newDistance = msg.hopCount + 1;
+  if (currentMaster.distance == 0xFF ||
+      planetopia::utils::MacAddress(currentMaster.mac) !=
+          planetopia::utils::MacAddress(msg.originMacAddress) ||
+      newDistance < currentMaster.distance) {
+    memcpy(currentMaster.mac, msg.originMacAddress, 6);
+    currentMaster.distance = newDistance;
+    memcpy(currentMaster.nextHop, msg.lastHopMacAddress, 6);
+  }
+
+  if (!isMaster) {
+    // C10 fix: only relay if this beacon is newer than the last one we relayed
+    bool isNewer = (msg.epochNum > lastRelayedEpoch) ||
+                   (msg.epochNum == lastRelayedEpoch && msg.seqNum > lastRelayedSeqNum);
+    if (!isNewer) {
+      Logger::logln("MESH", "Duplicate beacon relay suppressed", LogLevel::LOG_DEBUG);
+      return;
+    }
+    lastRelayedEpoch = msg.epochNum;
+    lastRelayedSeqNum = msg.seqNum;
+
+    uint8_t jitterMs = static_cast<uint8_t>(esp_random() % planetopia::config::RELAY_JITTER_MAX_MS);
+    relayPendingMsg = msg;
+    relayPendingMsg.hopCount = newDistance;
+    memcpy(relayPendingMsg.lastHopMacAddress, deviceMacAddress, 6);
+    relayPendingAt = millis() + 10 + jitterMs;
+    relayPending = true;
+  }
+}
+```
+
+- [ ] **Step 9: Run the five new tests to verify they pass**
+
+```
+cmake -B build -S . && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: all 5 new dual-master tests PASS, all prior tests still PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/benjamin.swanepoel/projects/personal/Planetopia-nodes
+git add main/project_config.h main/src/Mesh/Mesh.h main/src/Mesh/Mesh.cpp \
+        tests/mocks/firmware_stubs.cpp tests/mocks/mesh_logic_impl.cpp \
+        tests/unit/test_mesh_logic.cpp
+git commit -m "feat: DUAL_MASTER_MODE flag — dual TOFU, accept both master MACs, suppress multi-master warning"
+```

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-07-22
 **Status:** Approved (umbrella) — per-phase implementation plans generated on pickup
-**Scope:** 19 open issues across three repos, decomposed into 11 sequenced phases.
+**Scope:** 20 open issues across three repos, decomposed into 11 sequenced phases.
+
+> **Revision (2026-07-22, during Phase 0 planning):** Driving the real toolchain revealed that after #49's three compile blockers are fixed, the firmware **fails to link** — `MBEDTLS_CHACHAPOLY_C` is disabled in the ESP32 Arduino core, so the Phase 1 E2E AEAD (ChaCha20-Poly1305) has no implementation (filed as **#54**). The shipped E2E crypto has never linked on this toolchain. Fix: **migrate the build to ESP-IDF (arduino-as-component)** with a custom `mbedtls_config`. This promotes the formerly-deferred ESP-IDF migration into the **foundational Phase 0**, and folds the previously-deferred flash levers (drop-BT, mbedtls-trim) into scope.
 
 ## Purpose
 
@@ -20,7 +22,7 @@ The system supports the **latest protocol only**. Devices are reflashed; there i
 
 | Phase | Issues | Repo(s) | One-line |
 |---|---|---|---|
-| 0 — Build unblock | #49 | nodes | Fix arduino-cli compile (3 blockers) + add CI firmware-compile/size job |
+| 0 — ESP-IDF migration | #49, #54 | nodes | Migrate build to ESP-IDF (arduino-as-component) — links chachapoly, enables mbedtls/BT config, fixes the 4 build blockers + CI build/size job |
 | H — Hub enrollment | #87, #85, #86 | hub | Master keypair → correct JOIN_ACK → fix test. P0: enrollment is broken today |
 | H2 — Hub dual-master | #88 | hub | Populate secondary-master fields in JOIN_ACK (hub half of shipped firmware Phase 4/5) |
 | A — Persistence | #50, #43 | nodes | Migrate EepromManager → NVS/Preferences (clean start); fix DEV_MODE epoch + commit checks |
@@ -29,7 +31,7 @@ The system supports the **latest protocol only**. Devices are reflashed; there i
 | D — Enrollment harden | #42 | nodes | Pin master pubkey at flash; node verifies JOIN_ACK key against it |
 | E — Hygiene | #47 | nodes + protocol | 6 code-hygiene items + lattice-protocol `gofmt` |
 | F — Hub misc | #63, #64 | hub | Empty-name enrollment default; meshsim write-under-mutex deadlock |
-| G — Optimization | #52, #53 | nodes | Arduino-safe flash trim + RAM residency/bounds (memory_usage.md P1/P3) |
+| G — Optimization | #52, #53 | nodes | Flash trim (incl. drop-BT + mbedtls-trim, now unlocked by Phase 0's IDF build) + RAM residency/bounds (memory_usage.md P1/P3) |
 | (S) — folded into H | new | hub | Set `ProtoVersion=3` on all outbound frames + CI `mesh.pb.go`↔proto sync check |
 
 ## Dependency graph & sequencing
@@ -56,13 +58,18 @@ Phase G (nodes)        measurement-gated: needs Phase 0 (size job) + banks A (EE
 
 ## Per-issue approach (locked decisions)
 
-### Phase 0 — #49 (build unblock, nodes)
-Firmware does not compile under `arduino-cli` today; only the Arduino IDE's include resolution masks it. Three blockers:
-1. **nanopb include path** — add `main/src/mesh/serialization/nanopb` to the sketch include path (build property).
-2. **Non-self-contained headers** — `ButtonHandler.h` (and siblings) use unqualified `Logger`/`LogLevel` relying on `main.ino`'s `using namespace`. Each header `#include`s what it uses and fully-qualifies `lattice::utils::Logger` / `lattice::utils::LogLevel`. Sweep for the same pattern (overlaps #47).
-3. **Duplicate `mesh_message` typedef** — keep vendored `main/lib/lattice-protocol/c/` out of the Arduino `lib/` auto-scan (collides with `using ::mesh_message`).
+### Phase 0 — #49 + #54 (ESP-IDF migration, nodes)
+**Goal:** a firmware image that **compiles AND links** with a reproducible non-IDE toolchain and a CI size report. Driving the real toolchain (arduino-cli 1.5.1 + esp32@3.3.10) proved the current build is broken at two levels — three compile blockers, then a link failure the compile errors were masking.
 
-Then add a CI job: `arduino-cli compile --fqbn esp32:esp32:esp32 main` + `xtensa-esp32-elf-size` size report that regenerates `docs/memory_usage.md`. **Gate:** green firmware build required before any later firmware phase.
+**The four verified blockers:**
+1. **nanopb include path** — `mesh.pb.h:6` does `#include <pb.h>`; `main/src/mesh/serialization/nanopb` is not on the include path. *Verified fix:* add it as an include dir. (Under ESP-IDF: a CMake `target_include_directories`.)
+2. **Non-self-contained headers** — `ButtonHandler.h` uses unqualified `Logger`/`LogLevel` (9 sites; verified it is the *only* affected file). *Verified fix:* fully-qualify `lattice::utils::Logger`/`LogLevel`. Correctness fix regardless of toolchain; overlaps #47.
+3. **Duplicate `mesh_message` typedef** — **not** `lib/` auto-scan as originally filed (arduino-cli adds no such `-I`, verified via `compile_commands.json`). Real cause: `mesh_message.h`'s `#pragma once` fails to dedupe across two include-path spellings. *Verified fix:* a traditional `#ifndef` guard — emitted **upstream in `cmd/gen-headers`** (lattice-protocol) so it survives regeneration.
+4. **Link failure — `mbedtls_chachapoly_*` undefined (#54)** — `MBEDTLS_CHACHAPOLY_C` is disabled in the ESP32 Arduino core's mbedtls, so the Phase 1 E2E AEAD (ChaCha20-Poly1305) has no implementation. Verified: chachapoly symbols absent from the core's `libmbedcrypto.a`; gcm/sha256 present. **This is why the migration is pulled forward** — a custom `mbedtls_config` under ESP-IDF is the clean, cipher-and-wire-preserving fix.
+
+**Approach — ESP-IDF with arduino-as-component.** Migrate off bare Arduino/`arduino-cli` to an ESP-IDF (CMake) project that pulls in `arduino-esp32` as a component, so the existing Arduino API surface (`Arduino.h`, `EEPROM`, `esp_now`, `String`, etc.) keeps working with minimal source change, while gaining a custom `sdkconfig` + `mbedtls_config` we control. This: (a) enables `MBEDTLS_CHACHAPOLY_C` → resolves #54 with cipher + wire unchanged; (b) unlocks the deferred flash levers now folded into Phase G (`CONFIG_BT_ENABLED=n`, mbedtls suite trim); (c) gives a reproducible CI build + `xtensa-esp32-elf-size` size report that regenerates `docs/memory_usage.md`.
+
+**CI:** replace the (nonexistent) firmware build with an ESP-IDF build job + size-report artifact. **Gate:** a green build+link required before any later firmware phase (A/B/C/D/E/G). The exact migration steps — CMake project layout, `idf_component.yml`, `sdkconfig` defaults, source relocation — are detailed in the Phase 0 implementation plan.
 
 ### Phase H — #87 → #85 → #86 (hub enrollment, P0)
 Enrollment is broken on `main`: hub JOIN_ACK is malformed and every node rejects it (`Enrollment.cpp:95` fingerprint check fails). Ordered fix:
@@ -116,21 +123,17 @@ Six low-severity items, none affecting shipped correctness:
 - **#64:** `meshsim` `writeLocked` does a blocking TCP write while holding the sim mutex → deadlock if the peer stops reading. Add `SetWriteDeadline` in the write path; on deadline error, log + disconnect. Test-infra only.
 
 ### Phase G — #52, #53 (optimization, nodes, measurement-gated)
-Storage + memory optimization. Context: `docs/memory_usage.md` already holds a prioritized P0–P4 plan; P0/P2/P3-top are covered by Phases 0/A/B (#49/#50/#51). This phase implements the remaining **Arduino-safe** levers — the biggest flash wins (drop-BT, mbedTLS-suite-trim) need an ESP-IDF toolchain and are explicitly **out of scope** (deferred project below).
-- **#52 (flash, the real pressure point):** compile out logging `.rodata` (`#if`, not runtime `if`); confirm/enable `-Os` + LTO + `--gc-sections`; single AEAD (drop the unused cipher). Est. ~15–40 KB.
+Storage + memory optimization. Context: `docs/memory_usage.md` already holds a prioritized P0–P4 plan; P0/P2/P3-top are covered by Phases 0/A/B (#49/#50/#51). With ESP-IDF now the build (Phase 0), the biggest flash wins are **in scope** — no longer deferred.
+- **#52 (flash, the real pressure point):** `CONFIG_BT_ENABLED=n` in `sdkconfig` (~10 KB + heap — now possible under IDF); trim unused mbedtls suites via `mbedtls_config` (10–30 KB, keeping X25519 + the one AEAD); compile out logging `.rodata` (`#if`, not runtime `if`); confirm `-Os` + LTO + `--gc-sections`; single AEAD (drop the unused cipher). Est. ~35–80 KB.
 - **#53 (RAM):** shrink `mesh_message` in-RAM residency (242 B × 8-deep ring + per-frame stack copies — coordinate with the wire `static_assert`); right-size `RECV_QUEUE_SIZE`/`CACHE_SIZE`/`LATTICE_ROUTE_TABLE_MAX` after measuring real occupancy. Est. ~1 KB + bounds.
 
 **Gating:** must land after Phase 0 (the size-report job makes every before/after delta real, not estimated) and after A/B (which already bank the EEPROM ceiling + RouteTable win). #53 coordinates with #46 (`CACHE_SIZE`) and #51 (`LATTICE_ROUTE_TABLE_MAX`).
-
-## Deferred project (post-effort): ESP-IDF toolchain migration
-
-The largest flash levers — dropping BT (~10 KB, `btStop()` only disables at runtime) and trimming mbedTLS suites (10–30 KB) — require migrating off the Arduino core to **ESP-IDF / PlatformIO**. That is a large architectural change, out of scope here. **Deliverable:** a separate context + implementation plan doc to be written *after* this effort completes, evaluating the migration (est. +20–40 KB flash) against its cost/risk. Not started until the 11 phases here are done.
 
 ## Deliverable structure
 
 - **This umbrella spec** — committed now; the single cross-repo sequencing + decision record.
 - **Per-phase implementation plans** — generated via the writing-plans skill when each phase is picked up, so every phase stays PR-sized and independently executable.
-- **First plan:** Phase 0 (build unblock), since it gates all firmware verification and the memory re-measure.
+- **First plan:** Phase 0 (ESP-IDF migration), since it gates all firmware build/link, verification, and the memory re-measure.
 
 ## Open risks / notes
 

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -1,0 +1,117 @@
+# Umbrella Design: Close All Open Issues (lattice-nodes + lattice-hub + lattice-protocol)
+
+**Date:** 2026-07-22
+**Status:** Approved (umbrella) — per-phase implementation plans generated on pickup
+**Scope:** 17 open issues across three repos, decomposed into 10 sequenced phases.
+
+## Purpose
+
+Close every open issue across the Lattice mesh system. This document is the **decomposition and sequencing spec** — it maps every issue to a phase, records the locked design decision for each, and defines the cross-repo release order. It does **not** contain task-level implementation detail; each phase gets its own implementation plan (via the writing-plans skill) when it is picked up.
+
+## Global constraint: no backwards compatibility
+
+The system supports the **latest protocol only**. Devices are reflashed; there is no fielded fleet to keep compatible. This is a hard, project-wide simplification:
+
+- No data migration paths — persisted state may be reset on reflash.
+- Protocol/wire changes are flag-day. The hub already drops any frame with `ProtoVersion != 3` (`server.go:364`); the next bump is a clean cutover.
+- No version negotiation between nodes, master, or hub.
+
+## Issue → phase map
+
+| Phase | Issues | Repo(s) | One-line |
+|---|---|---|---|
+| 0 — Build unblock | #49 | nodes | Fix arduino-cli compile (3 blockers) + add CI firmware-compile/size job |
+| H — Hub enrollment | #87, #85, #86 | hub | Master keypair → correct JOIN_ACK → fix test. P0: enrollment is broken today |
+| H2 — Hub dual-master | #88 | hub | Populate secondary-master fields in JOIN_ACK (hub half of shipped firmware Phase 4/5) |
+| A — Persistence | #50, #43 | nodes | Migrate EepromManager → NVS/Preferences (clean start); fix DEV_MODE epoch + commit checks |
+| B — Routing | #45, #46, #51 | nodes | Distance-freshness coupling; replay high-water; RouteTable role-gating |
+| C — Downlink auth | #44 | protocol → nodes + hub | Per-hop HMAC-authenticated route_path; flag-day v4 proto field |
+| D — Enrollment harden | #42 | nodes | Button-press pairing window (TOFU-in-window) |
+| E — Hygiene | #47 | nodes + protocol | 6 code-hygiene items + lattice-protocol `gofmt` |
+| F — Hub misc | #63, #64 | hub | Empty-name enrollment default; meshsim write-under-mutex deadlock |
+| (S) — folded into H | new | hub | Set `ProtoVersion=3` on all outbound frames + CI `mesh.pb.go`↔proto sync check |
+
+## Dependency graph & sequencing
+
+```
+Phase 0 (nodes)  ──┐ gates all node-firmware verification + memory re-measure
+                   │
+Phase H (hub)  ────┼── gates Phase D (enrollment must work before it can be hardened)
+                   │    gates Phase H2
+Phase H2 (hub)     │
+                   │
+Phase A (nodes) ───┤ (needs Phase 0 green build)
+Phase B (nodes) ───┤ (needs Phase 0; internally parallelizable)
+Phase C (3 repos)──┤ (needs Phase 0 build + Phase H's proto-sync CI)
+Phase D (nodes) ───┘ (needs Phase 0 build + Phase H working enrollment)
+Phase E (nodes+proto)  rides Phase C's protocol release
+Phase F (hub)          fully independent — any time
+```
+
+- **Phase 0 and Phase H are in different repos with no shared dependency** — plan/execute concurrently.
+- **Phase B and Phase F are independent** — parallelizable.
+- **Phase C is the only multi-repo release.** Order: lattice-protocol change → release + tag → lattice-nodes submodule re-point + firmware → lattice-hub `go.mod` bump + `mesh.pb.go` regen. Never merge nodes against a floating protocol branch SHA (release-flow rule).
+
+## Per-issue approach (locked decisions)
+
+### Phase 0 — #49 (build unblock, nodes)
+Firmware does not compile under `arduino-cli` today; only the Arduino IDE's include resolution masks it. Three blockers:
+1. **nanopb include path** — add `main/src/mesh/serialization/nanopb` to the sketch include path (build property).
+2. **Non-self-contained headers** — `ButtonHandler.h` (and siblings) use unqualified `Logger`/`LogLevel` relying on `main.ino`'s `using namespace`. Each header `#include`s what it uses and fully-qualifies `lattice::utils::Logger` / `lattice::utils::LogLevel`. Sweep for the same pattern (overlaps #47).
+3. **Duplicate `mesh_message` typedef** — keep vendored `main/lib/lattice-protocol/c/` out of the Arduino `lib/` auto-scan (collides with `using ::mesh_message`).
+
+Then add a CI job: `arduino-cli compile --fqbn esp32:esp32:esp32 main` + `xtensa-esp32-elf-size` size report that regenerates `docs/memory_usage.md`. **Gate:** green firmware build required before any later firmware phase.
+
+### Phase H — #87 → #85 → #86 (hub enrollment, P0)
+Enrollment is broken on `main`: hub JOIN_ACK is malformed and every node rejects it (`Enrollment.cpp:95` fingerprint check fails). Ordered fix:
+- **#87 (prerequisite):** hub has no master Curve25519 keypair. Generate on first start (`crypto/rand` + `curve25519`), persist to `masterkey.json` (0600, `MASTER_KEY_PATH` env, default `/data/masterkey.json`), load on subsequent starts. Add `MasterPublicKey`/`MasterPrivateKey` to `MeshServerConfig`. Hub must also learn the master's serial-adapter MAC (env or read at startup) for `OriginMacAddress`.
+- **#85:** rebuild JOIN_ACK in `ApproveEnrollment` (`server.go:678`): `PublicKey` = master pubkey; `OriginMacAddress` = master serial MAC; `Data[0:4]` = first 4 bytes of the enrolling node's pubkey; **`ProtoVersion = 3`**.
+- **#86:** update `server_enrollment_test.go` to assert master pubkey + correct MAC + fingerprint (it currently asserts the node's key, hiding #85).
+- **Folded (Phase S):** set `ProtoVersion=3` on **all** outbound frames (JOIN_ACK, OP_NODE_ID_SET, CONFIG_SET, health-request, TX-power — only `SendNodeData` sets it today). Add a CI step asserting `mesh.pb.go` is regen-clean against `mesh.proto` + the `go.mod` protocol pin (no codegen check exists today; this is how ProtoVersion drift went unnoticed).
+
+### Phase H2 — #88 (hub dual-master, hub)
+Firmware Phase 4/5 fully implements node-side secondary master; hub never populates the wire fields. Add `SecondaryMasterPublicKey`/`SecondaryMasterMAC` to `MeshServerConfig`; when `DUAL_MASTER_ENABLED` and a secondary port is configured, `ApproveEnrollment` sets proto field 15 (`secondaryMasterMac`) + field 16 (`secondaryPublicKey`) in JOIN_ACK. Secondary master needs its own keypair (reuses #87 infrastructure). Secondary MAC via `SECONDARY_MASTER_MAC` env (explicit; simplest). Depends on Phase H.
+
+### Phase A — #50 + #43 (persistence, nodes)
+- **#50:** rewrite `EepromManager` onto NVS `Preferences` (key/value), dropping the fixed 512-byte map, manual address arithmetic, and `SCHEMA_VERSION` gating. **No migration path** (no-backcompat: clean NVS start on reflash). Removes the 98%-full ceiling permanently.
+- **#43 (absorbed into the rewrite):** in DEV_MODE keep a RAM-only monotonically-increasing epoch seed (refuse to E2E-seal if the epoch cannot advance) so dev builds never reuse AEAD nonces across reboots; check every NVS-write/`commit()` return and escalate/log on failure (a failed epoch persist is security-relevant).
+
+### Phase B — #45, #46, #51 (routing, nodes — internally parallel)
+- **#45:** `currentMaster.distance` is sticky-low → slow failover when only a longer relay path survives. Derive distance from `min(fresh-neighbor distance) + 1`, raising it only once the neighbor that supplied the low value ages out of `NeighborTable`. Review for route oscillation (the documented risk that kept this deferred).
+- **#46:** replace `ReplayCache`'s 16-entry exact-tuple ring with a per-origin high-water `(epoch, seq)` — accept only strictly-newer per origin. Memory bounded by peer count, not message rate; closes the early-eviction window. Add a `LATTICE_REPLAY_*` compile-time knob.
+- **#51:** `RouteTable` (~2.25 KB) is allocated on every node but used only by the master. Make it a pointer allocated on master-promotion (role read from NVS in `setup()`); leaves allocate nothing. Re-measure via the Phase 0 size job.
+
+### Phase C — #44 (downlink auth, protocol → nodes + hub)
+Downlink `route_path` is relay-asserted and unauthenticated (misroute/blackhole DoS). Fix with a **per-hop MAC chain keyed off the existing relay↔master pairwise E2E secret** — chosen because it is robust to node hot-swap (Phase 8 hot-swap is server-only, firmware unchanged: a replacement ESP32 enrolls fresh, the master learns its pubkey, the pairwise secret exists immediately, so the new relay can MAC its hops with zero extra provisioning). No new key material, no server participation, no new persisted state.
+- **lattice-protocol:** add a per-hop `route_mac[]` field (firmware-relevant; server tolerates/ignores it like `authTag`). Release + tag as **v4** (flag-day; no-backcompat).
+- **nodes:** each relay appends `HMAC(pairwise_secret, hop_context)` to `route_mac` as it rewrites `route_path`; the master verifies every hop against the per-node pairwise secrets it already holds; reject + log on mismatch.
+- **hub:** bump `go.mod` protocol pin to v4 + regen `mesh.pb.go`. No verification server-side (the master owns path auth; the hub is a pure downlink broadcaster).
+
+### Phase D — #42 (enrollment harden, nodes)
+Enrollment is trust-on-first-use; the master is not cryptographically authenticated. Note: once Phase H lands, the master's pubkey **is** conveyed in JOIN_ACK — but it is still unauthenticated (nothing signs that it is the real master's key). Mitigation: gate JOIN_ACK acceptance on a **physical button-held pairing window** (`ButtonHandler`); outside the window, drop TOFU master-learn. Document as the accepted "TOFU-in-window" trust model. ~0 server change. Depends on Phase H (a working enrollment to gate) and Phase 0's build.
+
+### Phase E — #47 (hygiene, nodes + protocol)
+Six low-severity items, none affecting shipped correctness:
+1. mbedtls context free-before-`err::fatal` (RAII/scope guard) in `E2ECrypto.h` / `MeshCrypto.h`.
+2. Cast `data_type` to `uint32_t` before shifts in `buildAad` (avoid implementation-defined signed shift).
+3. Serial relay `proto_version` literal should track `PROTO_VERSION` (`SerialAdapter.cpp:165`).
+4. Inline `route_len <= MAX_HOPS` clamp in `sendDownlinkToNode` (defense-in-depth).
+5. Note/guard the downlink LRU enrolled/master call-time-only check.
+6. lattice-protocol `gofmt -w` on `message/message.go` — fold into Phase C's protocol release.
+
+### Phase F — #63, #64 (hub misc, independent)
+- **#63:** dashboard approve posts an empty name → blank NodeCard. Add a name input to the dashboard approval flow (match artist-portal's pattern) **and** default `name` to the MAC string in `AssignNode` as a belt-and-suspenders orchestrator guard. Update `e2e/tests/dashboard/enrollments.spec.ts` (currently asserts `name === ''`).
+- **#64:** `meshsim` `writeLocked` does a blocking TCP write while holding the sim mutex → deadlock if the peer stops reading. Add `SetWriteDeadline` in the write path; on deadline error, log + disconnect. Test-infra only.
+
+## Deliverable structure
+
+- **This umbrella spec** — committed now; the single cross-repo sequencing + decision record.
+- **Per-phase implementation plans** — generated via the writing-plans skill when each phase is picked up, so every phase stays PR-sized and independently executable.
+- **First plan:** Phase 0 (build unblock), since it gates all firmware verification and the memory re-measure.
+
+## Open risks / notes
+
+- **Phase 0 is a prerequisite for measuring anything** — `docs/memory_usage.md` numbers are stale since the #24 restructure + Phases 1–5 and cannot be regenerated until the firmware compiles outside the IDE.
+- **Phase C proto release touches three repos** — follow the lattice-protocol release+tag flow; never re-point the nodes submodule at a floating branch SHA.
+- **`mesh.pb.*` is hand-edited on the nodes side** (no regen toolchain); add `max_size` options upstream before any regen, or the secondary-master serial codec reverts. The Phase H proto-sync CI check is hub-side (`mesh.pb.go`), separate from this nodes-side fragility.
+- **#45 fix must be reviewed for route oscillation** — the naive "latest beacon wins" is explicitly rejected; the freshness-coupled approach is the safe form.

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -141,3 +141,25 @@ Storage + memory optimization. Context: `docs/memory_usage.md` already holds a p
 - **Phase C proto release touches three repos** — follow the lattice-protocol release+tag flow; never re-point the nodes submodule at a floating branch SHA.
 - **`mesh.pb.*` is hand-edited on the nodes side** (no regen toolchain); add `max_size` options upstream before any regen, or the secondary-master serial codec reverts. The Phase H proto-sync CI check is hub-side (`mesh.pb.go`), separate from this nodes-side fragility.
 - **#45 fix must be reviewed for route oscillation** — the naive "latest beacon wins" is explicitly rejected; the freshness-coupled approach is the safe form.
+
+## Session status / resume (2026-07-22)
+
+Where this paused, so a fresh session can pick up without re-deriving.
+
+**Done:** umbrella spec approved; all decisions below locked; issues #52/#53/#54 filed; #49 corrected via comment. Branch `docs/close-all-issues-umbrella-spec` pushed to origin (spec + this doc + memory_usage.md + phase plans; `build/` gitignored).
+
+**Phase 0 research complete — recommendation to confirm:** build via **raw ESP-IDF with arduino-esp32 as a component** (not PlatformIO). Rationale: raw IDF guarantees mbedtls recompiles from source against our `sdkconfig`, so `CONFIG_MBEDTLS_CHACHAPOLY_C=y` deterministically links; the PlatformIO/pioarduino `custom_sdkconfig` path has an unverified gap on exactly that requirement. Version pins: **ESP-IDF v5.5.4**, **arduino-esp32 ^3.3.10** (via `idf_component.yml` / `idf.py add-dependency`), CI **`espressif/esp-idf-ci-action@v1`** running `idf.py build && idf.py size`.
+
+**Verified Phase-0 facts (drove the real toolchain arduino-cli 1.5.1 + esp32@3.3.10):**
+- chachapoly needs THREE Kconfig options: `CONFIG_MBEDTLS_CHACHA20_C=y`, `CONFIG_MBEDTLS_POLY1305_C=y`, `CONFIG_MBEDTLS_CHACHAPOLY_C=y` (CHACHAPOLY depends on the other two; all default `n`).
+- BT off = `CONFIG_BT_ENABLED=n`; arduino-esp32 does not require BT.
+- Node has **no TLS** (`grep` found no `WiFiClientSecure`/HTTPS/`esp_tls`) → mbedtls can trim hard (drop RSA/DHE/ECDSA/SECP256R1, keep X25519 + chachapoly + SHA-256). RSA has no standalone toggle — gated by key-exchange symbols.
+- Arduino API surface is all core-provided (String, EEPROM, `esp_now_`, Serial, digitalWrite, WiFi) → arduino-as-component keeps them; migration is mechanical (.ino→`main/main.cpp` + forward decls, `CONFIG_AUTOSTART_ARDUINO=y` or `initArduino()`, `CMakeLists.txt` with `SRC_DIRS "." "src"`, `partitions.csv`, `CONFIG_FREERTOS_HZ=1000`).
+- **EEPROM lib gotcha:** under ESP-IDF the Arduino `EEPROM` lib needs a custom partition (type `data`, subtype `0x99`, label `eeprom`) or `EEPROM.begin()` silently fails. **#50's NVS/Preferences migration removes this need** — EEPROM is confined to `EepromManager.{h,cpp}` + `Mesh.cpp`.
+- `idf.py` is NOT installed locally → Phase 0 build is only verifiable in CI or after a local IDF 5.5.4 install, not in the planning session.
+
+**Two decisions still open (needed before the Phase 0 implementation plan):**
+1. **Build tool** — confirm raw ESP-IDF (recommended) vs PlatformIO (pioarduino; would add a must-pass spike proving `custom_sdkconfig` rebuilds mbedtls).
+2. **EEPROM/#50 sequencing** — add a temporary `0x99` `eeprom` partition in Phase 0 (keep #50 in Phase A, phases stay independent) **vs** pull #50 (EEPROM→Preferences) into Phase 0 to avoid the partition workaround entirely.
+
+**Next action on resume:** answer the two decisions, then invoke `superpowers:writing-plans` for Phase 0 (ESP-IDF migration), saved to `docs/superpowers/plans/2026-07-22-phase0-esp-idf-migration.md`.

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-22
 **Status:** Approved (umbrella) — per-phase implementation plans generated on pickup
-**Scope:** 17 open issues across three repos, decomposed into 10 sequenced phases.
+**Scope:** 19 open issues across three repos, decomposed into 11 sequenced phases.
 
 ## Purpose
 
@@ -29,6 +29,7 @@ The system supports the **latest protocol only**. Devices are reflashed; there i
 | D — Enrollment harden | #42 | nodes | Pin master pubkey at flash; node verifies JOIN_ACK key against it |
 | E — Hygiene | #47 | nodes + protocol | 6 code-hygiene items + lattice-protocol `gofmt` |
 | F — Hub misc | #63, #64 | hub | Empty-name enrollment default; meshsim write-under-mutex deadlock |
+| G — Optimization | #52, #53 | nodes | Arduino-safe flash trim + RAM residency/bounds (memory_usage.md P1/P3) |
 | (S) — folded into H | new | hub | Set `ProtoVersion=3` on all outbound frames + CI `mesh.pb.go`↔proto sync check |
 
 ## Dependency graph & sequencing
@@ -46,6 +47,7 @@ Phase C (3 repos)──┤ (needs Phase 0 build + Phase H's proto-sync CI)
 Phase D (nodes) ───┘ (needs Phase 0 build + Phase H working enrollment)
 Phase E (nodes+proto)  rides Phase C's protocol release
 Phase F (hub)          fully independent — any time
+Phase G (nodes)        measurement-gated: needs Phase 0 (size job) + banks A (EEPROM) & B (RouteTable) first
 ```
 
 - **Phase 0 and Phase H are in different repos with no shared dependency** — plan/execute concurrently.
@@ -112,6 +114,17 @@ Six low-severity items, none affecting shipped correctness:
 ### Phase F — #63, #64 (hub misc, independent)
 - **#63:** dashboard approve posts an empty name → blank NodeCard. Add a name input to the dashboard approval flow (match artist-portal's pattern) **and** default `name` to the MAC string in `AssignNode` as a belt-and-suspenders orchestrator guard. Update `e2e/tests/dashboard/enrollments.spec.ts` (currently asserts `name === ''`).
 - **#64:** `meshsim` `writeLocked` does a blocking TCP write while holding the sim mutex → deadlock if the peer stops reading. Add `SetWriteDeadline` in the write path; on deadline error, log + disconnect. Test-infra only.
+
+### Phase G — #52, #53 (optimization, nodes, measurement-gated)
+Storage + memory optimization. Context: `docs/memory_usage.md` already holds a prioritized P0–P4 plan; P0/P2/P3-top are covered by Phases 0/A/B (#49/#50/#51). This phase implements the remaining **Arduino-safe** levers — the biggest flash wins (drop-BT, mbedTLS-suite-trim) need an ESP-IDF toolchain and are explicitly **out of scope** (deferred project below).
+- **#52 (flash, the real pressure point):** compile out logging `.rodata` (`#if`, not runtime `if`); confirm/enable `-Os` + LTO + `--gc-sections`; single AEAD (drop the unused cipher). Est. ~15–40 KB.
+- **#53 (RAM):** shrink `mesh_message` in-RAM residency (242 B × 8-deep ring + per-frame stack copies — coordinate with the wire `static_assert`); right-size `RECV_QUEUE_SIZE`/`CACHE_SIZE`/`LATTICE_ROUTE_TABLE_MAX` after measuring real occupancy. Est. ~1 KB + bounds.
+
+**Gating:** must land after Phase 0 (the size-report job makes every before/after delta real, not estimated) and after A/B (which already bank the EEPROM ceiling + RouteTable win). #53 coordinates with #46 (`CACHE_SIZE`) and #51 (`LATTICE_ROUTE_TABLE_MAX`).
+
+## Deferred project (post-effort): ESP-IDF toolchain migration
+
+The largest flash levers — dropping BT (~10 KB, `btStop()` only disables at runtime) and trimming mbedTLS suites (10–30 KB) — require migrating off the Arduino core to **ESP-IDF / PlatformIO**. That is a large architectural change, out of scope here. **Deliverable:** a separate context + implementation plan doc to be written *after* this effort completes, evaluating the migration (est. +20–40 KB flash) against its cost/risk. Not started until the 11 phases here are done.
 
 ## Deliverable structure
 

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -26,7 +26,7 @@ The system supports the **latest protocol only**. Devices are reflashed; there i
 | A — Persistence | #50, #43 | nodes | Migrate EepromManager → NVS/Preferences (clean start); fix DEV_MODE epoch + commit checks |
 | B — Routing | #45, #46, #51 | nodes | Distance-freshness coupling; replay high-water; RouteTable role-gating |
 | C — Downlink auth | #44 | protocol → nodes + hub | Per-hop HMAC-authenticated route_path; flag-day v4 proto field |
-| D — Enrollment harden | #42 | nodes | Button-press pairing window (TOFU-in-window) |
+| D — Enrollment harden | #42 | nodes | Pin master pubkey at flash; node verifies JOIN_ACK key against it |
 | E — Hygiene | #47 | nodes + protocol | 6 code-hygiene items + lattice-protocol `gofmt` |
 | F — Hub misc | #63, #64 | hub | Empty-name enrollment default; meshsim write-under-mutex deadlock |
 | (S) — folded into H | new | hub | Set `ProtoVersion=3` on all outbound frames + CI `mesh.pb.go`↔proto sync check |
@@ -88,7 +88,17 @@ Downlink `route_path` is relay-asserted and unauthenticated (misroute/blackhole 
 - **hub:** bump `go.mod` protocol pin to v4 + regen `mesh.pb.go`. No verification server-side (the master owns path auth; the hub is a pure downlink broadcaster).
 
 ### Phase D — #42 (enrollment harden, nodes)
-Enrollment is trust-on-first-use; the master is not cryptographically authenticated. Note: once Phase H lands, the master's pubkey **is** conveyed in JOIN_ACK — but it is still unauthenticated (nothing signs that it is the real master's key). Mitigation: gate JOIN_ACK acceptance on a **physical button-held pairing window** (`ButtonHandler`); outside the window, drop TOFU master-learn. Document as the accepted "TOFU-in-window" trust model. ~0 server change. Depends on Phase H (a working enrollment to gate) and Phase 0's build.
+Enrollment is trust-on-first-use; the master is not cryptographically authenticated. Once Phase H lands, the master's pubkey **is** conveyed in JOIN_ACK (`enrollment_public_key`) — but under plain TOFU it is still unauthenticated (an RF attacker present at enrollment can present their own key as the master).
+
+**Fix: pin the master public key at flash time and verify against it** — true authentication, not window-narrowing. Phase H/#87 gives the hub a durable master keypair (`masterkey.json`), so there is now a stable identity to pin. Since the fleet is reflashed anyway (no-backcompat) and it is a single key shared by all nodes, provisioning is cheap: inject the master pubkey at build/flash time (compile-time constant, or written to NVS at flash — compile-time constant is simplest and needs no storage). In `Enrollment::processJoinAck`, reject any JOIN_ACK whose `enrollment_public_key` does not match the pinned master key.
+
+This was reconsidered from an earlier button-window pick: button-window only *shrinks* the MITM window to the button-press moment and leaves the master key TOFU'd, whereas pinning rejects any wrong key regardless of timing. A server-signed JOIN_ACK was rejected as redundant — the node would still need the master pubkey to verify a signature, so once the key is pinned a direct compare is strictly simpler and gives the same guarantee (there is no key rotation to justify signing).
+
+**Dual-master (#88) trust is transitive:** pin the *primary* master pubkey → the primary's JOIN_ACK is authenticated → the secondary pubkey (proto field 16) arrives *inside* that authenticated frame → it is trusted without a second pin.
+
+Optional: a button-held enrollment-enable gate may still be kept as an operator-convenience control over *when* a node accepts enrollment, but it is **not** the security boundary — pinning is. ~0 server change.
+
+**Depends on Phase H** — not just for a working enrollment, but as a provisioning prerequisite: the hub must have generated its master keypair (#87) before a deployment's nodes are flashed with that pubkey. Also depends on Phase 0's build.
 
 ### Phase E — #47 (hygiene, nodes + protocol)
 Six low-severity items, none affecting shipped correctness:


### PR DESCRIPTION
## Summary
Fast-forwards two docs-only branches that were prepared but never merged, so the design artefacts survive on `main` rather than sitting on isolated remote branches.

### From `docs/close-all-issues-umbrella-spec` (6 commits)
- `docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md` — umbrella spec sequencing the 11 phases that close all 20 open issues across the three Lattice repos (no backwards-compat rule).
- `docs/memory_usage.md` — memory analysis feeding Phase G.
- `docs/superpowers/plans/nodes-phase{1..9}-*.md` — early per-phase plan drafts (some superseded by later dated plans, kept for provenance).
- `docs/superpowers/plans/2026-07-13-repo-restructure.md` — restructure plan.
- `.gitignore` (build/ ignore).

### From `docs/hardware-requirements` (7 commits)
- `docs/hardware/HARDWARE-REQUIREMENTS.md` — battery-powered hw spec.
- `docs/hardware/lattice-poc-bom.xlsx` + `generate_bom_spreadsheet.py` — POC BOM (2 masters + 5 PIR nodes) with verified supplier URLs (DIYElectronics + Takealot PLIDs).
- `docs/hardware/schematics/` — master, PIR, LED, relay, battery, solar PNGs + generator.
- `docs/superpowers/specs/2026-07-24-battery-powered-hardware-spec-design.md`.

Pure additions — no source-code overlap with `main`.

## Test plan
- [x] Both source branches merge cleanly (no code conflicts).
- [x] All added paths are under `docs/`.
- [ ] After merge, delete `origin/docs/close-all-issues-umbrella-spec` and `origin/docs/hardware-requirements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)