### PR TITLE
feat(phaseG): consume protocol v0.6.0 wire shrink + PROTO_VERSION 5

### DIFF
--- a/firmware/main/project_config.h
+++ b/firmware/main/project_config.h
@@ -166,7 +166,9 @@ inline constexpr size_t LATTICE_ROUTE_TABLE_MAX = 16;
 // under the ~20 cap on realistic relays.
 inline constexpr size_t LATTICE_DOWNLINK_PEER_MAX = 4;
 // Maximum allowed routing hops in the mesh network
-constexpr uint8_t MAX_HOPS = 10;
+// (protocol v0.6.0 wire shrink §8: routePath 60→48B, 10→8 hops. Observed
+// deployments never exceeded 4 hops, so this is safe with margin.)
+constexpr uint8_t MAX_HOPS = 8;
 // Peer staleness threshold (ms) before being considered offline
 constexpr uint32_t STALE_PEER_THRESHOLD_MS = 8000UL;
 // Routing timeout used by MessageRouter (ms)

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -245,16 +245,20 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
         // Server may relay a secondary-master identity alongside the
         // enrollment approval (Phase 4 dual-master failover) — pass it
         // through to the JOIN_ACK only if it's actually present (non-zero).
+        // Protocol v0.6.0 (wire shrink §8): packed into data[4..42] rather
+        // than top-level MeshMessage fields.
+        const uint8_t* secondaryMasterMac = msg.data + 4;
+        const uint8_t* secondaryPublicKey = msg.data + 10;
         bool hasSecondary = false;
         for (int i = 0; i < 6; ++i) {
-          if (msg.secondary_master_mac[i]) {
+          if (secondaryMasterMac[i]) {
             hasSecondary = true;
             break;
           }
         }
         if (hasSecondary) {
           meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key,
-                                   msg.secondary_master_mac, msg.secondary_public_key);
+                                   secondaryMasterMac, secondaryPublicKey);
         } else {
           meshInstance->enrollPeer(msg.target_mac_address, msg.enrollment_public_key);
         }

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -129,12 +129,18 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
   }
 
   // Protocol v0.6.0 (wire shrink §8): secondary master identity lives in
-  // outMsg.data[4..42], not top-level fields. See encode() above.
-  if (pbMsg.has_secondaryMasterMac) {
-    memcpy(outMsg.data + 4, pbMsg.secondaryMasterMac.bytes, 6);
-  }
-  if (pbMsg.has_secondaryPublicKey) {
-    memcpy(outMsg.data + 10, pbMsg.secondaryPublicKey.bytes, 32);
+  // outMsg.data[4..42], not top-level fields. See encode() above. data[] is
+  // now a general-purpose payload shared by every message type, so also
+  // gate on message_type == JOIN_ACK (defense in depth): if the hub ever
+  // mis-sets these has_* flags on a non-JOIN_ACK frame, this must not
+  // silently corrupt that frame's data payload.
+  if (outMsg.message_type == MESH_TYPE_JOIN_ACK) {
+    if (pbMsg.has_secondaryMasterMac) {
+      memcpy(outMsg.data + 4, pbMsg.secondaryMasterMac.bytes, 6);
+    }
+    if (pbMsg.has_secondaryPublicKey) {
+      memcpy(outMsg.data + 10, pbMsg.secondaryPublicKey.bytes, 32);
+    }
   }
 
   // For server-to-device messages (JOIN_ACK, SERIAL_CMD_BROADCAST) the MAC

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -55,16 +55,21 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     }
   }
 
