### PR TITLE
feat(phaseG): flash trim — log macros, mbedtls trim, dead-code delete, DRY

### DIFF
--- a/firmware/main/project_config.h
+++ b/firmware/main/project_config.h
@@ -1,6 +1,19 @@
 #ifndef PROJECT_CONFIG_H
 #define PROJECT_CONFIG_H
 
+// Compile-time mirror of DEFAULT_LOG_LEVEL (§6 "Logging" below, LogLevel::LOG_NONE) used by
+// LATTICE_LOG/LATTICE_LOGLN (Logger.h) to fold to a no-op at compile time when logging is fully
+// disabled. Must be defined before Logger.h is first included in a translation unit for the
+// gating to take effect there — Logger.h's own header guard means its #if is only evaluated once,
+// at first inclusion — hence this sits above every #include in this file. Logger.h carries its
+// own LOG_NONE fallback (same value) for translation units that include it directly without going
+// through this file first; the #ifndef below avoids a harmless-but-noisy macro-redefinition
+// warning when that fallback already fired earlier in the same translation unit. The static_assert
+// next to DEFAULT_LOG_LEVEL below catches drift between the two.
+#ifndef LATTICE_DEFAULT_LOG_LEVEL
+#define LATTICE_DEFAULT_LOG_LEVEL 4 // mirrors lattice::utils::LogLevel::LOG_NONE
+#endif
+
 #include <Arduino.h>
 #include "src/logging/Logger.h"
 #include "src/adapter/Adapter.h"
