### PR TITLE
docs(phaseG+H2+I): audit findings + expanded scope

### DIFF
--- a/docs/superpowers/plans/2026-08-04-phaseG-memory-opt.md
+++ b/docs/superpowers/plans/2026-08-04-phaseG-memory-opt.md
@@ -1,0 +1,243 @@
+# Phase G — Memory optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Land all Phase G scope from `docs/superpowers/specs/2026-08-04-phaseG-memory-opt-design.md` (flash + RAM levers + wire shrink + audit items A-Q). Cross-repo — protocol v0.6.0 flag-day.
+
+**Architecture:** Split into 7 tasks. Task 1 tags protocol v0.6.0. Tasks 2/3/5 land nodes-only trims + refactors independently. Task 4 bumps nodes submodule + wire-consumer changes (needs v0.6.0). Task 6 bumps hub go.mod + ProtoVersion 4→5 (needs v0.6.0). Task 7 verifies + closes.
+
+**Tech Stack:** Go 1.21 (protocol), C++ (ESP-IDF), Go 1.23 (hub), GoogleTest, Playwright.
+
+## Global Constraints
+
+- Flag-day, no backwards compat with protocol v0.5.0. `ProtoVersion` bumps 4→5 atomically at hub+nodes merge.
+- `WireSize` == 200B post-Phase G (static_assert enforced).
+- Design doc canonical: `docs/superpowers/specs/2026-08-04-phaseG-memory-opt-design.md`.
+- Audit ledger: `docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md`.
+- Umbrella "release-flow rule": protocol tag pushed BEFORE nodes/hub PRs open. Nodes+hub PRs merge together.
+- Under `UNIT_TEST`, `err::fail` throws `FatalError`.
+
+---
+
+### Task 1: Protocol v0.6.0 — wire shrink + regen (lattice-protocol)
+
+**Repo:** `/Users/benji/projects/personal/lattice-protocol` — branch `feat/phaseG-wire-shrink-v0.6.0`.
+
+**Files:**
+- Modify: `message/message.go` — drop `SecondaryMasterMac` + `SecondaryPublicKey` fields (proto tags 15+16); shrink `RoutePath [60]byte → [48]byte`. Update `WireSize` constant `250 → 200`.
+- Modify: `proto/mesh.options` — nanopb `max_size` for `routePath` 60→48; drop options for the two removed fields.
+- Regen: `c/mesh_message.h` (`WireSize=200`, `static_assert` updated); `proto/mesh.proto`.
+- Modify: `README.md` — versioning table row for v0.6.0.
+
+**Interfaces produced:**
+- `MeshMessage.WireSize == 200`.
+- `MeshMessage.SecondaryMasterMac` + `SecondaryPublicKey` REMOVED. Consumers must pack/unpack from `data[4..42]` in JOIN_ACK frames.
+- `MeshMessage.RoutePath` = 48 bytes (max 8 hops × 6 bytes).
+
+- [ ] **Step 1:** Edit `message/message.go` — remove the two `Secondary*` field lines; change `RoutePath` array size; update `WireSize` const.
+- [ ] **Step 2:** Edit `proto/mesh.options` — update `routePath max_size:48`; delete `secondaryMasterMac` + `secondaryPublicKey` size options.
+- [ ] **Step 3:** `go generate ./...` — regenerate `c/mesh_message.h` + `proto/mesh.proto`.
+- [ ] **Step 4:** `make check` — verify zero drift after regen.
+- [ ] **Step 5:** `go test ./...` — all packages pass.
+- [ ] **Step 6:** Add v0.6.0 row to `README.md` versioning table: "Wire shrink 250→200B: dropped top-level Secondary{MasterMac,PublicKey} (moved to JOIN_ACK data payload); `RoutePath[60→48]` (`MAX_HOPS` 10→8). Flag-day, no v5 backcompat."
+- [ ] **Step 7:** Commit + push + open PR:
+
+```bash
+git add message/message.go proto/mesh.options c/mesh_message.h proto/mesh.proto README.md
+git commit -m "feat: protocol v0.6.0 — wire shrink 250→200B (Phase G)
+
+Drops top-level SecondaryMasterMac + SecondaryPublicKey (moved to
+JOIN_ACK data payload by consumers; wire savings −38B on every frame).
+Reduces RoutePath[60→48] via MAX_HOPS 10→8 (−12B).
+
+WireSize 250 → 200. ESP-NOW headroom restored to 50B. Flag-day; bumps
+protocol to v5 (nodes+hub PROTO_VERSION coordination).
+
+Part of lattice-nodes Phase G (issues #52 + #53)."
+git push -u origin feat/phaseG-wire-shrink-v0.6.0
+gh pr create --title "feat: protocol v0.6.0 — wire shrink 250→200B (Phase G)" --body "Phase G wire shrink. Merge, then tag v0.6.0. Nodes + hub bumps depend on the tag."
+```
+
+- [ ] **Step 8: HANDOFF** — after PR merge, tag + push:
+
+```bash
+git checkout main && git pull --ff-only
+git tag -a v0.6.0 -m "v0.6.0: protocol v5 wire shrink 250→200B (Phase G)"
+git push origin v0.6.0
+```
+
+---
+
+### Task 2: Nodes flash trim (nodes, standalone)
+
+**Repo:** `/Users/benji/projects/personal/lattice-nodes` — branch `feat/phaseG-flash-trim`.
+
+Bundles: log-macro gating (§1), sdkconfig `-Os`/LTO verify (§2), mbedtls AES/GCM/CCM trim (§3), audit A (dead code), E (FF:FF broadcast), J (pin-mask), M (SevenSeg dedup), N (readOwnMac helper).
+
+**Files:**
+- Modify: `firmware/main/src/logging/Logger.h` — add `LATTICE_LOG` / `LATTICE_LOGLN` macros gated by `LATTICE_DEFAULT_LOG_LEVEL`.
+- Modify: `firmware/main/project_config.h` — add `LATTICE_DEFAULT_LOG_LEVEL` compile-time integer mirroring runtime enum.
+- Modify: `firmware/sdkconfig.defaults` — add/verify `CONFIG_COMPILER_OPTIMIZATION_SIZE=y`, `CONFIG_COMPILER_OPTIMIZATION_LTO=y`, `CONFIG_MBEDTLS_AES_C=n`, `CONFIG_MBEDTLS_GCM_C=n`, `CONFIG_MBEDTLS_CCM_C=n`.
+- Modify: ~100 `Logger::log*` call sites — mechanical rewrite to `LATTICE_LOG*` macros.
+- Delete: `Mesh.cpp` `printMac`, `printMeshMessage`, `generateRandomMeshKey`, `meshKeyIsSet` blocks; declarations in `Mesh.h`.
+- Delete: `Adapter.cpp` LED stub block + `LED_ADAPTER_DEFAULT_PIN`; `RELAY_ADAPTER` enum value (verify no references first with `grep -rn "RELAY_ADAPTER" firmware/main/`).
+- Delete: `Error.h:88-97` `ERROR_ASSERT` + `ERROR_CHECK` templates.
+- Delete: `MacAddress.h` `MacAddress(const String&)` ctor.
+- Create: `firmware/main/src/mesh/broadcast_mac.h` — single `constexpr uint8_t BROADCAST_MAC[6] = {0xFF,...}`; consolidate 7 sites in `Mesh.cpp` + `Enrollment.cpp:72`.
+- Create: `firmware/main/src/network/hw_mac.h` — one `readOwnMac(uint8_t[6])` helper; delete 3 duplicates.
+- Modify: `GpioInput.cpp:19-46` + `GpioOutput.cpp:19-42` — `switch` → `constexpr uint64_t VALID_MASK`.
+- Modify: `SevenSegDisplay.cpp:180-244` — `show()` + `showWithDP()` → `showInternal(value, leadingZeros, bool withDP)`.
+
+**Interfaces produced:**
+- `LATTICE_LOG(tag, msg, level)`, `LATTICE_LOGLN(tag, msg, level)` — no-op in prod (level=NONE), route to Logger otherwise.
+- `lattice::mesh::BROADCAST_MAC` — canonical.
+- `lattice::hw::readOwnMac(uint8_t[6])` — canonical.
+
+- [ ] **Step 1:** Add macros to `Logger.h` (per design §1).
+- [ ] **Step 2:** Update `project_config.h` with `LATTICE_DEFAULT_LOG_LEVEL`.
+- [ ] **Step 3:** Grep all `Logger::log`/`Logger::logln` call sites, rewrite to `LATTICE_LOG`/`LATTICE_LOGLN`.
+- [ ] **Step 4:** Update `sdkconfig.defaults` with `-Os`/LTO/mbedtls trim knobs. Try build; if mbedtls trim breaks link, roll back specific offending knob.
+- [ ] **Step 5:** Delete dead code per file list above.
+- [ ] **Step 6:** Create `broadcast_mac.h` + `hw_mac.h`; replace duplicates.
+- [ ] **Step 7:** Rewrite pin-validation `switch` → mask in Gpio{Input,Output}.cpp.
+- [ ] **Step 8:** Refactor SevenSegDisplay `show`/`showWithDP` → `showInternal`.
+- [ ] **Step 9:** Full unit + e2e suite green.
+- [ ] **Step 10:** Commit + push + PR:
+
+```bash
+git commit -m "feat(phaseG): flash trim — log macros, mbedtls trim, dead-code delete, DRY
+
+Flash levers 1-3 (log-.rodata compile-time gate, -Os/LTO verify,
+mbedtls AES/GCM/CCM off) + audit items A/E/J/M/N.
+
+Est. ~10-25 KB flash saved. CI size job attached below.
+
+Part of Phase G (issues #52, #53)."
+```
+
+---
+
+### Task 3: Nodes RAM residency + CompactMessage (nodes)
+
+**Branch:** `feat/phaseG-ram-residency` (or continue same feat branch — implementer's choice; separate branch keeps PR review manageable).
+
+Bundles: RECV_QUEUE_SIZE (§4), ROUTE_TABLE_MAX (§5), REPLAY_MAX_ORIGINS (§6), CompactMessage (§7), audit B (E2E_KEYCACHE role split), C (PENDING_RELAY_QUEUE follow), D (ReplayCache padding), K (PIR state), L (pin types).
+
+**Files:**
+- Modify: `firmware/main/project_config.h` — bound tunings + `LATTICE_E2E_KEYCACHE_MAX` role-conditional split (either two constants or a runtime cap driven by `isMaster`).
+- Modify: `firmware/main/src/mesh/ReplayCache.h` — field reorder for padding.
+- Modify: `firmware/main/src/mesh/E2EKeyStore.h` — role-conditional cache size.
+- Modify: `firmware/main/src/mesh/Enrollment.h` — `PENDING_RELAY_QUEUE_SIZE = 4` (mirrors new RECV_QUEUE_SIZE).
+- Create: `firmware/main/src/mesh/CompactMessage.{h,cpp}` — new compact struct + `toCompact`/`toWire` converters.
+- Modify: `firmware/main/src/mesh/Mesh.h` — `recvQueue` element type → `CompactMessage`.
+- Modify: `firmware/main/src/mesh/Mesh.cpp` — decode/encode boundary in `messageProcessor` + `drainRecvQueue`; extract type-specific fields from raw wire buffer when needed (JOIN_ACK secondary fields, RouteReport auth_path).
+- Modify: `firmware/main/src/adapter/pir/PirAdapter.h` — `_cooldownSeconds` → `constexpr`; collapse `_timerActive`/`_motionSent`.
+- Modify: `firmware/main/src/adapter/Adapter.h` + `AdapterFactory.*` — pin types `int` → `uint8_t`.
+- Test: `tests/unit/test_compact_message.cpp` (new) — round-trip preservation.
+
+- [ ] **Step 1:** Write failing round-trip tests for CompactMessage.
+- [ ] **Step 2:** Implement CompactMessage + converters.
+- [ ] **Step 3:** Tune bounds in project_config.h.
+- [ ] **Step 4:** ReplayCache padding reorder.
+- [ ] **Step 5:** E2E_KEYCACHE role split.
+- [ ] **Step 6:** PENDING_RELAY_QUEUE_SIZE follow.
+- [ ] **Step 7:** PIR state cleanup + pin type shrink.
+- [ ] **Step 8:** Change `recvQueue` element type + adapt Mesh.cpp decode boundary.
+- [ ] **Step 9:** Full unit + e2e suite green.
+- [ ] **Step 10:** Commit + push + PR.
+
+---
+
+### Task 4: Nodes wire consumer changes (needs Task 1's v0.6.0 tag)
+
+**Branch:** `feat/phaseG-wire-consumer`.
+
+**Precondition:** protocol `v0.6.0` tag exists on origin.
+
+**Files:**
+- Modify: `firmware/main/lib/lattice-protocol` submodule pin → v0.6.0.
+- Modify: `firmware/main/src/mesh/Enrollment.cpp::processJoinAck` — read secondary from `data[4..42]` (post-pin verify, pre-registration).
+- Modify: `firmware/main/project_config.h` — `MAX_HOPS = 8`.
+- Modify: `firmware/main/src/mesh/Mesh.h` — `PROTO_VERSION = 5`.
+- Modify: `firmware/main/src/mesh/Mesh.cpp` — verify `route_len ≤ MAX_HOPS` (Phase E clamp already handles).
+- Update: `tests/unit/test_enrollment.cpp` (or `test_mesh_logic.cpp`) — dual-master JOIN_ACK reads secondary from `data[]`.
+
+- [ ] **Step 1:** Bump submodule to v0.6.0; verify `c/mesh_message.h` reflects 200B.
+- [ ] **Step 2:** Update `Enrollment::processJoinAck` — parse secondary from data payload.
+- [ ] **Step 3:** Update `MAX_HOPS` = 8 in project_config.h.
+- [ ] **Step 4:** Bump `PROTO_VERSION` = 5.
+- [ ] **Step 5:** Update tests for new dual-master layout.
+- [ ] **Step 6:** Full regression + e2e.
+- [ ] **Step 7:** Commit + push + PR:
+
+```bash
+git commit -m "feat(phaseG): consume protocol v0.6.0 wire shrink + PROTO_VERSION 5
+
+Bumps submodule to v0.6.0 (wire 200B). Enrollment::processJoinAck
+reads secondary master MAC + pubkey from data[4..42] (previously
+top-level MeshMessage fields, now packed into JOIN_ACK data payload).
+MAX_HOPS 10→8. PROTO_VERSION 4→5 atomic flag-day (hub bumps in
+parallel PR)."
+```
+
+---
+
+### Task 5: Nodes DRY + robustness (audit F/G/H/I/O/P/Q)
+
+**Branch:** `feat/phaseG-audit-dry`.
+
+- Item F: cache `esp_wifi_get_mac` boot-time result in `g_deviceMac`; replace 4-6 per-RX-frame syscall sites.
+- Item G: cache `Enrollment::isEnrolled()` state — set in `init`/`processJoinAck`/`saveEnrolledFlag`.
+- Item H: `std::function` → function-pointer typedefs on `externalRecvCallback`, `RegisterPeerFn`, `EnrollmentRelayFn`.
+- Item I: drop `virtual` on GpioInput/GpioOutput `init()`.
+- Item O: extend `_persistOrEscalate` to all 18 NVS put-sites (13 non-security get `securityRelevant=false`).
+- Item P: extend `MbedtlsGuard.h` with `EcpGroupCtx`, `MpiCtx`, `EcpPointCtx`, `ChaChaPolyCtx`; migrate `MeshCrypto.h`/`E2ECrypto.h` sites.
+- Item Q: canonical `bool lattice::mac::eq(const uint8_t*, const uint8_t*)`; grep both existing idioms (`memcmp(...,6)==0` and `MacAddress == MacAddress`), replace all ~60 sites.
+
+- [ ] Each item = one commit; full regression per item.
+- [ ] Final PR bundles all 7 items with size delta in body.
+
+---
+
+### Task 6: Hub v0.6.0 + ProtoVersion 5 + JOIN_ACK data-payload write (needs Task 1's tag)
+
+**Repo:** `/Users/benji/projects/personal/lattice-hub` — branch `chore/phaseG-protocol-v0.6.0`.
+
+**Precondition:** protocol `v0.6.0` tag exists.
+
+**Files:**
+- Modify: `server/orchestrator/go.mod` — protocol v0.5.0 → v0.6.0; `go mod tidy`.
+- Regen: `server/orchestrator/mesh/mesh.pb.go` via `go generate ./mesh/...`.
+- Modify: `server/orchestrator/mesh/server.go::ApproveEnrollment` — pack secondary MAC + pubkey into `data[4..42]` of JOIN_ACK's data field when secondary is configured; drop the top-level `SecondaryMasterMac`/`SecondaryPublicKey` writes (fields no longer exist in v0.6.0).
+- Modify: `server/orchestrator/mesh/server.go` — every `ProtoVersion` gate + outbound stamp bumps `4 → 5` atomically.
+- Update: test fixtures — JOIN_ACK secondary read from `data[]` layout.
+
+- [ ] **Step 1:** Sync main; branch.
+- [ ] **Step 2:** `go get lattice-protocol@v0.6.0`; `go mod tidy`; `go generate ./mesh/...`.
+- [ ] **Step 3:** Update `ApproveEnrollment` — pack secondary into `data[4..42]`.
+- [ ] **Step 4:** Bump `ProtoVersion` 4→5 at every hit (grep `ProtoVersion` production + tests).
+- [ ] **Step 5:** `go test -race -count=1 ./...`.
+- [ ] **Step 6:** Commit + push + PR.
+
+---
+
+### Task 7: Cross-repo verify + close #52, #53
+
+- [ ] Confirm protocol v0.6.0 tag pushed.
+- [ ] Confirm nodes PRs (Tasks 2/3/4/5) + hub PR (Task 6) merged in correct order (Tasks 4+6 flag-day pair).
+- [ ] Post CI size deltas in each PR body.
+- [ ] `Closes #52, #53` fires on the nodes PR containing the flash+RAM items.
+- [ ] SDD ledger.
+
+---
+
+## Execution notes
+
+- Tasks 2, 3, 5 are nodes-only + parallelizable; each is its own PR.
+- Tasks 4 + 6 are the flag-day pair — must merge together.
+- Task 1 is the release-flow gate — its tag must exist before Tasks 4 + 6 open PRs.
+- Suggested subagent-driven execution order: Task 1 → Task 2 → Task 3 → Task 5 → (Task 4 + Task 6 parallel setup, sequential dispatch) → Task 7.
+
+## Self-review
+
+Coverage: §1 → Task 2, §2 → Task 2, §3 → Task 2, §4-§7 → Task 3, §8 → Tasks 1+4+6, §9 (A-Q) → Tasks 2 (A/E/J/M/N), 3 (B/C/D/K/L), 5 (F/G/H/I/O/P/Q), §10 CI size → Task 7 aggregate.

--- a/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
+++ b/docs/superpowers/specs/2026-07-22-close-all-open-issues-design.md
@@ -31,7 +31,9 @@ The system supports the **latest protocol only**. Devices are reflashed; there i
 | D — Enrollment harden | #42 | nodes | Pin master pubkey at flash; node verifies JOIN_ACK key against it |
 | E — Hygiene | #47 | nodes + protocol | 6 code-hygiene items + lattice-protocol `gofmt` |
 | F — Hub misc | #63, #64 | hub | Empty-name enrollment default; meshsim write-under-mutex deadlock |
-| G — Optimization | #52, #53 | nodes | Flash trim (incl. drop-BT + mbedtls-trim, now unlocked by Phase 0's IDF build) + RAM residency/bounds (memory_usage.md P1/P3) |
+| G — Optimization | #52, #53 | nodes + protocol + hub | Flash trim (log-macros, `-Os`/LTO, mbedtls AES/GCM trim) + RAM residency (CompactMessage, bounds tune) + wire shrink 250→200B via protocol v0.6.0 flag-day + 17 no-cost items (A-Q) from 2026-08-04 post-Phase-G audit |
+| H2 — Refactor sweep | (no upstream issue; audit-driven) | nodes | Medium-scope DRY/OOP/pattern refactors (items R-AA) surfaced by 2026-08-04 audit: String-concat log elimination, DisplayManager tick throttle, Button non-blocking debounce, health-frame dedup, adapter op-dispatch table, MAC-keyed-table helper, singleton→namespace migration |
+| I — Native ESP-IDF leverage | (no upstream issue; audit-driven) | nodes | Complete Arduino→ESP-IDF migration (items BB-JJ): Arduino WiFi.h → `esp_wifi_*` direct (~15-25KB flash), Preferences → `nvs_flash`, Logger → `esp_log.h`, tickless idle + `xTaskCreateStatic` (~30-40% avg current), `millis()` → `esp_timer_get_time` (49-day wrap fix), mbedtls → libsodium option, `MEMORY_BUFFER_ALLOC`, stack shrink |
 | (S) — folded into H | new | hub | Set `ProtoVersion=3` on all outbound frames + CI `mesh.pb.go`↔proto sync check |
 
 ## Dependency graph & sequencing
@@ -128,6 +130,47 @@ Storage + memory optimization. Context: `docs/memory_usage.md` already holds a p
 - **#53 (RAM):** shrink `mesh_message` in-RAM residency (242 B × 8-deep ring + per-frame stack copies — coordinate with the wire `static_assert`); right-size `RECV_QUEUE_SIZE`/`CACHE_SIZE`/`LATTICE_ROUTE_TABLE_MAX` after measuring real occupancy. Est. ~1 KB + bounds.
 
 **Gating:** must land after Phase 0 (the size-report job makes every before/after delta real, not estimated) and after A/B (which already bank the EEPROM ceiling + RouteTable win). #53 coordinates with #46 (`CACHE_SIZE`) and #51 (`LATTICE_ROUTE_TABLE_MAX`).
+
+**Expanded 2026-08-04:** protocol v0.6.0 flag-day wire shrink (250→200B) — move secondary-master fields into JOIN_ACK `data[64]` (-38B) + `MAX_HOPS` 10→8 (-12B). Cross-repo release-flow: protocol tag → nodes+hub in parallel; ProtoVersion 4→5.
+
+**Expanded 2026-08-04 (audit-driven, items A-Q):** 17 no-cost / trivial-risk items surfaced by a 4-agent code-review audit. Full ledger: `docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md`. Highlights: role-split `LATTICE_E2E_KEYCACHE_MAX` (leaves ≤2), `_persistOrEscalate` at all NVS write sites, `std::function` → function-pointer typedefs, `GpioInput`/`GpioOutput` vtable removal, canonical `mac_eq` free function replacing ~60 sites, extend `MbedtlsGuard` to remaining hand-managed contexts, delete dead helpers, `ReplayCache::Entry` padding fix. Est. additional ~1.5 KB RAM + ~5-8 KB flash.
+
+### Phase H2 — Refactor sweep (nodes, audit-driven)
+
+Medium-scope DRY/OOP/pattern refactors surfaced by the 2026-08-04 audit (items R-AA in `docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md`). Not tied to any pre-existing issue — captured as follow-up phase to fold in the code-review findings that were bigger than Phase G's "no-cost" bar. Runs after Phase G ships.
+
+- **String-concat log elimination (item R):** ~78 sites across mesh + adapter + hardware still build `String` temporaries before Phase G's macro gating can short-circuit. Rewrite to `snprintf` into stack `char[]`. Removes hot-path heap churn per mesh frame.
+- **DisplayManager tick throttle (item S):** only re-clock TM1637 on value change. Reclaims ~100-200 ms/sec CPU.
+- **Button non-blocking debounce (item T):** currently spins `delay(10)`; ButtonHandler polls two buttons every loop → ~20 ms/loop stall. Switch to timestamp-driven rolling debounce.
+- **`sendBroadcast` helper (item U):** fold 5 `esp_now_send(broadcastMac, ...)` sites into one.
+- **Adapter op-dispatch table (item V):** OP_CONFIG_SET/OP_NODE_ID_SET/OP_HEALTH_REQ/OP_TX_POWER_SET currently duplicated between base `Adapter` and `SerialAdapter`. ~150 lines dedup.
+- **Health-frame builder in base (item W):** dedup PIR + Serial health-report code paths.
+- **Combined `neighbors.observe + minFreshDistance` pass (item X):** halves neighbor-scan cost per beacon RX.
+- **MAC-keyed-table helper (item Y):** 5 classes reimplement the same skeleton (NeighborTable/RouteTable/E2EKeyStore/ReplayCache/PeerRegistry). Extract shared free helpers.
+- **`is_zero` helper (item Z):** replaces 3 hand-rolled zero-check loops.
+- **Singleton → namespace migration (item AA):** ~25 `getInstance()` sites → free functions holding file-static state; removes `__cxa_guard_*` prologues per callsite.
+
+Est. ~1-2 KB flash + significant hot-path heap-churn elimination.
+
+**Gating:** post-Phase-G. No cross-repo. No wire changes.
+
+### Phase I — Native ESP-IDF leverage (nodes, audit-driven)
+
+Complete the Arduino → ESP-IDF migration started by Phase 0. Items BB-JJ in the audit ledger. Runs after Phase H2 (order not strict; both are firmware-only).
+
+- **Arduino `WiFi.h` → direct `esp_wifi_*` (item BB):** pulls only `esp_netif_init` + `esp_event_loop_create_default` + `esp_wifi_init` + `esp_wifi_set_mode(WIFI_MODE_STA)` + `esp_wifi_start()`. Drops `WiFiGeneric/STA/AP/Scan/Client/Server`, TCP/IP-adapter shims, LWIP contexts. **Est. ~15-25 KB flash + several KB DRAM.** Single biggest lever.
+- **Arduino `Preferences` → direct `nvs_flash`/`nvs_open`/`nvs_get_*` (item CC):** removes wrapper (~1-2 KB flash) + unlocks `nvs_get_stats`, iterators, atomic-epoch guarantees.
+- **Arduino `Serial` + Logger heap → `uart_driver_install` + `esp_log.h` (item DD):** several KB flash; native `ESP_LOGI/W/E` level gating + color; removes libc printf + Arduino String overloads from logging path. Coordinate with Phase G's log macros + Phase H2's String elimination.
+- **Tickless idle + dedicated mesh task (item EE):** `CONFIG_PM_ENABLE=y` + `CONFIG_FREERTOS_USE_TICKLESS_IDLE=y` + `esp_pm_config_esp32_t{80, 240, true}` + `xTaskCreatePinnedToCoreStatic` for mesh drain (block on `xTaskNotifyGive` from RX callback) + static task alloc. **Est. ~30-40% avg current for battery nodes.** Depends on H2 item T (non-blocking Button) + item S (DisplayManager throttle) — those unblock the sleep windows PM would give.
+- **`millis()` → `esp_timer_get_time()` (item FF):** 100+ sites. Arduino wraps at 49 days; native `esp_timer_get_time()` is int64 microseconds (292 000 years). Audit `uint32_t lastSeenMillis` fields → `uint64_t`.
+- **mbedtls → libsodium option (item GG):** `crypto_scalarmult_curve25519` + `crypto_kdf_derive_from_key`. `espressif__libsodium` already in component manager. Cache `EntropyCtx` + `CtrDrbgCtx` seeded once at boot. Est. ~15-20 KB flash + smaller heap.
+- **`CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C=y` + 4KB static arena (item HH):** if staying with mbedtls. Bounds crypto heap; makes fragmentation deterministic.
+- **`CONFIG_ARDUINO_LOOP_STACK_SIZE=8192` → 4096 (item II):** measure high-water via `uxTaskGetStackHighWaterMark` first. **4 KB permanent DRAM.**
+- **PeerRegistry stream-per-record (item JJ):** `loadFromEEPROM`/`saveToEEPROM` currently stack-alloc 380B buffers for 10 records; stream one at a time. 380 B transient stack.
+
+Est. cumulative ~35-45 KB flash + ~10 KB DRAM + 30-40% average current + 49-day wrap bug class eliminated.
+
+**Gating:** post-Phase-H2 (or parallel; both firmware-only, no cross-repo). Some items (mbedtls swap GG) are mutually exclusive with others (HH memory-buffer alloc) — pick one per plan.
 
 ## Deliverable structure
 

--- a/docs/superpowers/specs/2026-08-04-phaseG-memory-opt-design.md
+++ b/docs/superpowers/specs/2026-08-04-phaseG-memory-opt-design.md
@@ -203,7 +203,43 @@ Savings: −12B/frame.
 1. Protocol PR merges + `v0.6.0` tag.
 2. Nodes + hub PRs open in parallel; must merge together (flag-day).
 
-### 9. CI size measurement
+### 9. Audit-driven no-cost wins (items A-Q from post-Phase-G audit)
+
+Reference: `docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md`. Adding 17 trivial/low-risk items to Phase G scope. Grouped by touchpoint:
+
+**Delete dead code (item A) — ~1-2 KB flash:**
+- `Mesh.cpp` — remove `printMac`, `printMeshMessage`, `generateRandomMeshKey`, `meshKeyIsSet` (all unreferenced).
+- `Adapter.cpp` — remove LED stub handler block, `RELAY_ADAPTER` enum value (never referenced), `LED_ADAPTER_DEFAULT_PIN`.
+- `Error.h:88-97` — remove `ERROR_ASSERT` + `ERROR_CHECK` templates (no callers).
+- `MacAddress.h` — remove `MacAddress(const String&)` sscanf ctor (no callers; pulls libc format tables).
+
+**Right-size RAM state:**
+- Item B: `LATTICE_E2E_KEYCACHE_MAX` role-split — leaves get 2 (primary+secondary master); masters get 10. Mirror `reevaluateRouteTable` role-conditional pattern. **~576 B RAM per leaf.**
+- Item C: `Enrollment::PENDING_RELAY_QUEUE_SIZE` 8→4 to track `RECV_QUEUE_SIZE`. **~152 B RAM.**
+- Item D: `ReplayCache::Entry` field reorder for padding: `{uint32 epoch, uint32 lastSeenMs, uint16 seq, uint8 mac[6], bool used}`. **48 B RAM.**
+- Item K: `pir/PirAdapter.h::_cooldownSeconds` → `constexpr`; collapse `_timerActive`/`_motionSent`. ~6-10 B/PIR.
+- Item L: pin types `int` → `uint8_t` across `Adapter.h` + factory. ~3-4 B/adapter.
+
+**DRY helpers + consolidation:**
+- Item E: consolidate FF:FF broadcast MAC — 7 `static const uint8_t[6]` sites into one `constexpr` header. ~50 B flash.
+- Item N: 3 copies of `readOwnMac(uint8_t[6])` (PirAdapter, SerialAdapter, SerialFraming) → one helper in `hw_mac.h`. ~150 B flash.
+- Item Q: canonical `bool lattice::mac::eq(const uint8_t*, const uint8_t*)` — replaces ~60 sites of two competing idioms (`memcmp(a,b,6)==0` and `MacAddress(a) == MacAddress(b)`; the latter is worse — extra `memcpy`). ~1.5-2 KB flash.
+- Item J: `GpioInput::isValidPin` / `GpioOutput::isValidPin` `switch` → `constexpr uint64_t VALID_MASK; return pin<64 && (MASK>>pin)&1;`. ~150-300 B flash.
+- Item M: `SevenSegDisplay::show()` and `showWithDP()` → one `showInternal(value, leadingZeros, bool withDP)`. 200-350 B flash.
+
+**Compile-time / type wins:**
+- Item H: `std::function` → plain function-pointer typedefs. Sites: `Mesh.h::externalRecvCallback`, `Enrollment.h::RegisterPeerFn` + `EnrollmentRelayFn`. All current bindings are function pointers or captureless lambdas. **~100 B RAM + ~1 KB flash.**
+- Item I: `GpioInput`/`GpioOutput` drop `virtual` on `init()` — never dispatched polymorphically (grep confirms no `GpioInput*` dispatch). Keeps Adapter virtual — that IS dispatched via `Adapter*`. ~200-400 B flash + pointer/instance.
+
+**Correctness / robustness:**
+- Item F: cache `esp_wifi_get_mac(WIFI_IF_STA, ...)` result at boot — currently called on every RX-frame (4-6 sites in Adapter, SerialAdapter, SerialFraming). MAC doesn't change. CPU win + minor flash.
+- Item G: cache `Enrollment::isEnrolled()` — currently reads NVS via `_prefs.getBool` every call, called 2-3× per `loop()` from `main.cpp`. Set cached bool in `init()`/`processJoinAck()`/`saveEnrolledFlag()`. Eliminates per-loop NVS I/O.
+- Item O: extend `_persistOrEscalate` (Phase A) to all 18 NVS put-sites (currently used at only 5). Non-security sites get `securityRelevant=false` so short-write failures don't silently discard. ~150 B flash + robustness.
+- Item P: extend `MbedtlsGuard.h` (Phase E) with `EcpGroupCtx`, `MpiCtx`, `EcpPointCtx`, `ChaChaPolyCtx` — Phase E left these hand-managed in `MeshCrypto.h::generateKeypair` and `E2ECrypto.h::sealPayload/openPayload`. Same UNIT_TEST-unwind leak class the guard fixed elsewhere.
+
+**Cumulative est. impact (items A-Q):** ~1.5 KB RAM + ~5-8 KB flash on top of the wire-shrink + CompactMessage + bounds-tune savings already in §1-§8.
+
+### 10. CI size measurement
 
 Use existing `firmware-build.yml` `idf.py size` job. Post the size delta in the PR body:
 

--- a/docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md
+++ b/docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md
@@ -1,0 +1,92 @@
+# Post-Phase-G Code-Review Audit — Findings Ledger
+
+**Status:** Reference document (not an implementation spec).
+**Date:** 2026-08-04
+**Method:** 4 parallel Explore-agent audits across mesh subsystem, non-mesh subsystems, cross-cutting patterns, heap+ESP-IDF leverage.
+**Purpose:** capture every audit finding with rank, saving, effort, and disposition (Phase G / H / I / keep-as-is) so future sessions have full context.
+
+## Bucket assignments
+
+- **Phase G (expanded, current)** — items A-Q (17 no-cost / trivial-risk wins).
+- **Phase H (post-G medium refactor)** — items R-AA (10 medium-scope refactors).
+- **Phase I (native ESP-IDF leverage)** — items BB-JJ (9 large-scope Arduino→ESP-IDF migrations).
+
+## Full findings table
+
+### Phase G additions (A-Q — no-cost / trivial-risk)
+
+| ID | File:line | Description | Saving | Effort |
+|---|---|---|---|---|
+| A | Multiple (`Mesh.cpp` `printMac`/`printMeshMessage`/`generateRandomMeshKey`/`meshKeyIsSet`; `Adapter.cpp` LED stub + RELAY enum + `LED_ADAPTER_DEFAULT_PIN`; `Error.h:88-97` `ERROR_ASSERT`/`ERROR_CHECK`; `MacAddress(const String&)` ctor) | Delete dead code | ~1-2 KB flash | trivial |
+| B | `project_config.h:117`, `E2EKeyStore.h:73` | Role-split `LATTICE_E2E_KEYCACHE_MAX`: leaves need ≤2 (primary+secondary master), masters may need more. Mirror `reevaluateRouteTable` pattern from Phase B. | ~576 B RAM per leaf | low |
+| C | `Enrollment.h:54` `PENDING_RELAY_QUEUE_SIZE` | Track `RECV_QUEUE_SIZE` 8→4 (its comment says "mirrors RECV_QUEUE"). | ~152 B RAM | trivial |
+| D | `ReplayCache.h:11-17` `Entry` field order | Reorder `{mac[6], uint32 epoch, uint16 seq, uint32 lastSeenMs, bool used}` → `{uint32 epoch, uint32 lastSeenMs, uint16 seq, uint8 mac[6], bool used}` to save 4B/entry padding. | 48 B RAM | trivial |
+| E | 7 sites (`Mesh.cpp:132,333,592,888,1069,1179,1342`, `Enrollment.cpp:72`) | Consolidate FF:FF broadcast MAC into one `constexpr` header. | ~50 B flash | trivial |
+| F | `Adapter.cpp:50,74`, `SerialAdapter.cpp:32`, `SerialFraming.cpp:16,140` | Cache `esp_wifi_get_mac(WIFI_IF_STA, ...)` once at boot instead of per-RX-frame syscall. MAC doesn't change at runtime. | CPU + minor flash | low |
+| G | `Enrollment.cpp:49-51`, `main.cpp:238,302,311` | Cache `isEnrolled()` — currently reads NVS via `_prefs.getBool` every call, called 2-3× per `loop()`. Set the cached bool in `init()`/`processJoinAck()`/`saveEnrolledFlag()`. | Per-loop NVS I/O eliminated | trivial |
+| H | `Mesh.h:75` `externalRecvCallback`; `Enrollment.h:12` `RegisterPeerFn`, `EnrollmentRelayFn` | `std::function` → plain function-pointer typedefs. All existing binding sites are function pointers or captureless lambdas. | ~100 B RAM + ~1 KB flash | low |
+| I | `hardware/input/GpioInput.h`, `hardware/output/GpioOutput.h`, plus `Pir.h`/`Button.h`/`Led.h`/`SevenSegDisplay.h` | Drop `virtual` on GpioInput/GpioOutput `init()` — never dispatched polymorphically. Keeps Adapter hierarchy virtual (that IS dispatched via `Adapter*`). | ~200-400 B flash + pointer/instance | low |
+| J | `GpioInput.cpp:19-46`, `GpioOutput.cpp:19-42` | Replace pin-validation `switch` with `constexpr uint64_t VALID_MASK; return pin<64 && (MASK>>pin)&1;`. | ~150-300 B flash | trivial |
+| K | `pir/PirAdapter.h:32` `_cooldownSeconds` → `constexpr`; collapse `_timerActive`/`_motionSent` into one enum | Reduce PIR adapter state redundancy. | ~6-10 B RAM/PIR node | trivial |
+| L | `Adapter.h:34` `int _pin` → `uint8_t`; factory pin API `int` → `uint8_t` | ESP32 pins are 0-39; wide types waste padding. | ~3-4 B RAM/adapter | trivial |
+| M | `SevenSegDisplay.cpp:180-244` `show()` and `showWithDP()` | Refactor into one `showInternal(value, leadingZeros, bool withDP)`; two 30-line copies differ only in `segs[3] |= 0x80`. | 200-350 B flash | low |
+| N | `PirAdapter.cpp:68`, `SerialAdapter.cpp:20`, `SerialFraming.cpp:15` | Three copies of `static void readOwnMac(uint8_t[6])` → one helper in a small `hw_mac.h`. | ~150 B flash | trivial |
+| O | `EepromManager.cpp` all `_prefs.put*` sites | `_persistOrEscalate` (from Phase A) used at only 5 of 18 sites. Route the other 13 through with `securityRelevant=false` so short-write failures don't silently discard. | ~150 B flash + robustness | low |
+| P | `MeshCrypto.h`, `E2ECrypto.h` | Extend `MbedtlsGuard.h` with `EcpGroupCtx`, `MpiCtx`, `EcpPointCtx`, `ChaChaPolyCtx` — Phase E left these hand-managed even though they're the same UNIT_TEST-unwind hazard. | UNIT_TEST leak fix + 15 lines dedup | low |
+| Q | ~60 sites across mesh + adapter | Canonical `bool lattice::mac::eq(const uint8_t*, const uint8_t*)` — currently two idioms (`memcmp(a,b,6)==0` and `MacAddress(a) == MacAddress(b)`), the latter is worse (extra memcpy). | ~1.5-2 KB flash | low-med |
+
+### Phase H additions (R-AA — medium refactor)
+
+| ID | File:line | Description | Saving | Effort |
+|---|---|---|---|---|
+| R | ~78 sites across mesh + adapter + hardware | `String`-concat log/format-arg elimination → `snprintf` into stack `char[]`. Heap churn currently fires even under Phase G's macro gating because arguments are constructed before the macro's ternary short-circuits. | Eliminates hot-path heap churn on every mesh frame | med |
+| S | `app/DisplayManager.h:22-27` | `DisplayManager::tick` re-clocks TM1637 (6 blocking `writeByte`s, each up to 20ms ACK wait) every `loop()` tick once enrolled. Only refresh on value-change; keep 500ms toggle for pre-enroll. | ~100-200 ms/sec CPU reclaimed | low |
+| T | `Button.cpp:26-35` (waitForHold `delay(10)`) | `Button::isPressed()` spins `delay(5)*2 = 10ms` blocking; ButtonHandler polls two buttons every loop → ~20ms/loop stalled. Switch to non-blocking last-poll timestamp + rolling debounce vote. | Removes ~20ms/loop stall; enables tickless idle | med |
+| U | `Mesh.cpp:594,1070,1180,1343`, `Enrollment.cpp:73` | Fold 5 `esp_now_send(broadcastMac, ...)` sites into `sendBroadcast(const mesh_message&)` helper on Mesh. | ~100-200 B flash | low |
+| V | `Adapter.cpp:41-93` vs `SerialAdapter.cpp:105-129,312-405` | OP_CONFIG_SET/OP_NODE_ID_SET/OP_HEALTH_REQ/OP_TX_POWER_SET dispatch table (or `handleControlOp(op, data, isTarget)` helper) — currently 150 lines duplicated between base `Adapter::onMeshData` and `SerialAdapter::onMeshDataImpl` (SerialAdapter handles them again in `handleCompleteFrame`). | ~1-2 KB flash | med |
+| W | `PirAdapter.cpp:72-86` vs `SerialAdapter.cpp:24-54` | Health-frame builder + tick-interval into `Adapter` base — `sendNodeHealth`/`sendHealthReport` are the same shape (opcode + adapterType + 6B MAC + 4B LE uptime into `data[64]`). | ~300-500 B flash + 10B RAM | low |
+| X | `Mesh.cpp:843,850` `processMasterBeacon` | Fold `neighbors.observe(...)` + `neighbors.minFreshDistance(millis())` into single pass — currently two full linear passes of the neighbor table on every beacon RX. Have `observe()` return the freshly-minimum distance, or a combined `observeAndMinDistance()`. | Halves neighbor-scan cost per beacon | low |
+| Y | mesh subsystem (NeighborTable, RouteTable, E2EKeyStore, ReplayCache, PeerRegistry) | 5 classes reimplement the same "linear-scan-by-MAC + slot-allocate + `memcpy(entry.mac, mac, 6); valid=true;`" skeleton (~180 lines dup). Extract shared free helpers: `mac_find_index(entries, N, stride, offset, mac)` + `evict_oldest_by_ts(...)`. Prefer non-template helpers over `MacKeyedTable<Payload,N>` to avoid template bloat. | ~100-150 lines dedup + ~0.8-1.2 KB flash | med |
+| Z | `Enrollment.cpp:158`, `E2EKeyStore.h:42`, `Mesh.cpp:1102` | `is_zero(const uint8_t*, size_t)` helper for 3 hand-rolled zero-check loops (6B and 32B). | tiny flash + clarity | trivial |
+| AA | ~25 `getInstance()` sites (`EepromManager`, `Mesh`, `PirAdapter`, `ErrorCore`) | Singleton proliferation → free-function namespace holding file-static state. Each Meyers singleton emits `__cxa_guard_*` prologue (~40B + byte flag) per unique callsite. | ~0.5-1 KB flash + shorter callsites | med |
+
+### Phase I additions (BB-JJ — native ESP-IDF leverage)
+
+| ID | File:line | Description | Benefit | Effort |
+|---|---|---|---|---|
+| BB | `Mesh.cpp:8,294`, `Mesh.h:6` | Arduino `WiFi.h` → direct `esp_netif_init` + `esp_event_loop_create_default` + `esp_wifi_init(&cfg)` + `esp_wifi_set_storage(WIFI_STORAGE_RAM)` + `esp_wifi_set_mode(WIFI_MODE_STA)` + `esp_wifi_start()`. Currently `WiFi.h` pulls entire `WiFiGeneric/STA/AP/Scan/Client/Server`, TCP/IP-adapter shims — none needed for ESP-NOW-only use. | **~15-25 KB flash + several KB DRAM (LWIP contexts)** | med (well-documented ESP-IDF pattern) |
+| CC | `persistence/EepromManager.{h,cpp}` | Arduino `Preferences` → direct `nvs_flash`/`nvs_open`/`nvs_get_*` API. Wrapper adds ~1-2 KB flash and hides `nvs_get_stats`, iterators, and the two-partition erase-log invariant needed for atomic epoch counter semantics. | ~1-2 KB flash + atomic epoch semantics | low |
+| DD | `Logger.cpp`, `SerialAdapter.cpp:86-172`, `main.cpp:87,92,240-245` | Arduino `Serial` (`HardwareSerial` + `String::println` overloads) → `uart_driver_install(UART_NUM_0, rx, tx, 0, nullptr, 0)` + `uart_write_bytes` for framed serial-adapter TX. Arduino text logging → `esp_log.h` (`ESP_LOGI/W/E`) with built-in level gating + color. | Several KB flash + removes libc printf + Arduino String overloads | med (coordinate with Phase G/H log rewrites) |
+| EE | `main.cpp:257-262,286-334` | Enable `CONFIG_PM_ENABLE=y` + `CONFIG_FREERTOS_USE_TICKLESS_IDLE=y`; configure `esp_pm_config_esp32_t{80, 240, true}` for light-sleep between beacon intervals. Add dedicated mesh drain task via `xTaskCreatePinnedToCoreStatic` pinned to core 1 + `xTaskNotifyGive` from RX callback → replace polled `while (recvQueueTail != recvQueueHead)` with block-until-notified. Frees `loop()` to sleep. | **~30-40% avg current for battery nodes** (order-of-magnitude power win) | med (verify ESP-NOW RX wakes CPU via WiFi task) |
+| FF | 100+ sites (`Mesh.cpp`, `PeerRegistry.cpp:59,70,143`, `ButtonHandler.h`, `DisplayManager.h`, `NeighborTable`, `checkMasterTimeout`) | Arduino `millis()` (uint32, wraps ~49 days) → `esp_timer_get_time()` (int64 microseconds, wraps in 292 000 years). Introduce `static inline uint64_t millisNow()`, migrate `lastSeenMillis` fields to `uint64_t`. | Eliminates 49-day wrap bug class affecting `isPeerInRange`, `NeighborTable`, `checkMasterTimeout`, replay staleness | med (field-type audit) |
+| GG | `E2ECrypto.h`, `MeshCrypto.h` | mbedtls ECDH+HKDF-SHA256 → libsodium `crypto_scalarmult_curve25519` + `crypto_kdf_derive_from_key`. `espressif__libsodium` already available as component-manager dep. Cache `EntropyCtx` + `CtrDrbgCtx` as static members of `E2EKeyStore` seeded once at boot; static-key ECDH doesn't need fresh DRBG entropy per call. | ~15-20 KB flash + smaller heap footprint | med-high (API surgery) |
+| HH | `sdkconfig.defaults`, `main.cpp` boot | If staying with mbedtls (not swapping to libsodium): `CONFIG_MBEDTLS_MEMORY_BUFFER_ALLOC_C=y` + `mbedtls_memory_buffer_alloc_init(static_buf, 4*1024)` at boot. All mbedtls callocs are then confined to a static arena; can't fragment main heap. | Bounds + isolates crypto heap; makes fragmentation deterministic | low (config-only) |
+| II | `sdkconfig.defaults` `CONFIG_ARDUINO_LOOP_STACK_SIZE=8192` | Halve to 4096 (or 4608 for safety). Deepest chain (`drainRecvQueue → processAdapterData → openPayload → mbedtls_chachapoly`) is ~1.5 KB. Measure high-water via `uxTaskGetStackHighWaterMark` first. | **4 KB permanent DRAM** | low |
+| JJ | `PeerRegistry.cpp:75-128` | `loadFromEEPROM`/`saveToEEPROM` stack-allocate `MAX_PEERS * PEER_RECORD_SIZE = 380B` buffers just to iterate 10 records. Stream one record at a time from EepromManager to shrink transient stack. | 380 B stack (transient) | med (EepromManager API change) |
+
+### Keep-as-is (looks refactorable, actually correct)
+
+- **`std::unique_ptr<RouteTable> routes`** (Phase B) — allocation-only-on-master saves 2.25 KB on leaves; correct trade.
+- **Round-robin `nextSlot` in `E2EKeyStore`** — LRU would cost RAM (timestamp/pointer per entry) for a "wrong eviction just re-derives" outcome.
+- **`isMaster` + `currentMaster.distance` coexisting** — different semantics (declared role vs observed hops on non-masters).
+- **Bounded `downlinkPeerLru` + hand-rolled MRU touch** — ESP-NOW peer-table eviction ordering matters; can't be shared cleanly with NeighborTable/RouteTable.
+- **UNIT_TEST-only `throw FatalError` in `err::fatal`** — deliberate; on-device `[[noreturn]] while(true){}` remains exception-free.
+- **Lock-free SPSC RX ring (`Mesh.cpp:357-374`)** — right pattern for WiFi-task→loop-task handoff; don't replace with FreeRTOS queue.
+- **`esp_now_*` used directly** (no Arduino wrapper). Correct.
+- **`esp_random()` at `Mesh.cpp:635,873`** — correct primitive.
+- **`esp_wifi_set_ps(WIFI_PS_NONE)` at `main.cpp:229`** — correct for a receive-critical node; do NOT switch to modem-sleep (Phase I `PM_ENABLE` is light-sleep, which is different and compatible).
+- **`IRAM_ATTR` on RX callback** — correct.
+- **Nanopb (not libprotobuf)** — correct choice for embedded.
+- **`makeErrorCode` in `ErrorCodes.h`** — display encoder for 7-seg; call sites pass digits directly, but keep it.
+
+## Estimated cumulative savings
+
+- **Phase G expansion (A-Q):** ~1.5 KB RAM + ~5-8 KB flash on top of already-planned wire+bounds+CompactMessage savings.
+- **Phase H (R-AA):** ~1-2 KB flash + significant hot-path heap-churn elimination.
+- **Phase I (BB-JJ):** ~35-45 KB flash + ~10 KB DRAM + 30-40% average current on battery nodes + 49-day wrap bug eliminated.
+
+**Grand total (all 3 phases shipped):** ~40-55 KB flash reclaimed, ~12-15 KB DRAM reclaimed, dominant power win on battery deployments.
+
+## Session provenance
+
+Audit ran by 4 parallel Explore agents on 2026-08-04 during Phase G planning session. Findings verified by cross-referencing between agents (some items surfaced independently in ≥2 audits, e.g. MAC-compare consolidation appeared in mesh audit + cross-cutting audit). No agent output was accepted without cross-check.


### PR DESCRIPTION
Post-Phase-G code-review audit (4 parallel Explore agents, 2026-08-04) surfaced ~30 mem/flash/efficiency findings. Splits:

- **Phase G expansion** — §9 adds 17 no-cost/trivial items (A-Q). ~1.5 KB RAM + ~5-8 KB flash on top of already-planned Phase G savings.
- **Phase H2** — new umbrella phase for 10 medium refactors (R-AA): String-concat log elimination, DisplayManager throttle, non-blocking Button, adapter op-dispatch, MAC-keyed-table helper, singleton→namespace.
- **Phase I** — new umbrella phase for 9 native ESP-IDF migrations (BB-JJ): Arduino WiFi.h → esp_wifi_* direct (~15-25 KB flash), Preferences → nvs_flash, Logger → esp_log.h, tickless idle + xTaskCreateStatic (~30-40% avg current for battery nodes), millis() → esp_timer_get_time (49-day wrap fix), mbedtls → libsodium option.

Full ledger: docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md.

Keep-as-is items documented (unique_ptr<RouteTable>, round-robin E2EKeyStore, lock-free SPSC RX ring, esp_now_* direct, IRAM_ATTR, nanopb).

Merge before starting Phase G implementation — the audit items are folded into Phase G's plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)