-  // secondary_master_mac/secondary_public_key (Phase 4 dual-master failover):
-  // the server stamps these onto a JOIN_ACK to designate a failover master
-  // alongside enrollment approval (see SerialAdapter::handleCompleteFrame /
-  // Mesh::enrollPeer's 4-arg overload). Only present, and only meaningful, on
+  // secondary master identity (Phase 4 dual-master failover): the server
+  // stamps this onto a JOIN_ACK to designate a failover master alongside
+  // enrollment approval (see SerialAdapter::handleCompleteFrame /
+  // Mesh::enrollPeer's 4-arg overload). Protocol v0.6.0 (wire shrink §8)
+  // packs this into the JOIN_ACK data[] payload rather than top-level
+  // MeshMessage fields: data[4..10] = secondaryMasterMac,
+  // data[10..42] = secondaryPublicKey. Only present, and only meaningful, on
   // JOIN_ACK; encode only when non-zero so ordinary single-master JOIN_ACKs
   // stay byte-identical to before this field existed.
   if (msg.message_type == MESH_TYPE_JOIN_ACK) {
+    const uint8_t* secondaryMasterMac = msg.data + 4;
+    const uint8_t* secondaryPublicKey = msg.data + 10;
     bool hasSecondary = false;
     for (int i = 0; i < 6; ++i) {
-      if (msg.secondary_master_mac[i]) {
+      if (secondaryMasterMac[i]) {
         hasSecondary = true;
         break;
       }
@@ -72,10 +77,10 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     if (hasSecondary) {
       pbMsg.has_secondaryMasterMac = true;
       pbMsg.secondaryMasterMac.size = 6;
-      memcpy(pbMsg.secondaryMasterMac.bytes, msg.secondary_master_mac, 6);
+      memcpy(pbMsg.secondaryMasterMac.bytes, secondaryMasterMac, 6);
       pbMsg.has_secondaryPublicKey = true;
       pbMsg.secondaryPublicKey.size = 32;
-      memcpy(pbMsg.secondaryPublicKey.bytes, msg.secondary_public_key, 32);
+      memcpy(pbMsg.secondaryPublicKey.bytes, secondaryPublicKey, 32);
     }
   }
 
@@ -123,11 +128,13 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
     memcpy(outMsg.enrollment_public_key, pbMsg.public_key.bytes, 32);
   }
 
+  // Protocol v0.6.0 (wire shrink §8): secondary master identity lives in
+  // outMsg.data[4..42], not top-level fields. See encode() above.
   if (pbMsg.has_secondaryMasterMac) {
-    memcpy(outMsg.secondary_master_mac, pbMsg.secondaryMasterMac.bytes, 6);
+    memcpy(outMsg.data + 4, pbMsg.secondaryMasterMac.bytes, 6);
   }
   if (pbMsg.has_secondaryPublicKey) {
-    memcpy(outMsg.secondary_public_key, pbMsg.secondaryPublicKey.bytes, 32);
+    memcpy(outMsg.data + 10, pbMsg.secondaryPublicKey.bytes, 32);
   }
 
   // For server-to-device messages (JOIN_ACK, SERIAL_CMD_BROADCAST) the MAC

--- a/firmware/main/src/mesh/CompactMessage.cpp
+++ b/firmware/main/src/mesh/CompactMessage.cpp
@@ -39,8 +39,10 @@ void toWire(const CompactMessage& src, mesh_message& dst) {
   memcpy(dst.route_path, src.route_path, sizeof(src.route_path));
   memcpy(dst.auth_tag, src.auth_tag, sizeof(src.auth_tag));
   memcpy(dst.auth_path, src.auth_path, sizeof(src.auth_path));
-  // secondary_master_mac / secondary_public_key: left zeroed by the memset
-  // above — CompactMessage does not carry them (see header comment).
+  // secondary_master_mac / secondary_public_key: not zeroed here — as of
+  // protocol v0.6.0 they live inside data[4..42], which the memcpy above
+  // (dst.data <- src.data) already copied through verbatim. See header
+  // comment.
 }
 
 } // namespace mesh