@@ -83,6 +96,10 @@ constexpr int NUM_DEFAULT_PEERS = sizeof(DEFAULT_PEERS) / sizeof(DEFAULT_PEERS[0
 // CRITICAL: For server communication, MUST be LOG_NONE to prevent text output
 // Only enable logging (LOG_DEBUG, LOG_INFO, etc.) for development/debugging
 constexpr lattice::utils::LogLevel DEFAULT_LOG_LEVEL = lattice::utils::LogLevel::LOG_NONE;
+static_assert(static_cast<int>(DEFAULT_LOG_LEVEL) == LATTICE_DEFAULT_LOG_LEVEL,
+              "LATTICE_DEFAULT_LOG_LEVEL (top of this file) must mirror DEFAULT_LOG_LEVEL here — "
+              "LATTICE_LOG/LATTICE_LOGLN (Logger.h) key off the macro at compile time; keep both "
+              "in sync when changing either.");
 
 // =====================
 // 7. TX Power Presets

--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -16,7 +16,7 @@ using namespace lattice::utils;
 
 Adapter::Adapter(int pin)
     : _pin(pin), _adapterType(adapter_types::UNKNOWN_ADAPTER), mesh_transmit_fn(nullptr) {
-  Logger::logln("Adapter", "Base adapter initialized with UNKNOWN_ADAPTER", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Adapter", "Base adapter initialized with UNKNOWN_ADAPTER", LogLevel::LOG_DEBUG);
 }
 
 adapter_types Adapter::getAdapterType() const {
@@ -26,7 +26,7 @@ adapter_types Adapter::getAdapterType() const {
 void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[64]) {
   if (mesh_transmit_fn) {
     mesh_transmit_fn(type, data);
-    Logger::logln("Adapter", "Data sent through mesh", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("Adapter", "Data sent through mesh", LogLevel::LOG_DEBUG);
   } else {
     lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
                        1, "Adapter: Transmit function not set");
@@ -35,7 +35,7 @@ void Adapter::sendDataThroughMesh(const adapter_types type, const uint8_t data[6
 
 void Adapter::setTransmitFn(TransmitPtr fn) {
   mesh_transmit_fn = fn;
-  Logger::logln("Adapter", "Transmit function assigned", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Adapter", "Transmit function assigned", LogLevel::LOG_DEBUG);
 }
 
 void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
@@ -61,11 +61,11 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
         adapter_types newType =
             lattice::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
         lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
-        Logger::logln("ADAPTER", "CONFIG_SET received, restarting with new adapter type",
+        LATTICE_LOGLN("ADAPTER", "CONFIG_SET received, restarting with new adapter type",
                       LogLevel::LOG_INFO);
         ESP.restart();
       } else {
-        Logger::logln("ADAPTER", "CONFIG_SET not targeted to this node, ignoring",
+        LATTICE_LOGLN("ADAPTER", "CONFIG_SET not targeted to this node, ignoring",
                       LogLevel::LOG_DEBUG);
       }
     }
@@ -83,52 +83,13 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
       if (isTarget) {
         uint8_t nodeId = message.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        Logger::logln("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
+        LATTICE_LOGLN("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
       }
     }
     // Other SERIAL_ADAPTER opcodes (e.g. OP_HEALTH_REQ) are Serial-node-specific;
     // fall through to onMeshDataImpl so Serial_Adapter can handle them.
     if (_adapterType != adapter_types::SERIAL_ADAPTER)
       return;
-  }
-
-  // Handle LED output commands for LED_ADAPTER nodes.
-  // No RGB LED driver is currently implemented in firmware — these are logged stubs.
-  // TODO: When an LED adapter (e.g. NeoPixel/WS2812) is wired up, replace the Logger
-  // calls below with the appropriate driver calls (e.g. ledStrip.setPixelColor(r, g, b)).
-  if (message.data_type == adapter_types::LED_ADAPTER &&
-      _adapterType == adapter_types::LED_ADAPTER) {
-    const uint8_t op = message.data[0];
-    if (op == OP_LED_SOLID) {
-      uint8_t r = message.data[1];
-      uint8_t g = message.data[2];
-      uint8_t b = message.data[3];
-      Logger::logln("ADAPTER",
-                    String("OP_LED_SOLID: R=") + String(r) + " G=" + String(g) + " B=" + String(b) +
-                        " (stub — no RGB driver)",
-                    LogLevel::LOG_INFO);
-      // Send OP_COMMAND_ACK back through the mesh
-      uint8_t ackData[64] = {0};
-      ackData[0] = OP_COMMAND_ACK;
-      ackData[1] = op; // echo the handled opcode as the command ID
-      sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);
-    } else if (op == OP_LED_OFF) {
-      Logger::logln("ADAPTER", "OP_LED_OFF (stub — no RGB driver)", LogLevel::LOG_INFO);
-      uint8_t ackData[64] = {0};
-      ackData[0] = OP_COMMAND_ACK;
-      ackData[1] = op;
-      sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);
-    } else if (op == OP_LED_BLINK) {
-      Logger::logln("ADAPTER", "OP_LED_BLINK (stub — no RGB driver)", LogLevel::LOG_INFO);
-      uint8_t ackData[64] = {0};
-      ackData[0] = OP_COMMAND_ACK;
-      ackData[1] = op;
-      sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, ackData);
-    } else if (op == OP_RELAY_SET) {
-      Logger::logln("ADAPTER", "OP_RELAY_SET received on LED_ADAPTER (unexpected)",
-                    LogLevel::LOG_WARN);
-    }
-    return;
   }
 
   // Normal per-adapter dispatch.

--- a/firmware/main/src/adapter/Adapter.h
+++ b/firmware/main/src/adapter/Adapter.h
@@ -24,7 +24,6 @@ enum adapter_types : int32_t {
   SERIAL_ADAPTER = 1,
   PIR_ADAPTER = 2,
   LED_ADAPTER = 3,
-  RELAY_ADAPTER = 4,
 };
 
 // Abstract base class for all adapters

--- a/firmware/main/src/adapter/AdapterFactory.cpp
+++ b/firmware/main/src/adapter/AdapterFactory.cpp
@@ -16,24 +16,24 @@ bool AdapterFactory::isDevMode_ = false;
 
 void AdapterFactory::setDevMode(bool isDev) {
   isDevMode_ = isDev;
-  Logger::logln("Factory", String("Dev mode ") + (isDev ? "enabled" : "disabled"),
+  LATTICE_LOGLN("Factory", String("Dev mode ") + (isDev ? "enabled" : "disabled"),
                 LogLevel::LOG_INFO);
 }
 
 Adapter* AdapterFactory::createAdapter(adapter_types type, int pin) {
   switch (type) {
   case adapter_types::PIR_ADAPTER:
-    Logger::logln("Factory", "Creating PirAdapter", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("Factory", "Creating PirAdapter", LogLevel::LOG_INFO);
     return new PirAdapter(pin);
 
   case adapter_types::SERIAL_ADAPTER:
-    Logger::logln("Factory", "Creating SerialAdapter", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("Factory", "Creating SerialAdapter", LogLevel::LOG_INFO);
     return new SerialAdapter(pin);
 
   default:
     lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
                        2, "AdapterFactory: Unknown adapter type");
-    Logger::logln("Factory", "Error: Unknown adapter type", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Factory", "Error: Unknown adapter type", LogLevel::LOG_ERROR);
     return nullptr;
   }
 }
@@ -51,7 +51,7 @@ uint8_t AdapterFactory::adapterTypeToEEPROM(adapter_types type) {
 
 adapter_types AdapterFactory::loadAdapterTypeFromEEPROM() {
   if (isDevMode_) {
-    Logger::logln("Factory", "Dev mode: returning default PIR adapter type", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("Factory", "Dev mode: returning default PIR adapter type", LogLevel::LOG_DEBUG);
     return adapter_types::PIR_ADAPTER; // Always return default in dev mode
   }
 
@@ -61,7 +61,7 @@ adapter_types AdapterFactory::loadAdapterTypeFromEEPROM() {
 
 void AdapterFactory::saveAdapterTypeToEEPROM(adapter_types type) {
   if (isDevMode_) {
-    Logger::logln("Factory", "Dev mode: skipping EEPROM save for adapter type",
+    LATTICE_LOGLN("Factory", "Dev mode: skipping EEPROM save for adapter type",
                   LogLevel::LOG_DEBUG);
     return; // Don't save to EEPROM in dev mode
   }
@@ -77,7 +77,7 @@ Adapter* AdapterFactory::createFromEEPROM() {
 
 void AdapterFactory::initializeDefaultsIfUnset() {
   if (isDevMode_) {
-    Logger::logln("Factory", "Dev mode: skipping EEPROM initialization", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("Factory", "Dev mode: skipping EEPROM initialization", LogLevel::LOG_DEBUG);
     return; // Don't initialize EEPROM in dev mode
   }
 
@@ -92,8 +92,6 @@ int AdapterFactory::getDefaultPinForAdapter(adapter_types type) {
   switch (type) {
   case adapter_types::PIR_ADAPTER:
     return PIR_ADAPTER_DEFAULT_PIN;
-  case adapter_types::LED_ADAPTER:
-    return LED_ADAPTER_DEFAULT_PIN;
   case adapter_types::SERIAL_ADAPTER:
     return SERIAL_ADAPTER_DEFAULT_PIN;
   default:

--- a/firmware/main/src/adapter/AdapterFactory.h
+++ b/firmware/main/src/adapter/AdapterFactory.h
@@ -9,7 +9,6 @@ namespace adapter {
 
 // Default pins for each adapter type
 static constexpr int PIR_ADAPTER_DEFAULT_PIN = 27;    // PIR sensor pin
-static constexpr int LED_ADAPTER_DEFAULT_PIN = 2;     // Built-in LED pin
 static constexpr int SERIAL_ADAPTER_DEFAULT_PIN = -1; // Serial doesn't need a pin
 
 class AdapterFactory {

--- a/firmware/main/src/adapter/pir/PirAdapter.cpp
+++ b/firmware/main/src/adapter/pir/PirAdapter.cpp
@@ -6,12 +6,14 @@
 #include "src/error/Error.h"
 #include "src/mesh/Mesh.h"
 #include "src/adapter/AdapterFactory.h"
+#include "src/network/hw_mac.h"
 #include <esp_wifi.h>
 
 namespace lattice {
 namespace adapter {
 
 using namespace lattice::utils;
+using lattice::hw::readOwnMac;
 
 PirAdapter* PirAdapter::instance = nullptr;
 
@@ -23,7 +25,7 @@ PirAdapter::PirAdapter(int pin)
 
 bool PirAdapter::init() {
   if (_initialized) {
-    Logger::logln("PIR_Adapter", "Warning: Already initialized.", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("PIR_Adapter", "Warning: Already initialized.", LogLevel::LOG_WARN);
     return true;
   }
 
@@ -43,7 +45,7 @@ bool PirAdapter::init() {
   _interruptEnabled = true;
   _initialized = true;
 
-  Logger::logln("PIR_Adapter", "Initialized successfully", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("PIR_Adapter", "Initialized successfully", LogLevel::LOG_INFO);
   return true;
 }
 
@@ -63,10 +65,6 @@ void PirAdapter::detectMotion() {
   _pir.signalMotion();
   _interruptEnabled = false;
   _pir.detachInterrupt();
-}
-
-static void readOwnMac(uint8_t out[6]) {
-  esp_wifi_get_mac(WIFI_IF_STA, out);
 }
 
 void PirAdapter::sendNodeHealth() {
@@ -99,14 +97,14 @@ void PirAdapter::loop() {
   }
 
   if (_timerActive && !_motionSent) {
-    Logger::logln("PIR_Adapter", "MOTION DETECTED!", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("PIR_Adapter", "MOTION DETECTED!", LogLevel::LOG_INFO);
     _motionSent = true;
     uint8_t data[64] = {1};
     PirAdapter::sendDataTrampoline(_adapterType, data);
   }
 
   if (_timerActive && (now - _lastTrigger > (_cooldownSeconds * 1000U))) {
-    Logger::logln("PIR_Adapter", "Cooldown ended. Re-arming sensor.", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("PIR_Adapter", "Cooldown ended. Re-arming sensor.", LogLevel::LOG_DEBUG);
     _timerActive = false;
     _motionSent = false;
 
@@ -139,7 +137,7 @@ void PirAdapter::simulateMotion() {
   // elapsed), so a real PIR firing again mid-cooldown is physically ignored.
   // Calling _pir.signalMotion() directly bypassed that gate and let a simulated
   // re-trigger inject motion the hardware never could, masking the cooldown.
-  Logger::logln("PIR_Adapter", "SIM: Injecting fake PIR motion event", LogLevel::LOG_WARN);
+  LATTICE_LOGLN("PIR_Adapter", "SIM: Injecting fake PIR motion event", LogLevel::LOG_WARN);
   detectMotion();
 }
 #endif

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -4,6 +4,7 @@
 #include "src/error/Error.h"
 #include <esp_wifi.h>
 #include "src/mesh/Mesh.h"
+#include "src/network/hw_mac.h"
 #include <cstring>
 #include <cstdio>
 #if SIMULATE_MODE
@@ -14,15 +15,12 @@ namespace lattice {
 namespace adapter {
 
 using namespace lattice::utils;
+using lattice::hw::readOwnMac;
 
 uint32_t SerialAdapter::lastHealthMillis = 0;
 
-static void readOwnMac(uint8_t out[6]) {
-  esp_wifi_get_mac(WIFI_IF_STA, out);
-}
-
 void SerialAdapter::sendHealthReport() {
-  Logger::logln("Serial_Adapter", "Sending health report", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("Serial_Adapter", "Sending health report", LogLevel::LOG_INFO);
 
   uint8_t data[64] = {0};
   data[0] = OP_HEALTH_REPORT;
@@ -38,7 +36,7 @@ void SerialAdapter::sendHealthReport() {
   data[10] = static_cast<uint8_t>((uptimeSec >> 16) & 0xFF);
   data[11] = static_cast<uint8_t>((uptimeSec >> 24) & 0xFF);
 
-  Logger::logln("Serial_Adapter",
+  LATTICE_LOGLN("Serial_Adapter",
                 String("Health report - MAC: ") + String(mac[0], HEX) + ":" + String(mac[1], HEX) +
                     ":" + String(mac[2], HEX) + ":" + String(mac[3], HEX) + ":" +
                     String(mac[4], HEX) + ":" + String(mac[5], HEX) +
@@ -50,19 +48,19 @@ void SerialAdapter::sendHealthReport() {
   // (who don't need it) and never deliver it to the master's own serial
   // port — the only place the server can ever see it.
   lattice::mesh::Mesh::transmitSelfOriginated(adapter_types::SERIAL_ADAPTER, data);
-  Logger::logln("Serial_Adapter", "Health report sent via mesh", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Serial_Adapter", "Health report sent via mesh", LogLevel::LOG_DEBUG);
 }
 
 SerialAdapter::SerialAdapter(int pin) : Adapter(pin), lastReportedHopCount(0) {
   _adapterType = adapter_types::SERIAL_ADAPTER;
 
-  Logger::logln("Serial_Adapter", "Serial_Adapter constructed with pin " + String(pin),
+  LATTICE_LOGLN("Serial_Adapter", "Serial_Adapter constructed with pin " + String(pin),
                 LogLevel::LOG_INFO);
 }
 
 bool SerialAdapter::init() {
   // Serial already initialized in main. Nothing to do.
-  Logger::logln("Serial_Adapter", "Serial_Adapter initialized successfully", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("Serial_Adapter", "Serial_Adapter initialized successfully", LogLevel::LOG_INFO);
   return true;
 }
 
@@ -74,7 +72,7 @@ void SerialAdapter::loop() {
 
   if (stateChanged || millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
     lastHealthMillis = static_cast<uint32_t>(millis());
-    Logger::logln("Serial_Adapter",
+    LATTICE_LOGLN("Serial_Adapter",
                   String(stateChanged ? "Health report triggered by state change (hopCount: "
                                       : "Sending periodic health report (hopCount: ") +
                       String(currentHopCount) + ")",
@@ -92,7 +90,7 @@ void SerialAdapter::loop() {
 }
 
 void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
-  Logger::logln(
+  LATTICE_LOGLN(
       "Serial_Adapter",
       "Processing incoming mesh message - Type: " + String((uint8_t)message.message_type) +
           " DataType: " + String(static_cast<int32_t>(message.data_type)) +
@@ -105,13 +103,13 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
   if (message.data_type == adapter_types::SERIAL_ADAPTER) {
     uint8_t op = message.data[0];
     if (op == OP_HEALTH_REQ) {
-      Logger::logln("Serial_Adapter", "Received health request via mesh, sending health report",
+      LATTICE_LOGLN("Serial_Adapter", "Received health request via mesh, sending health report",
                     LogLevel::LOG_INFO);
       sendHealthReport();
     } else if (op == OP_TX_POWER_SET) {
       uint8_t presetByte = message.data[1];
       if (presetByte > 2) {
-        Logger::logln("Serial_Adapter", "Invalid TX power preset from mesh, ignoring",
+        LATTICE_LOGLN("Serial_Adapter", "Invalid TX power preset from mesh, ignoring",
                       LogLevel::LOG_WARN);
       } else {
         auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
@@ -119,10 +117,10 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
         esp_err_t txErr = esp_wifi_set_max_tx_power(
             static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
-          Logger::logln("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
+          LATTICE_LOGLN("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
                         LogLevel::LOG_WARN);
         } else {
-          Logger::logln("Serial_Adapter", "TX power preset applied from mesh", LogLevel::LOG_INFO);
+          LATTICE_LOGLN("Serial_Adapter", "TX power preset applied from mesh", LogLevel::LOG_INFO);
         }
       }
     }
@@ -133,14 +131,14 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
   size_t n = lattice::adapter::serial::SerialFraming::encode(message, encoded, sizeof(encoded));
 
   if (n == 0) {
-    Logger::logln("Serial_Adapter", "Failed to encode mesh message for serial output",
+    LATTICE_LOGLN("Serial_Adapter", "Failed to encode mesh message for serial output",
                   LogLevel::LOG_ERROR);
     lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER, 4,
                        "Serial_Adapter: Message encoding failed");
     return;
   }
 
-  Logger::logln("Serial_Adapter",
+  LATTICE_LOGLN("Serial_Adapter",
                 "Encoded mesh message to " + String(n) + " bytes, sending to serial",
                 LogLevel::LOG_DEBUG);
 
@@ -149,7 +147,7 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
   Serial.write(lenLE, 2);
   Serial.write(encoded, n);
 
-  Logger::logln("Serial_Adapter", "Mesh message sent to serial successfully", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Serial_Adapter", "Mesh message sent to serial successfully", LogLevel::LOG_DEBUG);
 }
 
 void SerialAdapter::relayEnrollmentToServer(const uint8_t* mac, const uint8_t* pubKey) {
@@ -162,7 +160,7 @@ void SerialAdapter::relayEnrollmentToServer(const uint8_t* mac, const uint8_t* p
   uint8_t encoded[128];
   size_t n = lattice::adapter::serial::SerialFraming::encode(msg, encoded, sizeof(encoded));
   if (n == 0) {
-    Logger::logln("Serial_Adapter", "Failed to encode enrollment relay message",
+    LATTICE_LOGLN("Serial_Adapter", "Failed to encode enrollment relay message",
                   LogLevel::LOG_ERROR);
     return;
   }
@@ -170,25 +168,25 @@ void SerialAdapter::relayEnrollmentToServer(const uint8_t* mac, const uint8_t* p
   uint8_t lenLE[2] = {static_cast<uint8_t>(n & 0xFF), static_cast<uint8_t>((n >> 8) & 0xFF)};
   Serial.write(lenLE, 2);
   Serial.write(encoded, n);
-  Logger::logln("Serial_Adapter", "Enrollment request relayed to server", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("Serial_Adapter", "Enrollment request relayed to server", LogLevel::LOG_INFO);
 }
 
 void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
-  Logger::logln("Serial_Adapter", "Handling complete frame of " + String(len) + " bytes",
+  LATTICE_LOGLN("Serial_Adapter", "Handling complete frame of " + String(len) + " bytes",
                 LogLevel::LOG_INFO);
 
 #if SIMULATE_MODE
   if (len >= 1) {
     uint8_t op = data[0];
     if (op == OP_SIM_PIR_TRIGGER) {
-      Logger::logln("SIM", "Injecting fake PIR event", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("SIM", "Injecting fake PIR event", LogLevel::LOG_WARN);
       lattice::adapter::PirAdapter* pirAdapter = lattice::adapter::PirAdapter::getInstance();
       if (pirAdapter)
         pirAdapter->simulateMotion();
       return;
 
     } else if (op == OP_SIM_FAKE_BEACON && len >= 13) {
-      Logger::logln("SIM", "Injecting fake master beacon", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("SIM", "Injecting fake master beacon", LogLevel::LOG_WARN);
       lattice::mesh::mesh_message fakeBeacon{};
       fakeBeacon.proto_version = lattice::mesh::PROTO_VERSION;
       fakeBeacon.message_type = MESH_TYPE_MASTER_BEACON;
@@ -201,7 +199,7 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       return;
 
     } else if (op == OP_SIM_DUMP_STATE) {
-      Logger::logln("SIM", "=== Mesh State Dump ===", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("SIM", "=== Mesh State Dump ===", LogLevel::LOG_WARN);
       lattice::mesh::Mesh* meshRef = lattice::mesh::Mesh::getInstance();
       if (meshRef) {
         meshRef->debugDumpRadio();
@@ -219,13 +217,13 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
 
   lattice::mesh::mesh_message msg;
   if (!lattice::adapter::serial::SerialFraming::decode(data, len, msg)) {
-    Logger::logln("Serial_Adapter", "Failed to decode protobuf frame", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Serial_Adapter", "Failed to decode protobuf frame", LogLevel::LOG_ERROR);
     lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER, 5,
                        "Serial_Adapter: Failed to decode protobuf frame");
     return;
   }
 
-  Logger::logln("Serial_Adapter",
+  LATTICE_LOGLN("Serial_Adapter",
                 "Decoded message - Type: " + String((uint8_t)msg.message_type) +
                     " DataType: " + String(static_cast<int32_t>(msg.data_type)),
                 LogLevel::LOG_INFO);
@@ -240,7 +238,7 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       }
     }
     if (hasKey) {
-      Logger::logln("Serial_Adapter", "Server approved enrollment, registering peer",
+      LATTICE_LOGLN("Serial_Adapter", "Server approved enrollment, registering peer",
                     LogLevel::LOG_INFO);
       lattice::mesh::Mesh* meshInstance = lattice::mesh::Mesh::getInstance();
       if (meshInstance) {
@@ -262,22 +260,22 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
         }
       }
     } else {
-      Logger::logln("Serial_Adapter", "Server rejected enrollment request", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("Serial_Adapter", "Server rejected enrollment request", LogLevel::LOG_WARN);
     }
     return;
   }
 
   // Only forward adapter data via mesh transmit function; routing fields are managed by Mesh
   if (msg.message_type == MESH_TYPE_ADAPTER_DATA) {
-    Logger::logln("Serial_Adapter", "Forwarding adapter data via mesh transmit",
+    LATTICE_LOGLN("Serial_Adapter", "Forwarding adapter data via mesh transmit",
                   LogLevel::LOG_DEBUG);
 
     if (mesh_transmit_fn) {
       // Targeted send via normal mesh transmit path (to master, route onward)
       mesh_transmit_fn(static_cast<adapter_types>(msg.data_type), msg.data);
-      Logger::logln("Serial_Adapter", "Adapter data forwarded successfully", LogLevel::LOG_DEBUG);
+      LATTICE_LOGLN("Serial_Adapter", "Adapter data forwarded successfully", LogLevel::LOG_DEBUG);
     } else {
-      Logger::logln("Serial_Adapter", "transmit function not set", LogLevel::LOG_ERROR);
+      LATTICE_LOGLN("Serial_Adapter", "transmit function not set", LogLevel::LOG_ERROR);
       lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::ADAPTER,
                          6, "Serial_Adapter: transmit function not set");
     }
@@ -285,12 +283,12 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     bool isGenuineBroadcast = (memcmp(msg.target_mac_address, kBroadcastMac, 6) == 0);
     if (isGenuineBroadcast) {
-      Logger::logln("Serial_Adapter", "Broadcasting adapter data to all peers",
+      LATTICE_LOGLN("Serial_Adapter", "Broadcasting adapter data to all peers",
                     LogLevel::LOG_DEBUG);
       // Broadcast adapter data to all peers (plaintext — no single destination to seal for)
       lattice::mesh::Mesh::broadcastAdapterDataStatic(static_cast<adapter_types>(msg.data_type),
                                                       msg.data);
-      Logger::logln("Serial_Adapter", "Broadcast sent successfully", LogLevel::LOG_DEBUG);
+      LATTICE_LOGLN("Serial_Adapter", "Broadcast sent successfully", LogLevel::LOG_DEBUG);
     } else {
       // Master -> node command: source-route + seal to the specific destination
       // (spec §4), instead of flooding it in plaintext to every peer. The
@@ -299,29 +297,29 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       const uint8_t* fwdData = msg.data;
       uint8_t destMac[6];
       memcpy(destMac, &fwdData[1], 6); // CONFIG_SET target field
-      Logger::logln("Serial_Adapter", "Sending sealed, source-routed downlink to node",
+      LATTICE_LOGLN("Serial_Adapter", "Sending sealed, source-routed downlink to node",
                     LogLevel::LOG_DEBUG);
       lattice::mesh::Mesh::sendDownlinkToNodeStatic(
           destMac, static_cast<adapter_types>(msg.data_type), fwdData);
     }
   } else {
-    Logger::logln("Serial_Adapter", "Unknown message type: " + String(msg.message_type),
+    LATTICE_LOGLN("Serial_Adapter", "Unknown message type: " + String(msg.message_type),
                   LogLevel::LOG_WARN);
   }
 
   // Handle control opcodes: CONFIG_SET, HEALTH_REQ
   if (msg.data_type == adapter_types::SERIAL_ADAPTER) {
     uint8_t op = msg.data[0];
-    Logger::logln("Serial_Adapter",
+    LATTICE_LOGLN("Serial_Adapter",
                   "Processing SERIAL_ADAPTER control opcode: 0x" + String(op, HEX),
                   LogLevel::LOG_DEBUG);
 
     if (op == OP_HEALTH_REQ) {
-      Logger::logln("Serial_Adapter", "Received health request, sending health report",
+      LATTICE_LOGLN("Serial_Adapter", "Received health request, sending health report",
                     LogLevel::LOG_INFO);
       sendHealthReport();
     } else if (op == OP_CONFIG_SET) {
-      Logger::logln("Serial_Adapter", "Received configuration set request", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("Serial_Adapter", "Received configuration set request", LogLevel::LOG_INFO);
 
       // Apply only if targeted to me (or broadcast FF:..:FF)
       uint8_t myMac[6];
@@ -336,39 +334,39 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
 
       if (isTarget) {
         adapter_types newType = AdapterFactory::adapterTypeFromEEPROM(msg.data[7]);
-        Logger::logln("Serial_Adapter",
+        LATTICE_LOGLN("Serial_Adapter",
                       "Configuration applies to this node, setting adapter type to: " +
                           String(static_cast<int32_t>(newType)),
                       LogLevel::LOG_INFO);
 
         lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
-        Logger::logln("Serial_Adapter", "Adapter type saved to EEPROM successfully",
+        LATTICE_LOGLN("Serial_Adapter", "Adapter type saved to EEPROM successfully",
                       LogLevel::LOG_INFO);
         // Pin is automatically inferred from adapter type - no need to store it
         // Let main recreate adapter on next boot or we could soft-switch by signaling
         // error-led+restart
-        Logger::logln("Serial_Adapter", "Restarting device to apply new configuration",
+        LATTICE_LOGLN("Serial_Adapter", "Restarting device to apply new configuration",
                       LogLevel::LOG_INFO);
         ESP.restart();
       } else {
-        Logger::logln("Serial_Adapter", "Configuration not targeted to this node, ignoring",
+        LATTICE_LOGLN("Serial_Adapter", "Configuration not targeted to this node, ignoring",
                       LogLevel::LOG_DEBUG);
       }
     } else if (op == OP_TX_POWER_SET) {
-      Logger::logln("Serial_Adapter", "Received TX power preset update", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("Serial_Adapter", "Received TX power preset update", LogLevel::LOG_INFO);
       uint8_t presetByte = msg.data[1];
       if (presetByte > 2) {
-        Logger::logln("Serial_Adapter", "Invalid TX power preset, ignoring", LogLevel::LOG_WARN);
+        LATTICE_LOGLN("Serial_Adapter", "Invalid TX power preset, ignoring", LogLevel::LOG_WARN);
       } else {
         auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
         EepromManager::getInstance().saveTxPowerPreset(preset);
         esp_err_t txErr = esp_wifi_set_max_tx_power(
             static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
-          Logger::logln("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
+          LATTICE_LOGLN("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
                         LogLevel::LOG_WARN);
         } else {
-          Logger::logln("Serial_Adapter", "TX power preset updated", LogLevel::LOG_INFO);
+          LATTICE_LOGLN("Serial_Adapter", "TX power preset updated", LogLevel::LOG_INFO);
         }
 
         // Broadcast to all enrolled nodes so entire mesh updates
@@ -379,11 +377,11 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           fwdData[0] = OP_TX_POWER_SET;
           fwdData[1] = presetByte;
           lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER, fwdData);
-          Logger::logln("Serial_Adapter", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
+          LATTICE_LOGLN("Serial_Adapter", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
         }
       }
     } else if (op == OP_NODE_ID_SET) {
-      Logger::logln("Serial_Adapter", "Received node ID set request", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("Serial_Adapter", "Received node ID set request", LogLevel::LOG_INFO);
       uint8_t myMac[6];
       readOwnMac(myMac);
       bool allFF = true;
@@ -396,15 +394,15 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       if (isTarget) {
         uint8_t nodeId = msg.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        Logger::logln("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
+        LATTICE_LOGLN("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
       }
     } else {
-      Logger::logln("Serial_Adapter", "Unknown SERIAL_ADAPTER opcode: 0x" + String(op, HEX),
+      LATTICE_LOGLN("Serial_Adapter", "Unknown SERIAL_ADAPTER opcode: 0x" + String(op, HEX),
                     LogLevel::LOG_WARN);
     }
   }
 
-  Logger::logln("Serial_Adapter", "Frame processing completed successfully", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Serial_Adapter", "Frame processing completed successfully", LogLevel::LOG_DEBUG);
 }
 
 } // namespace adapter

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -5,6 +5,7 @@
 #include "src/adapter/Adapter.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
+#include "src/network/hw_mac.h"
 #include <esp_wifi.h>
 #include <cstring>
 
@@ -12,13 +13,11 @@ namespace lattice {
 namespace adapter {
 namespace serial {
 
-static void readOwnMac(uint8_t out[6]) {
-  esp_wifi_get_mac(WIFI_IF_STA, out);
-}
+using lattice::hw::readOwnMac;
 
 size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen) {
   using namespace lattice::utils;
-  Logger::logln("Serial_Adapter",
+  LATTICE_LOGLN("Serial_Adapter",
                 "Encoding mesh message - Type: " + String((uint8_t)msg.message_type) +
                     " DataType: " + String(static_cast<int32_t>(msg.data_type)) +
                     " HopCount: " + String(msg.hop_count),
@@ -82,11 +81,11 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
 
   pb_ostream_t stream = pb_ostream_from_buffer(out, maxLen);
   if (!pb_encode(&stream, mesh_MeshMessage_fields, &pbMsg)) {
-    Logger::logln("Serial_Adapter", "nanopb encode failed", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Serial_Adapter", "nanopb encode failed", LogLevel::LOG_ERROR);
     return 0;
   }
 
-  Logger::logln("Serial_Adapter",
+  LATTICE_LOGLN("Serial_Adapter",
                 "Successfully encoded mesh message to " + String(stream.bytes_written) + " bytes",
                 LogLevel::LOG_DEBUG);
   return stream.bytes_written;
@@ -94,7 +93,7 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
 
 bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& outMsg) {
   using namespace lattice::utils;
-  Logger::logln("Serial_Adapter", "Decoding protobuf message of " + String(len) + " bytes",
+  LATTICE_LOGLN("Serial_Adapter", "Decoding protobuf message of " + String(len) + " bytes",
                 LogLevel::LOG_DEBUG);
 
   memset(&outMsg, 0, sizeof(outMsg));
@@ -102,7 +101,7 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
   mesh_MeshMessage pbMsg = mesh_MeshMessage_init_zero;
   pb_istream_t stream = pb_istream_from_buffer(data, len);
   if (!pb_decode(&stream, mesh_MeshMessage_fields, &pbMsg)) {
-    Logger::logln("Serial_Adapter", "nanopb decode failed", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Serial_Adapter", "nanopb decode failed", LogLevel::LOG_ERROR);
     return false;
   }
 
@@ -144,7 +143,7 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
     memcpy(outMsg.last_hop_mac_address, pbMsg.lastHopMacAddress, 6);
   }
 
-  Logger::logln("Serial_Adapter", "Successfully decoded protobuf message", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("Serial_Adapter", "Successfully decoded protobuf message", LogLevel::LOG_DEBUG);
   return true;
 }
 
@@ -160,7 +159,7 @@ bool SerialFraming::injectByte(uint8_t byteIn) {
   case FrameState::AwaitingLen2:
     frameLength |= static_cast<uint16_t>(byteIn) << 8;
     if (frameLength == 0 || frameLength > MAX_PAYLOAD) {
-      Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
       lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER,
                          2, "Serial_Adapter: Invalid frame length");
       // Invalid length — reset
@@ -175,7 +174,7 @@ bool SerialFraming::injectByte(uint8_t byteIn) {
 
   case FrameState::AwaitingPayload:
     if (frameIndex >= MAX_PAYLOAD) {
-      Logger::logln("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("SERIAL", "Frame parse error", LogLevel::LOG_WARN);
       lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::ADAPTER,
                          3, "Serial_Adapter: Frame buffer overflow");
       frameState = FrameState::AwaitingLen1;

--- a/firmware/main/src/app/ButtonHandler.h
+++ b/firmware/main/src/app/ButtonHandler.h
@@ -37,20 +37,20 @@ private:
           bool newMaster = !mesh.getIsMaster();
           mesh.setIsMaster(newMaster);
           devMasterFlag = newMaster;
-          lattice::utils::Logger::logln(
-              "MAIN", String("DEV MODE: Role toggled. Now ") + (newMaster ? "MASTER" : "NODE"),
-              lattice::utils::LogLevel::LOG_INFO);
+          LATTICE_LOGLN("MAIN",
+                        String("DEV MODE: Role toggled. Now ") + (newMaster ? "MASTER" : "NODE"),
+                        lattice::utils::LogLevel::LOG_INFO);
           greenLed.blink(newMaster ? 3 : 2, 150, 150);
         } else {
           bool wasMaster = em.loadMasterFlag();
           bool newMaster = !wasMaster;
           em.saveMasterFlag(newMaster);
-          lattice::utils::Logger::logln("MAIN",
-                                        String("Button held 5s: CONFIG TOGGLED. Now ") +
-                                            (newMaster ? "MASTER" : "NODE"),
-                                        lattice::utils::LogLevel::LOG_INFO);
-          lattice::utils::Logger::logln("MAIN", "Restarting in 2 seconds for new role...",
-                                        lattice::utils::LogLevel::LOG_INFO);
+          LATTICE_LOGLN("MAIN",
+                        String("Button held 5s: CONFIG TOGGLED. Now ") +
+                            (newMaster ? "MASTER" : "NODE"),
+                        lattice::utils::LogLevel::LOG_INFO);
+          LATTICE_LOGLN("MAIN", "Restarting in 2 seconds for new role...",
+                        lattice::utils::LogLevel::LOG_INFO);
           greenLed.blink(newMaster ? 3 : 2, 200, 200);
           delay(2000);
           em.forceFlush();
@@ -78,14 +78,13 @@ private:
         if (!confirmPending) {
           confirmPending = true;
           confirmDeadline = millis() + 3000;
-          lattice::utils::Logger::logln("MAIN",
-                                        "Reset armed: hold again within 3s to confirm EEPROM wipe",
-                                        lattice::utils::LogLevel::LOG_WARN);
+          LATTICE_LOGLN("MAIN", "Reset armed: hold again within 3s to confirm EEPROM wipe",
+                        lattice::utils::LogLevel::LOG_WARN);
           redLed.blink(3, 100, 100);
         } else if (millis() < confirmDeadline) {
           confirmPending = false;
-          lattice::utils::Logger::logln("MAIN", "EEPROM wipe confirmed. Clearing all...",
-                                        lattice::utils::LogLevel::LOG_WARN);
+          LATTICE_LOGLN("MAIN", "EEPROM wipe confirmed. Clearing all...",
+                        lattice::utils::LogLevel::LOG_WARN);
           em.clearAll();
           redLed.blink(5, 100, 100);
           greenLed.blink(5, 100, 100);
@@ -98,8 +97,7 @@ private:
       wasPressed = false;
       if (confirmPending && millis() > confirmDeadline) {
         confirmPending = false;
-        lattice::utils::Logger::logln("MAIN", "Reset confirmation timed out",
-                                      lattice::utils::LogLevel::LOG_INFO);
+        LATTICE_LOGLN("MAIN", "Reset confirmation timed out", lattice::utils::LogLevel::LOG_INFO);
       }
     }
   }

--- a/firmware/main/src/error/Error.h
+++ b/firmware/main/src/error/Error.h
@@ -48,7 +48,7 @@ inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit
 #ifdef UNIT_TEST
   ++::lattice_test_errFailCount;
 #endif
-  utils::Logger::logln("ERROR", msg, utils::LogLevel::LOG_ERROR);
+  LATTICE_LOGLN("ERROR", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
   return false;
 }
@@ -59,7 +59,7 @@ inline bool fail(utils::ErrorType type, const char* msg) {
 }
 [[noreturn]] inline void fatal(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m,
                                uint8_t sub, const char* msg) {
-  utils::Logger::logln("FATAL", msg, utils::LogLevel::LOG_ERROR);
+  LATTICE_LOGLN("FATAL", msg, utils::LogLevel::LOG_ERROR);
   utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
 #ifdef UNIT_TEST
   throw FatalError(msg ? msg : "fatal");
@@ -78,20 +78,11 @@ inline bool check(bool condition, utils::ErrorType type, const char* msg) {
 inline bool checkEsp(esp_err_t status, utils::ErrorType type, const char* msg) {
   if (status == ESP_OK)
     return true;
-  utils::Logger::logln("ESP", String(msg) + ": " + esp_err_to_name(status),
-                       utils::LogLevel::LOG_ERROR);
+  LATTICE_LOGLN("ESP", String(msg) + ": " + esp_err_to_name(status), utils::LogLevel::LOG_ERROR);
   return fail(type, msg);
 }
 } // namespace err
 } // namespace lattice
-
-template <typename... Args> inline bool ERROR_ASSERT(bool cond, const char* msg) {
-  return lattice::err::check(cond, lattice::utils::ErrorType::CONFIG_ERROR, msg);
-}
-
-template <typename T> inline bool ERROR_CHECK(bool cond, T t, const char* msg) {
-  return lattice::err::check(cond, t, msg);
-}
 
 template <typename T> inline bool ERROR_CHECK_ESP_OK(esp_err_t expr, T t, const char* msg) {
   return lattice::err::checkEsp(expr, t, msg);

--- a/firmware/main/src/error/ErrorCore.cpp
+++ b/firmware/main/src/error/ErrorCore.cpp
@@ -22,7 +22,7 @@ void ErrorCore::init(hardware::Led* led, hardware::SevenSegDisplay* display) {
   if (r != ESP_RST_POWERON && r != ESP_RST_SW && r != ESP_RST_EXT) {
     signalError(ErrorTypeDigit::HARDWARE, ModuleDigit::CORE, 1, "Unexpected reset");
   }
-  Logger::logln("ErrorCore", "Initialized", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("ErrorCore", "Initialized", LogLevel::LOG_INFO);
 }
 void ErrorCore::signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const char* msg) {
   uint16_t code = makeErrorCode(t, m, sub);
@@ -46,7 +46,7 @@ void ErrorCore::signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const 
 }
 void ErrorCore::signalError(ErrorType type, const char* msg) {
   if (msg)
-    Logger::logln("Error", String("ERROR: ") + msg, LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Error", String("ERROR: ") + msg, LogLevel::LOG_ERROR);
   if (_initialized && _errorLed) {
     if (_inCallbackContext) {
       // Defer blink to main loop — never block in callback context
@@ -103,7 +103,7 @@ bool ErrorCore::shouldRestart(ErrorType t) const {
   return t == ErrorType::MEMORY_ERROR || t == ErrorType::HARDWARE_FAILURE;
 }
 [[noreturn]] void ErrorCore::restartDevice() {
-  Logger::logln("ErrorCore", "Restarting device...", LogLevel::LOG_WARN);
+  LATTICE_LOGLN("ErrorCore", "Restarting device...", LogLevel::LOG_WARN);
 #ifdef UNIT_TEST
   throw lattice::err::FatalError("ErrorCore::restartDevice");
 #else

--- a/firmware/main/src/hardware/input/GpioInput.cpp
+++ b/firmware/main/src/hardware/input/GpioInput.cpp
@@ -15,36 +15,10 @@ bool GpioInput::init() {
 }
 
 bool GpioInput::isValidInputPin(uint8_t pin) {
-  // Accept most GPIOs except strapping/flash pins and invalid
-  switch (pin) {
-  case 0:
-  case 2:
-  case 4:
-  case 5:
-  case 12:
-  case 13:
-  case 14:
-  case 15:
-  case 16:
-  case 17:
-  case 18:
-  case 19:
-  case 21:
-  case 22:
-  case 23:
-  case 25:
-  case 26:
-  case 27:
-  case 32:
-  case 33:
-  case 34:
-  case 35:
-  case 36:
-  case 39:
-    return true;
-  default:
-    return false;
-  }
+  // Accept most GPIOs except strapping/flash pins and invalid ones. Bit N set means pin N is
+  // valid: 0,2,4,5,12-19,21-23,25-27,32-36,39 (audit item J — was a 24-case switch).
+  constexpr uint64_t VALID_MASK = 0x9f0eeff035ULL;
+  return pin < 64 && ((VALID_MASK >> pin) & 1) != 0;
 }
 
 bool GpioInput::isInitialized() const {

--- a/firmware/main/src/hardware/output/GpioOutput.cpp
+++ b/firmware/main/src/hardware/output/GpioOutput.cpp
@@ -15,30 +15,10 @@ bool GpioOutput::init() {
 }
 
 bool GpioOutput::isValidOutputPin(uint8_t pin) {
-  switch (pin) {
-  case 2:
-  case 4:
-  case 5:
-  case 12:
-  case 13:
-  case 14:
-  case 15:
-  case 16:
-  case 17:
-  case 18:
-  case 19:
-  case 21:
-  case 22:
-  case 23:
-  case 25:
-  case 26:
-  case 27:
-  case 32:
-  case 33:
-    return true;
-  default:
-    return false;
-  }
+  // Bit N set means pin N is valid: 2,4,5,12-19,21-23,25-27,32-33 (audit item J — was a
+  // 19-case switch). Narrower than GpioInput's mask — excludes input-only pin 0 and 34-39.
+  constexpr uint64_t VALID_MASK = 0x30eeff034ULL;
+  return pin < 64 && ((VALID_MASK >> pin) & 1) != 0;
 }
 
 bool GpioOutput::isInitialized() const {

--- a/firmware/main/src/hardware/output/Led.cpp
+++ b/firmware/main/src/hardware/output/Led.cpp
@@ -29,12 +29,12 @@ bool Led::init() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
                          "Led: Invalid pin number");
     }
-    Logger::logln("Led", "ERROR: Invalid pin number for LED: " + String(_pin), LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Led", "ERROR: Invalid pin number for LED: " + String(_pin), LogLevel::LOG_ERROR);
     return false;
   }
   digitalWrite(_pin, LOW);
   _isOn = false;
-  Logger::logln("Led", "Initialized LED on pin " + String(_pin), LogLevel::LOG_INFO);
+  LATTICE_LOGLN("Led", "Initialized LED on pin " + String(_pin), LogLevel::LOG_INFO);
   return true;
 }
 
@@ -44,7 +44,7 @@ bool Led::on() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 2,
                          "Led: on() called before initialization");
     }
-    Logger::logln("Led", "ERROR: on() called before initialization", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Led", "ERROR: on() called before initialization", LogLevel::LOG_ERROR);
     return false;
   }
   return setState(true);
@@ -56,7 +56,7 @@ bool Led::off() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 3,
                          "Led: off() called before initialization");
     }
-    Logger::logln("Led", "ERROR: off() called before initialization", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Led", "ERROR: off() called before initialization", LogLevel::LOG_ERROR);
     return false;
   }
   return setState(false);
@@ -68,7 +68,7 @@ bool Led::toggle() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 4,
                          "Led: toggle() called before initialization");
     }
-    Logger::logln("Led", "ERROR: toggle() called before initialization", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Led", "ERROR: toggle() called before initialization", LogLevel::LOG_ERROR);
     return false;
   }
   return setState(!_isOn);
@@ -89,7 +89,7 @@ bool Led::setState(bool state) {
     return true;
   digitalWrite(_pin, state ? HIGH : LOW);
   _isOn = state;
-  Logger::logln("Led", String("LED on pin ") + String(_pin) + (state ? " ON" : " OFF"),
+  LATTICE_LOGLN("Led", String("LED on pin ") + String(_pin) + (state ? " ON" : " OFF"),
                 LogLevel::LOG_DEBUG);
   return true;
 }
@@ -104,7 +104,7 @@ bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
       lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 5,
                          "Led: blink() called before initialization");
     }
-    Logger::logln("Led", "ERROR: blink() called before initialization", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("Led", "ERROR: blink() called before initialization", LogLevel::LOG_ERROR);
     return false;
   }
   for (uint8_t i = 0; i < times; ++i) {
@@ -114,7 +114,7 @@ bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
     if (i < times - 1)
       delay(offTimeMs);
   }
-  Logger::logln("Led", String("Blink pattern: ") + String(times) + "x on pin " + String(_pin),
+  LATTICE_LOGLN("Led", String("Blink pattern: ") + String(times) + "x on pin " + String(_pin),
                 LogLevel::LOG_DEBUG);
   return true;
 }

--- a/firmware/main/src/hardware/output/SevenSegDisplay.cpp
+++ b/firmware/main/src/hardware/output/SevenSegDisplay.cpp
@@ -35,7 +35,7 @@ SevenSegDisplay::SevenSegDisplay(uint8_t dio, uint8_t clk)
 
 bool SevenSegDisplay::init() {
   if (!GpioOutput::isValidOutputPin(_dioPin) || !GpioOutput::isValidOutputPin(_clkPin)) {
-    Logger::logln("7SEG", "Invalid GPIO pins", lattice::utils::LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("7SEG", "Invalid GPIO pins", lattice::utils::LogLevel::LOG_ERROR);
     lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
                        "7Seg invalid pins");
     return false;
@@ -44,7 +44,7 @@ bool SevenSegDisplay::init() {
   pinMode(_clkPin, OUTPUT);
   digitalWrite(_clkPin, HIGH);
   digitalWrite(_dioPin, HIGH);
-  Logger::logln("7SEG", "SevenSegDisplay initialized", lattice::utils::LogLevel::LOG_INFO);
+  LATTICE_LOGLN("7SEG", "SevenSegDisplay initialized", lattice::utils::LogLevel::LOG_INFO);
   // Self-test: flash all segments 0x7F (88:88)
   uint8_t testSeg[4] = {0x7F, 0x7F, 0x7F, 0x7F};
   setSegments(testSeg);
@@ -115,7 +115,7 @@ bool SevenSegDisplay::writeByte(uint8_t b) {
   pinMode(_dioPin, OUTPUT);
   digitalWrite(_clkPin, LOW);
   if (!ack) {
-    Logger::logln("7SEG", "ACK timeout", lattice::utils::LogLevel::LOG_WARN);
+    LATTICE_LOGLN("7SEG", "ACK timeout", lattice::utils::LogLevel::LOG_WARN);
     lattice::err::fail(lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::HW, 2,
                        "7Seg ACK timeout");
   }
@@ -146,7 +146,7 @@ void SevenSegDisplay::setSegments(const uint8_t (&segs)[4]) {
   stop();
 }
 
-void SevenSegDisplay::show(int value, bool leadingZeros) {
+void SevenSegDisplay::showInternal(int value, bool leadingZeros, bool withDP) {
   bool negative = value < 0;
   int v = negative ? -value : value;
   if (v > 9999)
@@ -175,40 +175,17 @@ void SevenSegDisplay::show(int value, bool leadingZeros) {
     else
       segs[i] = encodeDigit(digits[i]);
   }
+  if (withDP)
+    segs[3] |= 0x80; // DP bit on last digit
   setSegments(segs);
 }
 
+void SevenSegDisplay::show(int value, bool leadingZeros) {
+  showInternal(value, leadingZeros, false);
+}
+
 void SevenSegDisplay::showWithDP(int value, bool leadingZeros) {
-  bool negative = value < 0;
-  int v = negative ? -value : value;
-  if (v > 9999)
-    v = 9999;
-
-  int digits[4];
-  for (int i = 3; i >= 0; --i) {
-    digits[i] = v % 10;
-    v /= 10;
-  }
-
-  if (negative) {
-    // show minus on leftmost non-zero digit position
-    for (int i = 0; i < 4; ++i) {
-      if (digits[i] != 0 || i == 3) { // last digit
-        digits[i] = -1;               // minus
-        break;
-      }
-    }
-  }
-
-  uint8_t segs[4];
-  for (int i = 0; i < 4; ++i) {
-    if (!leadingZeros && i < 3 && digits[i] == 0 && !negative)
-      segs[i] = 0x00;
-    else
-      segs[i] = encodeDigit(digits[i]);
-  }
-  segs[3] |= 0x80; // DP bit on last digit
-  setSegments(segs);
+  showInternal(value, leadingZeros, true);
 }
 
 } // namespace hardware

--- a/firmware/main/src/hardware/output/SevenSegDisplay.h
+++ b/firmware/main/src/hardware/output/SevenSegDisplay.h
@@ -34,6 +34,9 @@ private:
   void stop();
   bool writeByte(uint8_t b);
   uint8_t encodeDigit(int d);
+  // Shared body for show()/showWithDP() (audit item M — the two used to be near-identical
+  // 30-line copies differing only in the DP segment bit).
+  void showInternal(int value, bool leadingZeros, bool withDP);
 };
 
 } // namespace hardware

--- a/firmware/main/src/logging/Logger.h
+++ b/firmware/main/src/logging/Logger.h
@@ -21,6 +21,34 @@
   } while (0)
 #endif
 
+// ---------------------------------------------------------------------------------------------
+// LATTICE_LOG / LATTICE_LOGLN — compile-time log-level gating (design doc §1, Phase G).
+//
+// Numeric values mirror lattice::utils::LogLevel exactly (DEBUG=0 .. NONE=4) so the #if below
+// can compare against it directly, without needing the enum type available yet at this point in
+// the header. When LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE (the production default — see
+// project_config.h §6 "Logging"), both macros fold to ((void)0): the tag/message/level arguments
+// are never evaluated, so format strings and String concatenations at call sites never reach the
+// translation unit's .rodata / heap. Otherwise they route to the existing runtime-dispatched
+// Logger::log/logln (unchanged behaviour).
+#define LATTICE_LOG_LEVEL_NONE 4
+
+// project_config.h defines LATTICE_DEFAULT_LOG_LEVEL above its own #include of this header, so
+// that value is authoritative when present. This fallback only covers translation units that
+// include Logger.h directly without going through project_config.h first; it is pinned to
+// LOG_NONE (the production default) so such a TU never silently gets logging turned on.
+#ifndef LATTICE_DEFAULT_LOG_LEVEL
+#define LATTICE_DEFAULT_LOG_LEVEL LATTICE_LOG_LEVEL_NONE
+#endif
+
+#if LATTICE_DEFAULT_LOG_LEVEL == LATTICE_LOG_LEVEL_NONE
+#define LATTICE_LOG(tag, msg, level) ((void)0)
+#define LATTICE_LOGLN(tag, msg, level) ((void)0)
+#else
+#define LATTICE_LOG(tag, msg, level) ::lattice::utils::Logger::log(tag, msg, level)
+#define LATTICE_LOGLN(tag, msg, level) ::lattice::utils::Logger::logln(tag, msg, level)
+#endif
+
 namespace lattice {
 namespace utils {
 

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -4,6 +4,7 @@
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include "../../lib/lattice-protocol/c/mesh_message.h"
+#include "broadcast_mac.h"
 #include "src/adapter/Adapter.h"
 #include "config/master_pubkey_pin_wrapper.h"
 #include "project_config.h"
@@ -29,20 +30,20 @@ Enrollment::Enrollment() {
 void Enrollment::init() {
   auto& em = EepromManager::getInstance();
   if (em.loadKeypair(devicePrivateKey, devicePublicKey)) {
-    Logger::logln("MESH", "Device keypair loaded from EEPROM", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Device keypair loaded from EEPROM", LogLevel::LOG_INFO);
   } else {
-    Logger::logln("MESH", "Generating new Curve25519 keypair...", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Generating new Curve25519 keypair...", LogLevel::LOG_INFO);
     lattice::mesh::crypto::generateKeypair(devicePrivateKey, devicePublicKey);
     em.saveKeypair(devicePrivateKey, devicePublicKey);
-    Logger::logln("MESH", "New keypair generated and saved", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "New keypair generated and saved", LogLevel::LOG_INFO);
   }
   hasMasterMac = em.loadKnownMasterMac(knownMasterMac);
   if (hasMasterMac) {
-    Logger::logln("MESH", "Known master MAC loaded from EEPROM", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Known master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
   hasMasterMacSecondary = em.loadKnownMasterMacSecondary(knownMasterMacSecondary);
   if (hasMasterMacSecondary) {
-    Logger::logln("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
 }
 
@@ -69,20 +70,19 @@ void Enrollment::sendRequest(const uint8_t* deviceMac, uint8_t protoVersion, uin
   msg.hop_count = 0;
   memcpy(msg.enrollment_public_key, devicePublicKey, 32);
 
-  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
-  Logger::logln("MESH", "Enrollment request sent", LogLevel::LOG_INFO);
+  esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
+  LATTICE_LOGLN("MESH", "Enrollment request sent", LogLevel::LOG_INFO);
 }
 
 void Enrollment::processRequest(const mesh_message& msg) {
   enqueuePendingRelay(msg.origin_mac_address, msg.enrollment_public_key);
-  Logger::logln("MESH", "Enrollment request received, deferring relay to loop()",
+  LATTICE_LOGLN("MESH", "Enrollment request received, deferring relay to loop()",
                 LogLevel::LOG_INFO);
 }
 
 void Enrollment::enqueuePendingRelay(const uint8_t* mac, const uint8_t* pubKey) {
   if (_pendingRelayCount >= PENDING_RELAY_QUEUE_SIZE) {
-    Logger::logln("MESH", "Enrollment relay queue full — dropping request", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "Enrollment relay queue full — dropping request", LogLevel::LOG_WARN);
     return;
   }
   size_t idx = (_pendingRelayHead + _pendingRelayCount) % PENDING_RELAY_QUEUE_SIZE;
@@ -95,7 +95,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
                                 RegisterPeerFn registerFn) {
   // Called only when msg.target_mac_address == deviceMacAddress (Mesh checks this before calling)
   if (memcmp(msg.data, devicePublicKey, 4) != 0) {
-    Logger::logln("MESH", "JOIN_ACK fingerprint mismatch — ignoring", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "JOIN_ACK fingerprint mismatch — ignoring", LogLevel::LOG_WARN);
     return;
   }
 
@@ -109,7 +109,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
   if (!lattice::config::DEV_MODE && !lattice::mesh::pin::isTestBypassed()) {
     if (memcmp(msg.enrollment_public_key, lattice::mesh::pin::MASTER_PUBKEY,
                sizeof(lattice::mesh::pin::MASTER_PUBKEY)) != 0) {
-      Logger::logln("ENROLL", "JOIN_ACK master pubkey mismatch pin — drop", LogLevel::LOG_ERROR);
+      LATTICE_LOGLN("ENROLL", "JOIN_ACK master pubkey mismatch pin — drop", LogLevel::LOG_ERROR);
       return;
     }
   }
@@ -121,7 +121,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
   // may deliver a JOIN_ACK; anything else is a forgery and must not enroll us,
   // TOFU-learn, or touch peer key material.
   if (hasMasterMac && memcmp(msg.origin_mac_address, knownMasterMac, 6) != 0) {
-    Logger::logln("MESH", "JOIN_ACK from unexpected origin — ignoring", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "JOIN_ACK from unexpected origin — ignoring", LogLevel::LOG_WARN);
     return;
   }
 
@@ -135,11 +135,11 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
   // If registration fails (registry full), do NOT mark enrolled or TOFU-learn —
   // an "enrolled" node without an uplink route is worse than retrying.
   if (registerFn && !registerFn(msg.origin_mac_address, msg.enrollment_public_key)) {
-    Logger::logln("MESH", "JOIN_ACK peer registration failed — not enrolling", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("MESH", "JOIN_ACK peer registration failed — not enrolling", LogLevel::LOG_ERROR);
     return;
   }
 
-  Logger::logln("MESH", "Enrollment approved! Saving enrolled flag.", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("MESH", "Enrollment approved! Saving enrolled flag.", LogLevel::LOG_INFO);
   EepromManager::getInstance().saveEnrolledFlag(true);
 
   // The node sending JOIN_ACK is the master — record its MAC (TOFU)
@@ -147,7 +147,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
     memcpy(knownMasterMac, msg.origin_mac_address, 6);
     hasMasterMac = true;
     EepromManager::getInstance().saveKnownMasterMac(knownMasterMac);
-    Logger::logln("MESH", "Master MAC learned and saved (TOFU)", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Master MAC learned and saved (TOFU)", LogLevel::LOG_INFO);
   }
 
   // Dual-master (spec §5): if the server included a secondary master, register it

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -12,6 +12,7 @@
 #include "MeshCrypto.h"
 #include "E2ECrypto.h"
 #include "RouteMac.h"
+#include "broadcast_mac.h"
 #include "config/master_pubkey_pin_wrapper.h"
 
 namespace lattice {
@@ -66,40 +67,10 @@ void Mesh::readMacAddress() {
         lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::MESH, 1,
         (String("MESH: Failed to read MAC address: ") + esp_err_to_name(ret)).c_str());
   } else {
-    Logger::log("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
-    Logger::logln("MESH", lattice::utils::MacAddress(deviceMacAddress).toString(),
+    LATTICE_LOG("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("MESH", lattice::utils::MacAddress(deviceMacAddress).toString(),
                   LogLevel::LOG_DEBUG);
   }
-}
-
-static String macToStr(const uint8_t (&mac)[6]) {
-  return lattice::utils::MacAddress(mac).toString();
-}
-
-void Mesh::printMeshMessage(const mesh_message& msg) {
-  Logger::logln("MESH", "------ Mesh Message ------", LogLevel::LOG_DEBUG);
-  Logger::logln("MESH", "Origin:    " + macToStr(msg.origin_mac_address), LogLevel::LOG_DEBUG);
-  Logger::logln("MESH", "Target:    " + macToStr(msg.target_mac_address), LogLevel::LOG_DEBUG);
-  Logger::logln("MESH", "Last Hop:  " + macToStr(msg.last_hop_mac_address), LogLevel::LOG_DEBUG);
-
-  Logger::logln(
-      "MESH",
-      "MsgType:   " + String((uint8_t)msg.message_type) + " (" +
-          (msg.message_type == MESH_TYPE_MASTER_BEACON ? "MASTER_BEACON" : "ADAPTER_DATA") + ")",
-      LogLevel::LOG_DEBUG);
-
-  Logger::logln("MESH", "DataType:  " + String((uint8_t)msg.data_type), LogLevel::LOG_DEBUG);
-
-  String dataStr;
-  for (int i = 0; i < 12; ++i) {
-    if (msg.data[i] < 0x10)
-      dataStr += "0";
-    dataStr += String(msg.data[i], HEX) + " ";
-  }
-  Logger::logln("MESH", "Data:      " + dataStr, LogLevel::LOG_DEBUG);
-
-  Logger::logln("MESH", "Hop Count: " + String(msg.hop_count), LogLevel::LOG_DEBUG);
-  Logger::logln("MESH", "-------------------------", LogLevel::LOG_DEBUG);
 }
 
 PeerInfo* Mesh::findNextHopToMaster() {
@@ -256,13 +227,13 @@ bool Mesh::init() {
   uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
   EepromManager::getInstance().saveBootEpoch(epoch);
   replay.init(epoch);
-  Logger::logln("MESH", "Boot epoch: " + String(replay.bootEpoch), LogLevel::LOG_INFO);
+  LATTICE_LOGLN("MESH", "Boot epoch: " + String(replay.bootEpoch), LogLevel::LOG_INFO);
 
   // Phase D (#42): DEV_MODE bypasses the beacon origin-MAC pin (dev firmware
   // regenerates a fresh keypair/MAC each boot, so pinning would reject the
   // dev master). Make that state visible in operator logs.
   if (lattice::config::DEV_MODE) {
-    Logger::logln("MESH", "DEV_MODE: master pubkey pin disabled — do not ship this build",
+    LATTICE_LOGLN("MESH", "DEV_MODE: master pubkey pin disabled — do not ship this build",
                   LogLevel::LOG_WARN);
   }
 
@@ -276,10 +247,10 @@ bool Mesh::init() {
     uint8_t txPowerVal = lattice::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
     esp_err_t txErr = esp_wifi_set_max_tx_power(static_cast<int8_t>(txPowerVal));
     if (txErr != ESP_OK) {
-      Logger::logln("MESH", String("TX power set failed: ") + esp_err_to_name(txErr),
+      LATTICE_LOGLN("MESH", String("TX power set failed: ") + esp_err_to_name(txErr),
                     LogLevel::LOG_WARN);
     } else {
-      Logger::logln("MESH", "TX power preset applied", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("MESH", "TX power preset applied", LogLevel::LOG_INFO);
     }
   }
 
@@ -309,10 +280,10 @@ void Mesh::loadPersistentState() {
   loadMeshKeyFromEEPROM();
   enrollment.init();
   if (enrollment.hasMasterMac) {
-    Logger::logln("MESH", "Known master MAC loaded from EEPROM", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Known master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
   if (_dualMasterMode && enrollment.hasMasterMacSecondary) {
-    Logger::logln("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
 }
 
@@ -326,12 +297,11 @@ bool Mesh::setupEspNow() {
   lattice::err::checkEsp(esp_now_set_pmk(meshKey), lattice::utils::ErrorType::HARDWARE_FAILURE,
                          "Failed to set ESP-NOW PMK");
 
-  // Register the broadcast MAC so esp_now_send(broadcastMac, ...) reaches all
+  // Register the broadcast MAC so esp_now_send(BROADCAST_MAC, ...) reaches all
   // nodes — including unregistered ones. esp_now_send(nullptr, ...) only delivers
   // to already-registered peers; using the explicit FF:FF:… MAC is required for a
   // true 802.11 broadcast frame.
-  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  if (!esp_now_is_peer_exist(broadcastMac)) {
+  if (!esp_now_is_peer_exist(BROADCAST_MAC)) {
     esp_now_peer_info_t broadcast = {};
     memset(broadcast.peer_addr, 0xFF, 6);
     broadcast.channel = 0;
@@ -344,14 +314,14 @@ bool Mesh::setupEspNow() {
   }
   esp_now_register_send_cb(onDataSentCallback);
   esp_now_register_recv_cb(Mesh::dataRecvTrampoline);
-  Logger::logln("MESH", "ESP-NOW initialized successfully", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("MESH", "ESP-NOW initialized successfully", LogLevel::LOG_INFO);
   return true;
 }
 // ------------------------------------------------
 
 void Mesh::onDataSentCallback(const wifi_tx_info_t* mac_addr, esp_now_send_status_t status) {
   String statusStr = (status == ESP_NOW_SEND_SUCCESS) ? "Delivery Success" : "Delivery Fail";
-  Logger::logln("MESH", "Last Packet Send Status: " + statusStr, LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("MESH", "Last Packet Send Status: " + statusStr, LogLevel::LOG_DEBUG);
 }
 
 void IRAM_ATTR Mesh::onDataRecvCallback(const esp_now_recv_info* info, const uint8_t* incomingData,
@@ -387,14 +357,14 @@ void Mesh::drainRecvQueue() {
     // frame that would otherwise bypass both this flag-day drop and the replay
     // gate below (which is itself keyed on proto_version == PROTO_VERSION).
     if (msg.proto_version != PROTO_VERSION) {
-      Logger::logln("MESH", "Unsupported proto version, dropping", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "Unsupported proto version, dropping", LogLevel::LOG_WARN);
       continue;
     }
 
     // Replay check
     if (msg.proto_version == PROTO_VERSION && msg.epoch_num > 0) {
       if (replay.isReplay(msg, millis())) {
-        Logger::logln("MESH", "Replayed message dropped", LogLevel::LOG_DEBUG);
+        LATTICE_LOGLN("MESH", "Replayed message dropped", LogLevel::LOG_DEBUG);
         continue;
       }
     }
@@ -422,7 +392,7 @@ void Mesh::drainRecvQueue() {
       processRouteReport(msg);
       break;
     default:
-      Logger::logln("MESH", "Unknown message type, dropping", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "Unknown message type, dropping", LogLevel::LOG_WARN);
     }
   }
 }
@@ -436,12 +406,12 @@ void IRAM_ATTR Mesh::dataRecvTrampoline(const esp_now_recv_info* mac_addr, const
 
 void Mesh::sendMessage(const uint8_t* target, const mesh_message& msg) {
   if (lattice::utils::MacAddress(target) == lattice::utils::MacAddress(deviceMacAddress)) {
-    Logger::logln("MESH", "Not sending to self. Skipped.", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("MESH", "Not sending to self. Skipped.", LogLevel::LOG_DEBUG);
     return;
   }
   esp_err_t result = esp_now_send(target, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
   if (result == ESP_OK) {
-    Logger::logln("MESH", "Message sent to peer", LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("MESH", "Message sent to peer", LogLevel::LOG_DEBUG);
   } else {
     lattice::err::fail(lattice::core::ErrorTypeDigit::COMM, lattice::core::ModuleDigit::MESH, 5,
                        (String("MESH: Error sending message: ") + esp_err_to_name(result)).c_str());
@@ -450,7 +420,7 @@ void Mesh::sendMessage(const uint8_t* target, const mesh_message& msg) {
 
 void Mesh::broadcastToAllPeers(const mesh_message& msg) {
   if (peers.peerCount == 0) {
-    Logger::logln("MESH", "WARNING: No peers to broadcast to!", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "WARNING: No peers to broadcast to!", LogLevel::LOG_WARN);
     return;
   }
   for (size_t i = 0; i < peers.peerCount; ++i) {
@@ -505,7 +475,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
     const uint8_t *kUp, *kDown;
     _checkEpochRollback(msg.epoch_num, msg.seq_num);
     if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kUp, msg)) {
-      Logger::logln("MESH", "E2E seal unavailable — uplink dropped", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "E2E seal unavailable — uplink dropped", LogLevel::LOG_WARN);
       return;
     }
 
@@ -541,7 +511,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
     // reboot-reason tracking, and turns every such gap (see
     // docs/design-gaps/multihop-data-uplink.md) into an error loop instead of a
     // silent drop. The upstream sender retries on its own timer.
-    Logger::logln("MESH", "No next hop to master — message dropped. Master timeout or unreachable.",
+    LATTICE_LOGLN("MESH", "No next hop to master — message dropped. Master timeout or unreachable.",
                   LogLevel::LOG_WARN);
   }
 }
@@ -556,7 +526,7 @@ void Mesh::transmitDispatch(const adapter_types type, const uint8_t* data, bool 
 
 void Mesh::transmit(const adapter_types type, const uint8_t* data) {
   if (!instance) {
-    Logger::logln("MESH", "transmit() called before init", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "transmit() called before init", LogLevel::LOG_WARN);
     return;
   }
   instance->transmitDispatch(type, data, false);
@@ -564,7 +534,7 @@ void Mesh::transmit(const adapter_types type, const uint8_t* data) {
 
 void Mesh::transmitSelfOriginated(const adapter_types type, const uint8_t* data) {
   if (!instance) {
-    Logger::logln("MESH", "transmitSelfOriginated() called before init", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "transmitSelfOriginated() called before init", LogLevel::LOG_WARN);
     return;
   }
   instance->transmitDispatch(type, data, true);
@@ -589,23 +559,22 @@ void Mesh::broadcastMasterBeacon() {
   // Broadcast-only: send to the registered FF:FF:… broadcast peer so the frame
   // reaches all nodes — including those not yet individually registered.
   // esp_now_send(nullptr, …) only delivers to already-registered unicast peers.
-  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
   esp_err_t br =
-      esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&beacon), sizeof(beacon));
-  Logger::logln("MESH", String("Beacon broadcast ") + (br == ESP_OK ? "OK" : "FAIL"),
+      esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&beacon), sizeof(beacon));
+  LATTICE_LOGLN("MESH", String("Beacon broadcast ") + (br == ESP_OK ? "OK" : "FAIL"),
                 LogLevel::LOG_DEBUG);
 }
 
 void Mesh::loadMeshKeyFromEEPROM() {
   // Attempt to load mesh key from EEPROM
   if (!EepromManager::getInstance().loadMeshKey(meshKey, MESH_KEY_SIZE)) {
-    Logger::logln("MESH", "EEPROM read failed, using default mesh key", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "EEPROM read failed, using default mesh key", LogLevel::LOG_WARN);
   }
 
   // If in DEV_MODE always override with compile-time key
   if (lattice::config::DEV_MODE) {
     memcpy(meshKey, lattice::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
-    Logger::logln("MESH", "DEV_MODE: Overriding mesh key with compile-time default",
+    LATTICE_LOGLN("MESH", "DEV_MODE: Overriding mesh key with compile-time default",
                   LogLevel::LOG_INFO);
   }
 
@@ -619,7 +588,7 @@ void Mesh::loadMeshKeyFromEEPROM() {
   }
 
   if (unset) {
-    Logger::logln("MESH", "Mesh key unset, loading default from config", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Mesh key unset, loading default from config", LogLevel::LOG_INFO);
     memcpy(meshKey, lattice::config::DEFAULT_MESH_KEY, MESH_KEY_SIZE);
     saveMeshKeyToEEPROM(meshKey); // Will be skipped automatically in dev mode
   }
@@ -627,21 +596,6 @@ void Mesh::loadMeshKeyFromEEPROM() {
 
 void Mesh::saveMeshKeyToEEPROM(const uint8_t* key) {
   EepromManager::getInstance().saveMeshKey(key, MESH_KEY_SIZE);
-}
-
-// Generate a new random 16-byte mesh key
-void Mesh::generateRandomMeshKey() {
-  for (int i = 0; i < MESH_KEY_SIZE; ++i) {
-    meshKey[i] = static_cast<uint8_t>(esp_random() & 0xFF);
-  }
-  Logger::logln("MESH", "Generated new random mesh key", LogLevel::LOG_DEBUG);
-}
-
-bool Mesh::meshKeyIsSet() const {
-  for (int i = 0; i < MESH_KEY_SIZE; ++i)
-    if (meshKey[i] != 0xFF)
-      return true;
-  return false;
 }
 
 void Mesh::broadcastAdapterData(adapter_types type, const uint8_t* data, bool deliverLocally) {
@@ -678,7 +632,7 @@ void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const 
   const uint8_t *kUp, *kDown;
   _checkEpochRollback(msg.epoch_num, msg.seq_num);
   if (!peerE2EKeys(destMac, &kUp, &kDown) || !lattice::mesh::crypto::sealPayload(kDown, msg)) {
-    Logger::logln("MESH", "downlink seal unavailable — dropped", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "downlink seal unavailable — dropped", LogLevel::LOG_WARN);
     return;
   }
 
@@ -688,7 +642,7 @@ void Mesh::sendDownlinkToNode(const uint8_t* destMac, adapter_types type, const 
     // Defensive clamp (issue #47 item 4) before indexing path[]/msg.route_path
     // with pathLen below — see downlinkRouteLenExceedsMaxHops() above.
     if (downlinkRouteLenExceedsMaxHops(pathLen)) {
-      Logger::logln("MESH", "downlink route_len exceeds MAX_HOPS — dropping", LogLevel::LOG_ERROR);
+      LATTICE_LOGLN("MESH", "downlink route_len exceeds MAX_HOPS — dropping", LogLevel::LOG_ERROR);
       return;
     }
     // RouteTable stores the path in origin->master order (as accumulated by
@@ -735,7 +689,7 @@ void Mesh::debugDumpRadio() {
       out += "0";
     out += String(meshKey[i], HEX) + " ";
   }
-  Logger::logln("MESH", out, LogLevel::LOG_INFO);
+  LATTICE_LOGLN("MESH", out, LogLevel::LOG_INFO);
 }
 
 void Mesh::checkMasterTimeout() {
@@ -744,7 +698,7 @@ void Mesh::checkMasterTimeout() {
   if (currentMaster.distance == 0xFF)
     return; // No master known yet
   if (millis() - lastMasterBeaconReceivedMs > STALE_MASTER_THRESHOLD_MS) {
-    Logger::logln("MESH", "Master beacon timeout — clearing route, treating as offline",
+    LATTICE_LOGLN("MESH", "Master beacon timeout — clearing route, treating as offline",
                   LogLevel::LOG_WARN);
     memset(currentMaster.mac, 0, 6);
     currentMaster.distance = 0xFF;
@@ -772,14 +726,14 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   if (!lattice::config::DEV_MODE && !lattice::mesh::pin::isTestBypassed()) {
     if (memcmp(msg.origin_mac_address, lattice::mesh::pin::MASTER_MAC,
                sizeof(lattice::mesh::pin::MASTER_MAC)) != 0) {
-      Logger::logln("MESH", "Beacon origin MAC mismatch pin — drop", LogLevel::LOG_ERROR);
+      LATTICE_LOGLN("MESH", "Beacon origin MAC mismatch pin — drop", LogLevel::LOG_ERROR);
       return;
     }
   }
 
   // Guard: drop beacon if hop count would overflow uint8_t or exceed limit
   if (msg.hop_count >= lattice::config::MAX_HOPS) {
-    Logger::logln("MESH", "Beacon hop count exceeded MAX_HOPS, dropping relay", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "Beacon hop count exceeded MAX_HOPS, dropping relay", LogLevel::LOG_WARN);
     return;
   }
 
@@ -794,7 +748,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     memcpy(enrollment.knownMasterMac, msg.origin_mac_address, 6);
     enrollment.hasMasterMac = true;
     EepromManager::getInstance().saveKnownMasterMac(enrollment.knownMasterMac);
-    Logger::logln("MESH", "Master MAC learned from first beacon (TOFU fallback)",
+    LATTICE_LOGLN("MESH", "Master MAC learned from first beacon (TOFU fallback)",
                   LogLevel::LOG_INFO);
   } else if (!fromPrimary && !fromSecondary) {
     // Beacon from unrecognised MAC
@@ -803,16 +757,16 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
       memcpy(enrollment.knownMasterMacSecondary, msg.origin_mac_address, 6);
       enrollment.hasMasterMacSecondary = true;
       EepromManager::getInstance().saveKnownMasterMacSecondary(enrollment.knownMasterMacSecondary);
-      Logger::logln("MESH", "Secondary master MAC learned (TOFU)", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("MESH", "Secondary master MAC learned (TOFU)", LogLevel::LOG_INFO);
       // fall through to process this beacon as valid
     } else if (millis() - lastMasterBeaconReceivedMs < STALE_MASTER_THRESHOLD_MS) {
       // Known master(s) still fresh — reject unknown MAC
-      Logger::logln("MESH", "Beacon from unexpected MAC rejected (master still alive)",
+      LATTICE_LOGLN("MESH", "Beacon from unexpected MAC rejected (master still alive)",
                     LogLevel::LOG_WARN);
       return;
     } else {
       // All known masters stale — accept as new primary (hotswap)
-      Logger::logln("MESH", "Stale master — accepting new master MAC", LogLevel::LOG_INFO);
+      LATTICE_LOGLN("MESH", "Stale master — accepting new master MAC", LogLevel::LOG_INFO);
       memcpy(enrollment.knownMasterMac, msg.origin_mac_address, 6);
       EepromManager::getInstance().saveKnownMasterMac(enrollment.knownMasterMac);
     }
@@ -822,9 +776,9 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
           lattice::utils::MacAddress(msg.origin_mac_address) &&
       lastSeenMasterMac[0] != 0) {
     if (_dualMasterMode) {
-      Logger::logln("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
+      LATTICE_LOGLN("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
     } else {
-      Logger::logln("MESH", "WARNING: Multiple masters detected!", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "WARNING: Multiple masters detected!", LogLevel::LOG_WARN);
       lattice::err::fail(
           lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 7,
           "Multiple master nodes detected! Network split or misconfiguration likely.");
@@ -851,7 +805,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   uint8_t derived = (min_d == 0xFF) ? 0xFF : static_cast<uint8_t>(min_d + 1);
   if (derived != currentMaster.distance) {
     currentMaster.distance = derived;
-    Logger::logln("MESH", "Route distance derived: " + String(derived), LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Route distance derived: " + String(derived), LogLevel::LOG_INFO);
   }
 
   if (!isMaster) {
@@ -860,7 +814,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
         (msg.epoch_num > replay.lastRelayedEpoch) ||
         (msg.epoch_num == replay.lastRelayedEpoch && msg.seq_num > replay.lastRelayedSeqNum);
     if (!isNewer) {
-      Logger::logln("MESH", "Duplicate beacon relay suppressed", LogLevel::LOG_DEBUG);
+      LATTICE_LOGLN("MESH", "Duplicate beacon relay suppressed", LogLevel::LOG_DEBUG);
       return;
     }
     replay.lastRelayedEpoch = msg.epoch_num;
@@ -885,10 +839,8 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 
 void Mesh::processAdapterData(const mesh_message& msg) {
   // OP_CONFIG_SET = 0xC1 (from lib/lattice-protocol/opcodes.h)
-  static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-
   bool addressedToSelf = (memcmp(msg.target_mac_address, deviceMacAddress, 6) == 0);
-  bool isBroadcastTarget = (memcmp(msg.target_mac_address, kBroadcastMac, 6) == 0);
+  bool isBroadcastTarget = (memcmp(msg.target_mac_address, BROADCAST_MAC, 6) == 0);
   bool addressedToMaster =
       enrollment.hasMasterMac && (memcmp(msg.target_mac_address, currentMaster.mac, 6) == 0);
 
@@ -940,7 +892,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   // over the air at the master is either a stale self-echo or a forgery — drop it
   // rather than deliver it to externalRecvCallback without E2E authentication.
   if (isMaster && !addressedToSelf && isSealedType(msg.message_type)) {
-    Logger::logln("MESH",
+    LATTICE_LOGLN("MESH",
                   "Master: sealed-type frame not addressed to self rejected (unauthenticated)",
                   LogLevel::LOG_WARN);
     return;
@@ -954,7 +906,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     const uint8_t *kUp, *kDown;
     if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
         !lattice::mesh::crypto::openPayload(kUp, opened)) {
-      Logger::logln("MESH", "E2E open failed — frame dropped", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "E2E open failed — frame dropped", LogLevel::LOG_WARN);
       return;
     }
   }
@@ -968,7 +920,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   if (!isMaster && addressedToSelf && msg.message_type == MESH_TYPE_ADAPTER_DATA) {
     const uint8_t *kUp, *kDown;
     if (!masterE2EKeys(&kUp, &kDown) || !lattice::mesh::crypto::openPayload(kDown, opened)) {
-      Logger::logln("MESH", "downlink open failed — dropped", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "downlink open failed — dropped", LogLevel::LOG_WARN);
       return;
     }
     nodeOpened = true;
@@ -989,7 +941,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
   // (e.g. OP_HEALTH_REQ, OP_TX_POWER_SET) is unaffected — this guard only
   // fires for CONFIG_SET/NODE_ID_SET.
   if (isConfigOpcode && !needsOpen && !nodeOpened) {
-    Logger::logln("MESH", "Config opcode via unopened/broadcast path rejected (unauthenticated)",
+    LATTICE_LOGLN("MESH", "Config opcode via unopened/broadcast path rejected (unauthenticated)",
                   LogLevel::LOG_WARN);
     return;
   }
@@ -999,7 +951,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
         enrollment.hasMasterMacSecondary &&
         memcmp(opened.origin_mac_address, enrollment.knownMasterMacSecondary, 6) == 0;
     if (!fromPrimary && !fromSecondary) {
-      Logger::logln("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
       return;
     }
   }
@@ -1066,15 +1018,14 @@ void Mesh::processJoinAck(const mesh_message& msg) {
     mesh_message relay = msg;
     relay.hop_count++;
     memcpy(relay.last_hop_mac_address, deviceMacAddress, 6);
-    static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&relay), sizeof(relay));
+    esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&relay), sizeof(relay));
     return;
   }
   // Masters issue JOIN_ACKs; they never enroll via one. Without this guard a
   // forged ACK addressed to the master (fingerprint is observable over the
   // air) could TOFU-poison it and register attacker key material.
   if (isMaster) {
-    Logger::logln("MESH", "JOIN_ACK addressed to master — ignoring", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "JOIN_ACK addressed to master — ignoring", LogLevel::LOG_WARN);
     return;
   }
   enrollment.processJoinAck(msg, deviceMacAddress,
@@ -1108,7 +1059,7 @@ bool Mesh::registerPeerWithKey(const uint8_t* mac, const uint8_t* publicKey32, b
         }
       }
       if (keyEstablished) {
-        Logger::logln("MESH", "Peer already registered — keeping established key",
+        LATTICE_LOGLN("MESH", "Peer already registered — keeping established key",
                       LogLevel::LOG_DEBUG);
         p->lastSeenMillis = millis();
         return true; // already routable; nothing to change
@@ -1119,7 +1070,7 @@ bool Mesh::registerPeerWithKey(const uint8_t* mac, const uint8_t* publicKey32, b
     p->lastSeenMillis = millis();
   } else {
     if (peers.peerCount >= MAX_PEERS) {
-      Logger::logln("MESH", "Peer list full, cannot enroll", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "Peer list full, cannot enroll", LogLevel::LOG_WARN);
       return false;
     }
     PeerInfo newPeer;
@@ -1176,9 +1127,8 @@ void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint
   }
   // Broadcast via the registered FF:FF:… peer so the new node receives the ACK
   // even before it is individually registered as a unicast peer.
-  static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
-  Logger::logln("MESH", "JOIN_ACK sent to newly enrolled node", LogLevel::LOG_INFO);
+  esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&ack), sizeof(ack));
+  LATTICE_LOGLN("MESH", "JOIN_ACK sent to newly enrolled node", LogLevel::LOG_INFO);
 }
 // --------------------------------------------------------
 
@@ -1202,17 +1152,17 @@ void Mesh::processRouteReport(const mesh_message& msg) {
     const uint8_t *kUp, *kDown;
     if (!peerE2EKeys(msg.origin_mac_address, &kUp, &kDown) ||
         !lattice::mesh::crypto::openPayload(kUp, opened)) {
-      Logger::logln("MESH", "E2E open failed — route report dropped", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "E2E open failed — route report dropped", LogLevel::LOG_WARN);
       return;
     }
     if (opened.data[0] != OP_ROUTE_REPORT) {
-      Logger::logln("MESH", "processRouteReport: bad opcode, dropping", LogLevel::LOG_WARN);
+      LATTICE_LOGLN("MESH", "processRouteReport: bad opcode, dropping", LogLevel::LOG_WARN);
       return;
     }
     if (msg.route_len > lattice::config::MAX_HOPS) {
       // Tiger-Style: bounds-check before indexing route_path below — a
       // corrupt/hostile route_len must never drive an out-of-bounds read.
-      Logger::logln("MESH", "Route report: route_len exceeds MAX_HOPS, dropping",
+      LATTICE_LOGLN("MESH", "Route report: route_len exceeds MAX_HOPS, dropping",
                     LogLevel::LOG_ERROR);
       return;
     }
@@ -1238,7 +1188,7 @@ void Mesh::processRouteReport(const mesh_message& msg) {
       const uint8_t* hop_mac = &msg.route_path[static_cast<size_t>(i) * 6];
       const uint8_t *hopKUp, *hopKDown;
       if (!peerE2EKeys(hop_mac, &hopKUp, &hopKDown)) {
-        Logger::logln("MESH", "Route report: unknown hop, dropping", LogLevel::LOG_ERROR);
+        LATTICE_LOGLN("MESH", "Route report: unknown hop, dropping", LogLevel::LOG_ERROR);
         return;
       }
       uint8_t ctx[routemac::HOP_CTX_LEN];
@@ -1247,7 +1197,7 @@ void Mesh::processRouteReport(const mesh_message& msg) {
       memcpy(prev_hop, hop_mac, 6);
     }
     if (memcmp(computed, msg.auth_path, routemac::AUTH_PATH_LEN) != 0) {
-      Logger::logln("MESH", "Route report: MAC verify failed, dropping", LogLevel::LOG_ERROR);
+      LATTICE_LOGLN("MESH", "Route report: MAC verify failed, dropping", LogLevel::LOG_ERROR);
       return;
     }
 
@@ -1268,11 +1218,11 @@ void Mesh::processRouteReport(const mesh_message& msg) {
   // from AAD, so this does not break the tag) so the master learns the full
   // origin->master relay chain for downlink source routing.
   if (msg.hop_count >= lattice::config::MAX_HOPS) {
-    Logger::logln("MESH", "processRouteReport: hop limit reached, dropping", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "processRouteReport: hop limit reached, dropping", LogLevel::LOG_WARN);
     return;
   }
   if (msg.route_len >= lattice::config::MAX_HOPS) {
-    Logger::logln("MESH", "route report path full — dropping", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("MESH", "route report path full — dropping", LogLevel::LOG_WARN);
     return;
   }
 
@@ -1303,7 +1253,7 @@ void Mesh::processRouteReport(const mesh_message& msg) {
   // above), drop and log rather than forwarding an unauthenticated hop.
   const uint8_t *kUp, *kDown;
   if (!masterE2EKeys(&kUp, &kDown)) {
-    Logger::logln("MESH", "Route report: no k_up for master, dropping relay hop",
+    LATTICE_LOGLN("MESH", "Route report: no k_up for master, dropping relay hop",
                   LogLevel::LOG_WARN);
     return;
   }
@@ -1339,11 +1289,10 @@ void Mesh::loop() {
   // err::fail every beacon interval on any node without a route (e.g. pre-enrollment).
   if (relayPending && millis() >= relayPendingAt) {
     relayPending = false;
-    static const uint8_t broadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    esp_err_t res = esp_now_send(broadcastMac, reinterpret_cast<const uint8_t*>(&relayPendingMsg),
+    esp_err_t res = esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&relayPendingMsg),
                                  sizeof(relayPendingMsg));
     if (res != ESP_OK) {
-      Logger::logln("MESH", String("Beacon relay broadcast failed: ") + esp_err_to_name(res),
+      LATTICE_LOGLN("MESH", String("Beacon relay broadcast failed: ") + esp_err_to_name(res),
                     LogLevel::LOG_WARN);
     }
   }

--- a/firmware/main/src/mesh/Mesh.h
+++ b/firmware/main/src/mesh/Mesh.h
@@ -61,8 +61,6 @@ private:
   PeerRegistry peers; // Peer list management (no heap alloc)
 
   void readMacAddress();
-  void printMac(const uint8_t* mac);
-  void printMeshMessage(const mesh_message& msg);
 
   static void onDataSentCallback(const wifi_tx_info_t* mac_addr, esp_now_send_status_t status);
   void IRAM_ATTR onDataRecvCallback(const esp_now_recv_info* mac, const uint8_t* incomingData,
@@ -95,8 +93,6 @@ private:
 
   void loadMeshKeyFromEEPROM();
   void saveMeshKeyToEEPROM(const uint8_t* key);
-  void generateRandomMeshKey();
-  bool meshKeyIsSet() const;
 
   // --- Tiger Style refactor helpers ---
   void processMasterBeacon(const mesh_message& msg);

--- a/firmware/main/src/mesh/PeerRegistry.cpp
+++ b/firmware/main/src/mesh/PeerRegistry.cpp
@@ -102,7 +102,7 @@ void PeerRegistry::loadFromEEPROM() {
 
   // Fallback in dev mode or when list is empty
   if (peerCount == 0) {
-    Logger::logln("MESH", "Peer list empty; loading defaults from config", LogLevel::LOG_INFO);
+    LATTICE_LOGLN("MESH", "Peer list empty; loading defaults from config", LogLevel::LOG_INFO);
     for (int i = 0; i < lattice::config::NUM_DEFAULT_PEERS; ++i) {
       PeerInfo peer;
       memcpy(peer.mac, lattice::config::DEFAULT_PEERS[i], 6);
@@ -145,7 +145,7 @@ void PeerRegistry::addAndPersist(const uint8_t* mac) {
   saveToEEPROM();
   // Note: ESP-NOW registration (registerPeerWithEspNow) is handled by Mesh layer
   // since it requires devicePrivateKey (a Mesh field) and MeshCrypto (mbedtls).
-  Logger::logln("MESH", "Peer added", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("MESH", "Peer added", LogLevel::LOG_DEBUG);
 }
 
 void PeerRegistry::removeAndPersist(const uint8_t* mac) {
@@ -159,7 +159,7 @@ void PeerRegistry::removeAndPersist(const uint8_t* mac) {
   esp_err_t result = esp_now_del_peer(mac);
   lattice::err::checkEsp(result, lattice::utils::ErrorType::COMMUNICATION_FAIL,
                          "removePeerFromEEPROM: del_peer failed");
-  Logger::logln("MESH", "Removed ESP-NOW peer.", LogLevel::LOG_DEBUG);
+  LATTICE_LOGLN("MESH", "Removed ESP-NOW peer.", LogLevel::LOG_DEBUG);
 }
 
 } // namespace mesh

--- a/firmware/main/src/mesh/broadcast_mac.h
+++ b/firmware/main/src/mesh/broadcast_mac.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <cstdint>
+
+// Canonical ESP-NOW broadcast MAC (FF:FF:FF:FF:FF:FF), header-only.
+//
+// Consolidates the ~7 independent `static const uint8_t ...[6] = {0xFF, ...}` copies that used
+// to live scattered across Mesh.cpp and Enrollment.cpp (post-Phase-G audit item E). One
+// definition, one place to read/change.
+
+namespace lattice {
+namespace mesh {
+
+constexpr uint8_t BROADCAST_MAC[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+} // namespace mesh
+} // namespace lattice

--- a/firmware/main/src/network/MacAddress.h
+++ b/firmware/main/src/network/MacAddress.h
@@ -12,7 +12,6 @@ struct MacAddress {
   // Constructors
   MacAddress() { memset(bytes, 0, 6); }
   explicit MacAddress(const uint8_t* mac) { memcpy(bytes, mac, 6); }
-  explicit MacAddress(const String& macString);
 
   // Comparison operators
   bool operator==(const MacAddress& other) const { return memcmp(bytes, other.bytes, 6) == 0; }
@@ -40,18 +39,6 @@ struct MacAddress {
   void setBroadcast() { memset(bytes, 0xFF, 6); }
   void setZero() { memset(bytes, 0, 6); }
 };
-
-inline MacAddress::MacAddress(const String& macString) {
-  // Expect format "AA:BB:CC:DD:EE:FF"
-  int vals[6];
-  if (sscanf(macString.c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", &vals[0], &vals[1], &vals[2],
-             &vals[3], &vals[4], &vals[5]) == 6) {
-    for (int i = 0; i < 6; ++i)
-      bytes[i] = static_cast<uint8_t>(vals[i]);
-  } else {
-    setZero();
-  }
-}
 
 } // namespace utils
 } // namespace lattice

--- a/firmware/main/src/network/hw_mac.h
+++ b/firmware/main/src/network/hw_mac.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <cstdint>
+#include <esp_wifi.h>
+
+// Canonical "read this node's own station MAC" helper, header-only.
+//
+// Consolidates 3 identical `static void readOwnMac(uint8_t[6])` copies that used to live in
+// PirAdapter.cpp, SerialAdapter.cpp and SerialFraming.cpp (post-Phase-G audit item N). One
+// definition, one place to change if the interface (WIFI_IF_STA) ever does.
+
+namespace lattice {
+namespace hw {
+
+inline void readOwnMac(uint8_t out[6]) {
+  esp_wifi_get_mac(WIFI_IF_STA, out);
+}
+
+} // namespace hw
+} // namespace lattice

--- a/firmware/main/src/persistence/EepromManager.cpp
+++ b/firmware/main/src/persistence/EepromManager.cpp
@@ -21,7 +21,7 @@ bool EepromManager::init() {
   if (isInitialized)
     return true;
   if (!_prefs.begin(NVS_KEYS::NAMESPACE, false)) {
-    Logger::logln("NVS", "Failed to open NVS namespace", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("NVS", "Failed to open NVS namespace", LogLevel::LOG_ERROR);
     lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::EEPROM, 1,
                        "EepromManager: NVS begin failed");
     return false;
@@ -52,7 +52,7 @@ bool EepromManager::getDevMode() const {
 
 bool EepromManager::ensureInitialized() {
   if (!isInitialized) {
-    Logger::logln("NVS", "NVS not initialized", LogLevel::LOG_ERROR);
+    LATTICE_LOGLN("NVS", "NVS not initialized", LogLevel::LOG_ERROR);
     return false;
   }
   return true;
@@ -60,9 +60,9 @@ bool EepromManager::ensureInitialized() {
 
 void EepromManager::logOperation(const char* operation, const char* details) {
   if (details) {
-    Logger::logln("NVS", String(operation) + ": " + details, LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("NVS", String(operation) + ": " + details, LogLevel::LOG_DEBUG);
   } else {
-    Logger::logln("NVS", operation, LogLevel::LOG_DEBUG);
+    LATTICE_LOGLN("NVS", operation, LogLevel::LOG_DEBUG);
   }
 }
 
@@ -211,7 +211,7 @@ bool EepromManager::loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32) {
   memcpy(both + 32, publicKey32, 32);
   uint16_t computed = crc16(both, 64);
   if (static_cast<uint16_t>(stored) != computed) {
-    Logger::logln("NVS", "Keypair CRC mismatch", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("NVS", "Keypair CRC mismatch", LogLevel::LOG_WARN);
     return false;
   }
   return true;
@@ -359,7 +359,7 @@ void EepromManager::clearAll() {
 }
 
 void EepromManager::dumpEEPROM() {
-  Logger::logln("NVS", "NVS dump not implemented (use idf.py nvs-dump)", LogLevel::LOG_INFO);
+  LATTICE_LOGLN("NVS", "NVS dump not implemented (use idf.py nvs-dump)", LogLevel::LOG_INFO);
 }
 
 bool EepromManager::_persistOrEscalate(const char* key, size_t got, size_t want,
@@ -372,7 +372,7 @@ bool EepromManager::_persistOrEscalate(const char* key, size_t got, size_t want,
                        "NVS write failed (security-relevant key)");
     return false; // unreachable outside UNIT_TEST
   }
-  Logger::logln("NVS",
+  LATTICE_LOGLN("NVS",
                 String("write failed key=") + key + " got=" + String((unsigned)got) +
                     " want=" + String((unsigned)want),
                 LogLevel::LOG_ERROR);

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -6,6 +6,11 @@ CONFIG_AUTOSTART_ARDUINO=y
 CONFIG_FREERTOS_HZ=1000
 CONFIG_ARDUINO_LOOP_STACK_SIZE=8192
 
+# Flash: optimize for size + link-time optimization (Phase G §2, issue #52 lever 2).
+# gc-sections + function-sections are ESP-IDF defaults already.
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+CONFIG_COMPILER_OPTIMIZATION_LTO=y
+
 # Partition table (no EEPROM partition — NVS replaces it)
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
@@ -18,8 +23,16 @@ CONFIG_BT_ENABLED=n
 CONFIG_MBEDTLS_CHACHA20_C=y
 CONFIG_MBEDTLS_POLY1305_C=y
 CONFIG_MBEDTLS_CHACHAPOLY_C=y
-CONFIG_MBEDTLS_HARDWARE_AES=y
 CONFIG_MBEDTLS_HARDWARE_SHA=y
+
+# mbedtls: trim AES/GCM/CCM — E2E AEAD is ChaCha20-Poly1305 only (Phase A), TLS is off
+# (CONFIG_MBEDTLS_TLS_ENABLED=n below), so no RSA/TLS session code needs AES. (Phase G §3,
+# issue #52 lever 3.) CONFIG_MBEDTLS_HARDWARE_AES depends on MBEDTLS_AES_C, so it must go
+# off with it — leaving it =y here would be a dangling/inconsistent default.
+CONFIG_MBEDTLS_AES_C=n
+CONFIG_MBEDTLS_GCM_C=n
+CONFIG_MBEDTLS_CCM_C=n
+CONFIG_MBEDTLS_HARDWARE_AES=n
 
 # mbedtls: HKDF used by E2ECrypto::deriveE2EKeys to expand ECDH secret
 CONFIG_MBEDTLS_HKDF_C=y


### PR DESCRIPTION
## Summary

Task 2 of the Phase G memory-opt plan (flash-size levers 1-3 + audit items A/E/J/M/N). See
`docs/superpowers/specs/2026-08-04-phaseG-memory-opt-design.md` §1-3, §9.

- **§1 Log macros:** `LATTICE_LOG`/`LATTICE_LOGLN` in `Logger.h`, gated by
  `LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE` → `((void)0)` (else identical to
  `Logger::log*`). `project_config.h` defines the compile-time mirror + a
  `static_assert` against the runtime `DEFAULT_LOG_LEVEL` enum so they can't
  drift. **176 call sites** mechanically migrated across 14 files.
- **§2 -Os/LTO:** `CONFIG_COMPILER_OPTIMIZATION_SIZE`/`_LTO` added to
  `sdkconfig.defaults` (were unset pre-Phase-G).
- **§3 mbedtls trim:** `CONFIG_MBEDTLS_AES_C/GCM_C/CCM_C=n` (E2E AEAD is
  ChaCha20-Poly1305 only, confirmed via `grep` — zero AES/GCM/CCM references
  in firmware source). Also disabled the now-dangling
  `CONFIG_MBEDTLS_HARDWARE_AES` (Kconfig `depends on MBEDTLS_AES_C`). All
  three knobs kept — none rolled back.
- **Audit A:** deleted dead code (`Mesh.cpp` printMac/printMeshMessage/
  generateRandomMeshKey/meshKeyIsSet, `Adapter.cpp` LED stub +
  `LED_ADAPTER_DEFAULT_PIN`, `RELAY_ADAPTER` enum, `Error.h`
  ERROR_ASSERT/ERROR_CHECK, `MacAddress(const String&)` ctor) — each verified
  reference-free before removal.
- **Audit E:** new `mesh/broadcast_mac.h`, consolidates 7 duplicate FF:FF
  `static const uint8_t[6]` sites in `Mesh.cpp`/`Enrollment.cpp`.
- **Audit J:** `GpioInput`/`GpioOutput` `isValid*Pin` switch → `constexpr
  uint64_t VALID_MASK` bit test (masks round-trip verified against the
  original case lists for all pins 0-63).
- **Audit M:** `SevenSegDisplay::show()`/`showWithDP()` → shared
  `showInternal()`.
- **Audit N:** new `network/hw_mac.h`, consolidates 3 duplicate
  `readOwnMac()` copies (PirAdapter/SerialAdapter/SerialFraming).

No wire-format changes. No cross-repo work. Firmware-only.

## Verification caveat

No ESP-IDF toolchain (`idf.py`) available in the dev environment this PR was
authored in, so §2/§3's sdkconfig changes could not be build-verified
locally. Host unit/e2e tests are unaffected (they fetch a standalone mbedtls,
independent of `sdkconfig.defaults`). **This PR's CI `firmware-build.yml`
(`idf.py build` + `idf.py size`) is the first real gate for those two items**
— if the mbedtls trim breaks the link, the fix is a single-line revert in
`firmware/sdkconfig.defaults` (each knob is isolated).

## Test plan

- [x] `cmake --build tests/build --parallel` — clean, zero warnings
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 --label-exclude e2e` — 218/218 passed
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 -L e2e` — 41/41 passed (full e2e suite; the brief's exact `-R "aead|enroll|route|beacon"` filter is case-sensitive and only matches 1 test name, so ran the full e2e label too for confidence)
- [x] `clang-format --style=file --dry-run --Werror` over `firmware/main/src` (exact CI `lint-format` invocation) — clean
- [ ] CI `firmware-build.yml` `idf.py build` + `idf.py size` — **please confirm on this PR**, not verifiable locally (see caveat above)
- [ ] CI `static-analysis` (cppcheck) — not installed locally, not independently run

🤖 Generated with [Claude Code](https://claude.com/claude-code)