--- a/firmware/main/src/mesh/CompactMessage.h
+++ b/firmware/main/src/mesh/CompactMessage.h
@@ -34,18 +34,18 @@ namespace mesh {
 // MasterSendsSealedConfigSetThroughRelayToLeaf, which exercises the real
 // ISR->queue->drain pipeline for a downlink relay + AEAD open).
 //
-// What IS safe to drop: secondary_master_mac[6] + secondary_public_key[32]
-// (JOIN_ACK dual-master fields, Phase 4). No current test — unit or e2e —
-// exercises these fields via the real receive pipeline (dual-master e2e
-// coverage TOFU-learns the secondary from its BEACON, not from JOIN_ACK's
-// secondary fields; see tests/e2e/scenarios/test_dual_master_e2e.cpp's
-// top-of-file comment: full DATA failover via JOIN_ACK-conveyed secondary
-// keying is already a documented, pre-existing gap, not a working, tested
-// path). toWire() zeroes them on reconstruction — a Mesh::recvQueue frame
-// carrying a real dual-master JOIN_ACK's secondary fields over the air will
-// not propagate them past the compact boundary; this is a known, narrow,
-// test-verified-safe limitation of this optimization, not a new regression
-// of a working feature.
+// secondary_master_mac[6] + secondary_public_key[32] (JOIN_ACK dual-master
+// fields, Phase 4) have no dedicated slot in this struct — but as of
+// protocol v0.6.0 (wire shrink §8) they no longer have a dedicated slot on
+// the wire either. They were folded into mesh_message::data[64] at
+// data[4..42] (see SerialFraming::decode / Enrollment::processJoinAck).
+// Because toCompact()/toWire() copy data[64] verbatim (CompactMessage.cpp),
+// this secondary data DOES survive the compact round trip today: a
+// Mesh::recvQueue frame carrying a real dual-master JOIN_ACK's secondary
+// fields keeps them, embedded in dst.data, all the way through
+// drainRecvQueue's reconstruction. There is nothing to "drop" here anymore
+// — readers just need to know to pull the secondary MAC/pubkey out of
+// data[4..42] on JOIN_ACK frames, same as the wire form requires.
 struct CompactMessage {
   int32_t data_type;
   uint32_t epoch_num;
@@ -65,27 +65,31 @@ struct CompactMessage {
   uint8_t route_path[48];
   uint8_t auth_tag[16];
   uint8_t auth_path[8];
-  // Skipped (see rationale above): secondary_master_mac[6], secondary_public_key[32]
-  // (protocol v0.6.0 dropped these top-level wire fields entirely — see
-  // Enrollment::processJoinAck, which now reads the JOIN_ACK secondary from
-  // data[4..42] instead).
+  // No dedicated secondary_master_mac[6] / secondary_public_key[32] fields
+  // (see header comment above): protocol v0.6.0 dropped these as top-level
+  // wire fields entirely — see Enrollment::processJoinAck, which reads the
+  // JOIN_ACK secondary from data[4..42] instead. That data lives inside
+  // `data[64]` below and round-trips with it.
 };
-// CompactMessage carries every field mesh_message still has except
-// secondary_master_mac/secondary_public_key, which no longer exist on the
-// wire at all as of protocol v0.6.0 (they moved into JOIN_ACK's data[]
-// payload — see Enrollment::processJoinAck). Not currently used for Mesh::recvQueue
-// (see Mesh.h's RecvQueueEntry comment) — kept at <= 220 so a future consumer
-// noticing this doesn't have to re-derive the achievable budget from scratch.
+// CompactMessage has no dedicated field for secondary_master_mac/
+// secondary_public_key, which no longer exist as top-level wire fields as
+// of protocol v0.6.0 (they moved into JOIN_ACK's data[] payload — see
+// Enrollment::processJoinAck). They are still present, opaquely, inside
+// `data[64]` below, which toCompact()/toWire() copy verbatim. Not currently
+// used for Mesh::recvQueue (see Mesh.h's RecvQueueEntry comment) — kept at
+// <= 220 so a future consumer noticing this doesn't have to re-derive the
+// achievable budget from scratch.
 static_assert(sizeof(CompactMessage) <= 220, "CompactMessage residency budget");
 
 // Convert wire -> compact for enqueue. Copies every field CompactMessage
-// declares; secondary_master_mac/secondary_public_key are intentionally not
-// read (there is nowhere to put them).
+// declares, including data[64] verbatim — which carries JOIN_ACK's
+// secondary_master_mac/secondary_public_key at data[4..42] along with it.
 void toCompact(const mesh_message& src, CompactMessage& dst);
 
 // Convert compact -> wire for reconstruction (e.g. drainRecvQueue dispatch,
-// or re-sending a previously-queued frame). Fields CompactMessage does not
-// carry (secondary_master_mac, secondary_public_key) are zeroed in dst.
+// or re-sending a previously-queued frame). data[64] (including any
+// JOIN_ACK secondary_master_mac/secondary_public_key at data[4..42]) is
+// copied through verbatim from src.
 void toWire(const CompactMessage& src, mesh_message& dst);
 
 } // namespace mesh

--- a/firmware/main/src/mesh/CompactMessage.h
+++ b/firmware/main/src/mesh/CompactMessage.h
@@ -6,11 +6,12 @@ namespace lattice {
 namespace mesh {
 
 // Compact in-RAM representation of mesh_message for buffered/queued processing
-// (Phase G §7, RAM residency). The wire form (mesh_message, 250B) remains the
-// source of truth for anything that touches the radio (SerialFraming / ESP-NOW
-// send path) — this type only shrinks what a frame costs while it sits in
-// Mesh::recvQueue or is carried on the stack past the initial decode boundary
-// (Mesh::onDataRecvCallback / Mesh::drainRecvQueue).
+// (Phase G §7, RAM residency). The wire form (mesh_message, 200B as of the
+// protocol v0.6.0 wire shrink, §8 — was 250B when this type was designed)
+// remains the source of truth for anything that touches the radio
+// (SerialFraming / ESP-NOW send path) — this type only shrinks what a frame
+// costs while it sits in Mesh::recvQueue or is carried on the stack past the
+// initial decode boundary (Mesh::onDataRecvCallback / Mesh::drainRecvQueue).
 //
 // Field-drop rationale (audited against every recvQueue-reachable consumer in
 // Mesh.cpp/Enrollment.cpp before finalizing — see task-3-report.md for the
@@ -58,14 +59,21 @@ struct CompactMessage {
   uint8_t route_len;
   uint8_t data[64];
   uint8_t enrollment_public_key[32];
-  uint8_t route_path[60];
+  // Mirrors mesh_message::route_path, which protocol v0.6.0 (wire shrink §8)
+  // shrank 60→48 (MAX_HOPS 10→8). Must track the wire size exactly — toWire()
+  // memcpy's sizeof(this field) into mesh_message::route_path[48].
+  uint8_t route_path[48];
   uint8_t auth_tag[16];
   uint8_t auth_path[8];
-  // Skipped (see rationale above): secondary_master_mac[6], secondary_public_key[32].
+  // Skipped (see rationale above): secondary_master_mac[6], secondary_public_key[32]
+  // (protocol v0.6.0 dropped these top-level wire fields entirely — see
+  // Enrollment::processJoinAck, which now reads the JOIN_ACK secondary from
+  // data[4..42] instead).
 };
-// Achieved: 212B (vs mesh_message's packed 250B) — the 38B saved is exactly
-// secondary_master_mac[6] + secondary_public_key[32], the only fields proven
-// safe to drop (see rationale above). Not currently used for Mesh::recvQueue
+// CompactMessage carries every field mesh_message still has except
+// secondary_master_mac/secondary_public_key, which no longer exist on the
+// wire at all as of protocol v0.6.0 (they moved into JOIN_ACK's data[]
+// payload — see Enrollment::processJoinAck). Not currently used for Mesh::recvQueue
 // (see Mesh.h's RecvQueueEntry comment) — kept at <= 220 so a future consumer
 // noticing this doesn't have to re-derive the achievable budget from scratch.
 static_assert(sizeof(CompactMessage) <= 220, "CompactMessage residency budget");

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -170,8 +170,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
       break;
     }
   if (hasSecondary) {
-    bool secondaryRegistered =
-        registerFn && registerFn(secondaryMasterMac, secondaryPublicKey);
+    bool secondaryRegistered = registerFn && registerFn(secondaryMasterMac, secondaryPublicKey);
     if (secondaryRegistered && !hasMasterMacSecondary) {
       memcpy(knownMasterMacSecondary, secondaryMasterMac, 6);
       hasMasterMacSecondary = true;

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -150,21 +150,30 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
     LATTICE_LOGLN("MESH", "Master MAC learned and saved (TOFU)", LogLevel::LOG_INFO);
   }
 
-  // Dual-master (spec §5): if the server included a secondary master, register it
-  // as a peer (persists mac+pubkey, so masterE2EKeys can derive against it after
-  // failover) and record it as the secondary for beacon adoption. Guarded on a
-  // non-zero secondary MAC.
+  // Dual-master (spec §5, wire shrink §8): if the server included a secondary
+  // master, register it as a peer (persists mac+pubkey, so masterE2EKeys can
+  // derive against it after failover) and record it as the secondary for
+  // beacon adoption. Protocol v0.6.0 packs the secondary into the JOIN_ACK
+  // data[] payload instead of top-level MeshMessage fields:
+  //   data[0..4]   = node pubkey fingerprint (already verified above)
+  //   data[4..10]  = secondaryMasterMac (zero if single-master)
+  //   data[10..42] = secondaryPublicKey (zero if single-master)
+  //   data[42..64] = zero
+  // AEAD authTag still covers data[64] exactly, so these bytes are
+  // AEAD-protected same as before. Guarded on a non-zero secondary MAC.
+  const uint8_t* secondaryMasterMac = msg.data + 4;
+  const uint8_t* secondaryPublicKey = msg.data + 10;
   bool hasSecondary = false;
   for (int i = 0; i < 6; ++i)
-    if (msg.secondary_master_mac[i]) {
+    if (secondaryMasterMac[i]) {
       hasSecondary = true;
       break;
     }
   if (hasSecondary) {
     bool secondaryRegistered =
-        registerFn && registerFn(msg.secondary_master_mac, msg.secondary_public_key);
+        registerFn && registerFn(secondaryMasterMac, secondaryPublicKey);
     if (secondaryRegistered && !hasMasterMacSecondary) {
-      memcpy(knownMasterMacSecondary, msg.secondary_master_mac, 6);
+      memcpy(knownMasterMacSecondary, secondaryMasterMac, 6);
       hasMasterMacSecondary = true;
       EepromManager::getInstance().saveKnownMasterMacSecondary(knownMasterMacSecondary);
     }

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -1120,10 +1120,16 @@ void Mesh::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32, const uint
   memcpy(ack.enrollment_public_key, enrollment.getPublicKey(), 32);
   // Stamp the server-provided secondary-master identity, if any, so the
   // enrolling node can TOFU-learn its failover master from this same ACK
-  // (Phase 4). Left zeroed (ack's default) when there is no secondary.
+  // (Phase 4). Protocol v0.6.0 (wire shrink §8) packs this into the JOIN_ACK
+  // data[] payload rather than top-level MeshMessage fields:
+  //   data[0..4]   = node pubkey fingerprint (set above)
+  //   data[4..10]  = secondaryMasterMac
+  //   data[10..42] = secondaryPublicKey
+  //   data[42..64] = zero
+  // Left zeroed (ack's default) when there is no secondary.
   if (secondaryMac && secondaryPubKey32) {
-    memcpy(ack.secondary_master_mac, secondaryMac, 6);
-    memcpy(ack.secondary_public_key, secondaryPubKey32, 32);
+    memcpy(ack.data + 4, secondaryMac, 6);
+    memcpy(ack.data + 10, secondaryPubKey32, 32);
   }
   // Broadcast via the registered FF:FF:… peer so the new node receives the ACK
   // even before it is individually registered as a unicast peer.

--- a/firmware/main/src/mesh/Mesh.h
+++ b/firmware/main/src/mesh/Mesh.h
@@ -36,7 +36,9 @@ using ::mesh_message;
 using ::MeshMessageType;
 using lattice::adapter::adapter_types;
 
-static constexpr uint8_t PROTO_VERSION = 4;
+// Protocol v0.6.0 flag-day (Phase G §8 wire shrink): 4→5, bumped atomically
+// with hub Task 6 in a parallel PR — must merge together.
+static constexpr uint8_t PROTO_VERSION = 5;
 
 class Mesh {
 #ifdef UNIT_TEST

--- a/firmware/main/src/mesh/RouteTable.h
+++ b/firmware/main/src/mesh/RouteTable.h
@@ -57,7 +57,7 @@ private:
     uint8_t pathLen;
     bool valid;
     uint32_t lastSeenMillis;
-    uint8_t path[config::MAX_HOPS * 6]; // 60 bytes, matches route_path[]
+    uint8_t path[config::MAX_HOPS * 6]; // 48 bytes (MAX_HOPS=8), matches route_path[]
   };
   Entry entries[config::LATTICE_ROUTE_TABLE_MAX]{};
 

--- a/tests/e2e/harness/FakeHub.cpp
+++ b/tests/e2e/harness/FakeHub.cpp
@@ -113,10 +113,12 @@ void FakeHub::approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKe
   memcpy(ack.data, nodePubKey32, 4);
   // Server-designated secondary master (Phase 4 dual-master failover). Left
   // zeroed by the 2-arg overload above, which SerialAdapter::handleCompleteFrame
-  // treats as "no secondary present" (see its all-zero secondary_master_mac
-  // check) and so falls back to the plain 2-arg Mesh::enrollPeer.
-  memcpy(ack.secondary_master_mac, secondaryMac, 6);
-  memcpy(ack.secondary_public_key, secondaryPubKey32, 32);
+  // treats as "no secondary present" (see its all-zero secondaryMasterMac
+  // check). Protocol v0.6.0 (wire shrink §8) packs this into the JOIN_ACK
+  // data[] payload rather than top-level fields: data[4..10] = secondary MAC,
+  // data[10..42] = secondary pubkey.
+  memcpy(ack.data + 4, secondaryMac, 6);
+  memcpy(ack.data + 10, secondaryPubKey32, 32);
   sendFrame(ack);
 }
 

--- a/tests/e2e/harness/FakeHub.h
+++ b/tests/e2e/harness/FakeHub.h
@@ -43,8 +43,9 @@ public:
   void approveEnrollment(const uint8_t* nodeMac, const uint8_t* nodePubKey32);
 
   // Same as above, but also tells the node about a server-designated secondary
-  // master (Phase 4 dual-master failover): sets ack.secondary_master_mac/
-  // secondary_public_key before injecting the JOIN_ACK. SerialAdapter::
+  // master (Phase 4 dual-master failover): sets ack.data[4..42] (protocol
+  // v0.6.0 wire shrink §8 — secondary MAC + pubkey, previously top-level
+  // fields) before injecting the JOIN_ACK. SerialAdapter::
   // handleCompleteFrame forwards these into the 4-arg Mesh::enrollPeer overload,
   // which relays them on to the enrolling node's own JOIN_ACK, where
   // Enrollment::processJoinAck registers the secondary as a peer (so

--- a/tests/unit/test_compact_message.cpp
+++ b/tests/unit/test_compact_message.cpp
@@ -28,14 +28,10 @@ mesh_message makeFullWireMessage() {
   for (int i = 0; i < 32; ++i)
     msg.enrollment_public_key[i] = static_cast<uint8_t>(0x50 + i);
   msg.route_len = 3;
-  for (int i = 0; i < 60; ++i)
-    msg.route_path[i] = static_cast<uint8_t>(0x60 + (i % 60));
+  for (int i = 0; i < 48; ++i)
+    msg.route_path[i] = static_cast<uint8_t>(0x60 + (i % 48));
   for (int i = 0; i < 16; ++i)
     msg.auth_tag[i] = static_cast<uint8_t>(0x70 + i);
-  for (int i = 0; i < 6; ++i)
-    msg.secondary_master_mac[i] = static_cast<uint8_t>(0x80 + i);
-  for (int i = 0; i < 32; ++i)
-    msg.secondary_public_key[i] = static_cast<uint8_t>(0x90 + i);
   for (int i = 0; i < 8; ++i)
     msg.auth_path[i] = static_cast<uint8_t>(0xA0 + i);
   return msg;
@@ -71,27 +67,12 @@ TEST(CompactMessage, RoundTripPreservesStoredFields) {
   EXPECT_EQ(0, memcmp(out.auth_path, src.auth_path, sizeof(src.auth_path)));
 }
 
-// Fields CompactMessage does NOT declare (secondary_master_mac,
-// secondary_public_key — see CompactMessage.h's rationale comment) must come
-// back zeroed after a round trip, even though the source wire message had
-// them populated with non-zero data.
-TEST(CompactMessage, RoundTripZeroesSkippedFields) {
-  mesh_message src = makeFullWireMessage();
-  // Sanity: the fixture really did populate the fields we expect to be dropped.
-  ASSERT_NE(0, src.secondary_master_mac[0]);
-  ASSERT_NE(0, src.secondary_public_key[0]);
-
-  CompactMessage compact{};
-  toCompact(src, compact);
-
-  mesh_message out{};
-  toWire(compact, out);
-
-  uint8_t zero6[6] = {0};
-  uint8_t zero32[32] = {0};
-  EXPECT_EQ(0, memcmp(out.secondary_master_mac, zero6, 6));
-  EXPECT_EQ(0, memcmp(out.secondary_public_key, zero32, 32));
-}
+// NOTE: the old "RoundTripZeroesSkippedFields" test (secondary_master_mac /
+// secondary_public_key dropped by CompactMessage) was removed here — protocol
+// v0.6.0 (wire shrink §8) deleted those top-level mesh_message fields
+// entirely, so there is nothing left for CompactMessage to skip; JOIN_ACK's
+// secondary identity now lives in data[4..42], which round-trips as part of
+// the ordinary `data` field coverage in RoundTripPreservesStoredFields above.
 
 // toWire() fully overwrites its output — no stale data from a previous
 // reconstruction should leak through (matters since drainRecvQueue reuses a
@@ -122,6 +103,14 @@ TEST(CompactMessage, ZeroMessageRoundTripsToZero) {
   EXPECT_EQ(0, memcmp(&out, &allZero, sizeof(mesh_message)));
 }
 
-TEST(CompactMessage, SizeIsSmallerThanWire) {
-  EXPECT_LT(sizeof(CompactMessage), sizeof(mesh_message));
+// Protocol v0.6.0 (wire shrink §8) removed secondary_master_mac/
+// secondary_public_key from mesh_message entirely — those were the only two
+// fields CompactMessage ever dropped (see CompactMessage.h's rationale
+// comment), so there is nothing left for it to shrink relative to the
+// now-200B wire struct. This asserts CompactMessage never grows PAST the
+// wire size (it still carries every field mesh_message has), not that it is
+// smaller — that guarantee no longer holds now that its one differentiator
+// was deleted upstream rather than dropped by CompactMessage itself.
+TEST(CompactMessage, SizeDoesNotExceedWire) {
+  EXPECT_LE(sizeof(CompactMessage), sizeof(mesh_message));
 }

--- a/tests/unit/test_mesh_logic.cpp
+++ b/tests/unit/test_mesh_logic.cpp
@@ -834,8 +834,10 @@ TEST_F(JoinAckRelayTest, ProcessJoinAckRegistersSecondaryMasterAndKeys) {
   memcpy(ack.target_mac_address, leaf.testDeviceMac(), 6);
   memcpy(ack.data, leafPub, 4); // fingerprint of the leaf's pubkey
   memcpy(ack.enrollment_public_key, primPub, 32); // primary pubkey
-  memcpy(ack.secondary_master_mac, secMac, 6);
-  memcpy(ack.secondary_public_key, secPub, 32);
+  // Protocol v0.6.0 (wire shrink §8): secondary master identity packed into
+  // data[4..42] rather than top-level fields.
+  memcpy(ack.data + 4, secMac, 6);
+  memcpy(ack.data + 10, secPub, 32);
 
   leaf.processJoinAck(ack);
 
@@ -1237,8 +1239,10 @@ TEST_F(JoinAckRelayTest, EnrollPeerStampsSecondaryIdentityIntoJoinAck) {
   // JOIN_ACK is broadcast; find it in the mock's sent frames.
   ASSERT_TRUE(sawBroadcastOfType(MESH_TYPE_JOIN_ACK));
   mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK);
-  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, sec, 6));
-  EXPECT_EQ(0, memcmp(ack.secondary_public_key, secPub, 32));
+  // Protocol v0.6.0 (wire shrink §8): secondary master identity packed into
+  // data[4..42] rather than top-level fields.
+  EXPECT_EQ(0, memcmp(ack.data + 4, sec, 6));
+  EXPECT_EQ(0, memcmp(ack.data + 10, secPub, 32));
 }
 
 TEST_F(JoinAckRelayTest, EnrollPeerTwoArgLeavesSecondaryZero) {
@@ -1250,8 +1254,8 @@ TEST_F(JoinAckRelayTest, EnrollPeerTwoArgLeavesSecondaryZero) {
   ASSERT_TRUE(sawBroadcastOfType(MESH_TYPE_JOIN_ACK));
   mesh_message ack = lastEspNowBroadcastOfType(MESH_TYPE_JOIN_ACK);
   uint8_t zero6[6] = {}, zero32[32] = {};
-  EXPECT_EQ(0, memcmp(ack.secondary_master_mac, zero6, 6));
-  EXPECT_EQ(0, memcmp(ack.secondary_public_key, zero32, 32));
+  EXPECT_EQ(0, memcmp(ack.data + 4, zero6, 6));
+  EXPECT_EQ(0, memcmp(ack.data + 10, zero32, 32));
 }
 
 // ─── Config-opcode injection resistance (CRITICAL finding) ──────────────────

--- a/tests/unit/test_route_table.cpp
+++ b/tests/unit/test_route_table.cpp
@@ -45,7 +45,7 @@ TEST(RouteTable, RecordUpdatesExistingNode) {
 TEST(RouteTable, RejectsOverlongPath) {
   RouteTable t;
   uint8_t big[66] = {};
-  t.record(NODE, big, 11, 1000); // 11 > MAX_HOPS(10) → ignored
+  t.record(NODE, big, 11, 1000); // 11 > MAX_HOPS(8) → ignored
   uint8_t out[60], outLen = 0;
   EXPECT_FALSE(t.lookup(NODE, out, &outLen));
 }


### PR DESCRIPTION
## Summary
- Bumps `firmware/main/lib/lattice-protocol` submodule pin to `v0.6.0` (`99cd30c`) — wire 250B → 200B.
- `Enrollment::processJoinAck` reads secondary master MAC + pubkey from JOIN_ACK `data[4..42]` instead of the now-deleted top-level `secondary_master_mac`/`secondary_public_key` fields, per design doc §8:
  - `data[0..4)` node pubkey fingerprint (unchanged)
  - `data[4..10)` secondaryMasterMac
  - `data[10..42)` secondaryPublicKey
  - `data[42..64)` zero
- `MAX_HOPS` 10 → 8 (`firmware/main/project_config.h`); `route_path` shrinks to 48B on the wire.
- `PROTO_VERSION` 4 → 5 (`firmware/main/src/mesh/Mesh.h`) — **flag-day pair with hub Task 6 PR (must merge together)**.
- Migrates every other direct reader/writer of the removed `secondary_master_mac`/`secondary_public_key` fields to the same `data[4..42]` layout, since the fields are a hard struct removal in v0.6.0's header, not a deprecation — the branch does not compile otherwise: `Mesh::enrollPeer`'s JOIN_ACK write side, the `SerialAdapter`/`SerialFraming` serial↔hub bridge, and the `FakeHub` e2e harness.
- `CompactMessage::route_path` 60→48 to stay in sync with `mesh_message::route_path[48]` (was a latent memcpy-overrun risk in `toWire()`; unreachable today since `CompactMessage` isn't wired into any production path — Task 3's explicit deferral, untouched here).

## Test plan
- [x] `cmake --build tests/build --parallel` — clean build
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 --label-exclude e2e` — 222/222 passed
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 -L e2e -R "enroll|aead|route|beacon|dualmaster|DualMaster"` — 5/5 passed
- [x] Full e2e suite (`-L e2e`) run for extra confidence given the breadth of touch points — 41/41 passed
- **263/263 total tests pass.**

Flag-day pair with hub Task 6 PR (must merge together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)