### PR TITLE
feat(phaseG): audit DRY + robustness bundle F/G/H/I/O/P/Q (Task 5)

### DIFF
--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -6,7 +6,7 @@
 #include "src/adapter/serial/SerialAdapter.h"
 #include "src/persistence/EepromManager.h"
 #include "lib/lattice-protocol/c/opcodes.h"
-#include <esp_wifi.h>
+#include "src/network/hw_mac.h"
 #include <cstring>
 
 namespace lattice {
@@ -47,7 +47,7 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
     const uint8_t op = message.data[0];
     if (op == OP_CONFIG_SET) {
       uint8_t ownMac[6];
-      esp_wifi_get_mac(WIFI_IF_STA, ownMac);
+      lattice::hw::readOwnMac(ownMac);
       // Accept broadcast (FF:FF:FF:FF:FF:FF) or unicast to our MAC
       bool allFF = true;
       for (int i = 0; i < 6; ++i) {
@@ -71,7 +71,7 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
     }
     if (op == OP_NODE_ID_SET) {
       uint8_t ownMac[6];
-      esp_wifi_get_mac(WIFI_IF_STA, ownMac);
+      lattice::hw::readOwnMac(ownMac);
       bool allFF = true;
       for (int i = 0; i < 6; ++i) {
         if (message.data[1 + i] != 0xFF) {

--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -7,7 +7,7 @@
 #include "src/persistence/EepromManager.h"
 #include "lib/lattice-protocol/c/opcodes.h"
 #include "src/network/hw_mac.h"
-#include <cstring>
+#include "src/network/MacEq.h"
 
 namespace lattice {
 namespace adapter {
@@ -56,7 +56,7 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
           break;
         }
       }
-      bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
+      bool isTarget = allFF || lattice::mac::eq(&message.data[1], ownMac);
       if (isTarget) {
         adapter_types newType =
             lattice::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
@@ -79,7 +79,7 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
           break;
         }
       }
-      bool isTarget = allFF || (memcmp(&message.data[1], ownMac, 6) == 0);
+      bool isTarget = allFF || lattice::mac::eq(&message.data[1], ownMac);
       if (isTarget) {
         uint8_t nodeId = message.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);

--- a/firmware/main/src/adapter/pir/PirAdapter.cpp
+++ b/firmware/main/src/adapter/pir/PirAdapter.cpp
@@ -7,7 +7,6 @@
 #include "src/mesh/Mesh.h"
 #include "src/adapter/AdapterFactory.h"
 #include "src/network/hw_mac.h"
-#include <esp_wifi.h>
 
 namespace lattice {
 namespace adapter {

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -5,6 +5,7 @@
 #include <esp_wifi.h>
 #include "src/mesh/Mesh.h"
 #include "src/network/hw_mac.h"
+#include "src/network/MacEq.h"
 #include <cstring>
 #include <cstdio>
 #if SIMULATE_MODE
@@ -281,7 +282,7 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     }
   } else if (msg.message_type == MESH_TYPE_SERIAL_CMD_BROADCAST) {
     static const uint8_t kBroadcastMac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    bool isGenuineBroadcast = (memcmp(msg.target_mac_address, kBroadcastMac, 6) == 0);
+    bool isGenuineBroadcast = lattice::mac::eq(msg.target_mac_address, kBroadcastMac);
     if (isGenuineBroadcast) {
       LATTICE_LOGLN("Serial_Adapter", "Broadcasting adapter data to all peers",
                     LogLevel::LOG_DEBUG);
@@ -330,7 +331,7 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           allFF = false;
           break;
         }
-      bool isTarget = allFF || (memcmp(msg.target_mac_address, myMac, 6) == 0);
+      bool isTarget = allFF || lattice::mac::eq(msg.target_mac_address, myMac);
 
       if (isTarget) {
         adapter_types newType = AdapterFactory::adapterTypeFromEEPROM(msg.data[7]);
@@ -390,7 +391,7 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           allFF = false;
           break;
         }
-      bool isTarget = allFF || (memcmp(&msg.data[1], myMac, 6) == 0);
+      bool isTarget = allFF || lattice::mac::eq(&msg.data[1], myMac);
       if (isTarget) {
         uint8_t nodeId = msg.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -6,7 +6,6 @@
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include "src/network/hw_mac.h"
-#include <esp_wifi.h>
 #include <cstring>
 
 namespace lattice {

--- a/firmware/main/src/hardware/input/Button.h
+++ b/firmware/main/src/hardware/input/Button.h
@@ -10,7 +10,7 @@ class Button : public GpioInput {
 public:
   explicit Button(uint8_t pin);
   // Initialize the button GPIO (uses internal PULL-DOWN)
-  bool init() override;
+  bool init();
   // Returns true if the button is currently pressed (active HIGH)
   bool isPressed();
   // Returns true if held for the given ms (blocking call)

--- a/firmware/main/src/hardware/input/GpioInput.h
+++ b/firmware/main/src/hardware/input/GpioInput.h
@@ -11,7 +11,13 @@ public:
   explicit GpioInput(uint8_t pin);
   virtual ~GpioInput() = default;
 
-  virtual bool init();
+  // Not virtual (post-Phase-G audit item I): every call site invokes init()
+  // on a concrete type (Pir::init(), Button::init(), each calling
+  // GpioInput::init() explicitly for shared validation) — never dispatched
+  // through a GpioInput* / GpioInput& base pointer, so the vtable slot buys
+  // nothing. ~GpioInput() is left virtual/untouched — out of scope for this
+  // item, which only targets init().
+  bool init();
   static bool isValidInputPin(uint8_t pin);
   bool isInitialized() const;
 

--- a/firmware/main/src/hardware/input/Pir.h
+++ b/firmware/main/src/hardware/input/Pir.h
@@ -11,7 +11,7 @@ public:
   explicit Pir(uint8_t pin);
   ~Pir() = default;
 
-  bool init() override;
+  bool init();
   bool isMotionDetected() const;
   void clearMotion();
 

--- a/firmware/main/src/hardware/output/GpioOutput.h
+++ b/firmware/main/src/hardware/output/GpioOutput.h
@@ -11,7 +11,9 @@ public:
   explicit GpioOutput(uint8_t pin);
   virtual ~GpioOutput() = default;
 
-  virtual bool init();
+  // Not virtual (post-Phase-G audit item I) — see GpioInput::init()'s comment;
+  // same reasoning: never dispatched through a GpioOutput* base pointer.
+  bool init();
   static bool isValidOutputPin(uint8_t pin);
   bool isInitialized() const;
 

--- a/firmware/main/src/mesh/E2ECrypto.h
+++ b/firmware/main/src/mesh/E2ECrypto.h
@@ -132,14 +132,12 @@ inline bool sealPayload(const uint8_t* key32, mesh_message& msg) {
   uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
   buildNonce(msg, nonce);
   buildAad(msg, aad);
-  mbedtls_chachapoly_context ctx;
-  mbedtls_chachapoly_init(&ctx);
-  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  lattice::mesh::mbedtls_guard::ChaChaPolyCtx ctx; // item P
+  int ret = mbedtls_chachapoly_setkey(ctx, key32);
   if (ret == 0) {
-    ret = mbedtls_chachapoly_encrypt_and_tag(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+    ret = mbedtls_chachapoly_encrypt_and_tag(ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
                                              msg.data, msg.data, msg.auth_tag);
   }
-  mbedtls_chachapoly_free(&ctx);
   return ret == 0;
 }
 
@@ -149,14 +147,12 @@ inline bool openPayload(const uint8_t* key32, mesh_message& msg) {
   uint8_t nonce[E2E_NONCE_LEN], aad[E2E_AAD_LEN];
   buildNonce(msg, nonce);
   buildAad(msg, aad);
-  mbedtls_chachapoly_context ctx;
-  mbedtls_chachapoly_init(&ctx);
-  int ret = mbedtls_chachapoly_setkey(&ctx, key32);
+  lattice::mesh::mbedtls_guard::ChaChaPolyCtx ctx; // item P
+  int ret = mbedtls_chachapoly_setkey(ctx, key32);
   if (ret == 0) {
-    ret = mbedtls_chachapoly_auth_decrypt(&ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
+    ret = mbedtls_chachapoly_auth_decrypt(ctx, sizeof(msg.data), nonce, aad, E2E_AAD_LEN,
                                           msg.auth_tag, msg.data, msg.data);
   }
-  mbedtls_chachapoly_free(&ctx);
   return ret == 0;
 }
 

--- a/firmware/main/src/mesh/E2EKeyStore.h
+++ b/firmware/main/src/mesh/E2EKeyStore.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include "E2ECrypto.h"
 #include "../../project_config.h"
+#include "src/network/MacEq.h"
 
 namespace lattice {
 namespace mesh {
@@ -55,7 +56,7 @@ public:
     if (capacity_ == 0)
       return false;
     for (size_t i = 0; i < capacity_; ++i) {
-      if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0) {
+      if (entries[i].valid && lattice::mac::eq(entries[i].mac, mac)) {
         *kUpOut = entries[i].kUp;
         *kDownOut = entries[i].kDown;
         return true;

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -45,10 +45,11 @@ void Enrollment::init() {
   if (hasMasterMacSecondary) {
     LATTICE_LOGLN("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
+  _enrolled = em.loadEnrolledFlag();
 }
 
 bool Enrollment::isEnrolled() const {
-  return EepromManager::getInstance().loadEnrolledFlag();
+  return _enrolled;
 }
 
 void Enrollment::sendRequest(const uint8_t* deviceMac, uint8_t protoVersion, uint32_t epochNum,
@@ -141,6 +142,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
 
   LATTICE_LOGLN("MESH", "Enrollment approved! Saving enrolled flag.", LogLevel::LOG_INFO);
   EepromManager::getInstance().saveEnrolledFlag(true);
+  _enrolled = true;
 
   // The node sending JOIN_ACK is the master — record its MAC (TOFU)
   if (!hasMasterMac) {

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -6,6 +6,7 @@
 #include "../../lib/lattice-protocol/c/mesh_message.h"
 #include "broadcast_mac.h"
 #include "src/adapter/Adapter.h"
+#include "src/network/MacEq.h"
 #include "config/master_pubkey_pin_wrapper.h"
 #include "project_config.h"
 #include <esp_now.h>
@@ -121,7 +122,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
   // MAC is known (from enrollment or the beacon TOFU fallback), only that origin
   // may deliver a JOIN_ACK; anything else is a forgery and must not enroll us,
   // TOFU-learn, or touch peer key material.
-  if (hasMasterMac && memcmp(msg.origin_mac_address, knownMasterMac, 6) != 0) {
+  if (hasMasterMac && !lattice::mac::eq(msg.origin_mac_address, knownMasterMac)) {
     LATTICE_LOGLN("MESH", "JOIN_ACK from unexpected origin — ignoring", LogLevel::LOG_WARN);
     return;
   }

--- a/firmware/main/src/mesh/Enrollment.h
+++ b/firmware/main/src/mesh/Enrollment.h
@@ -45,6 +45,14 @@ private:
   uint8_t devicePrivateKey[32]{};
   uint8_t devicePublicKey[32]{};
 
+  // Cached mirror of the NVS "enrolled" flag (post-Phase-G audit item G).
+  // isEnrolled() used to call EepromManager::loadEnrolledFlag() -> NVS read
+  // on every call — main.cpp's loop() calls it 2-3x per iteration. Loaded
+  // once from NVS in init(), flipped true the moment processJoinAck()
+  // persists the flag; never cleared once set (matches loadEnrolledFlag()'s
+  // one-way semantics — nothing in this codebase un-enrolls a node).
+  bool _enrolled{false};
+
   // Bounded, heap-free FIFO of enrollment requests awaiting relay to the server.
   // Sized to RECV_QUEUE_SIZE (Phase G §4: 4): the master drains this queue once per
   // loop() AFTER draining its ESP-NOW receive ring, so the enrollment requests from

--- a/firmware/main/src/mesh/Enrollment.h
+++ b/firmware/main/src/mesh/Enrollment.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstdint>
 #include <cstring>
-#include <functional>
 #include "../../lib/lattice-protocol/c/mesh_message.h"
 
 namespace lattice {
@@ -9,7 +8,11 @@ namespace mesh {
 
 using EnrollmentRelayFn = void (*)(const uint8_t* mac, const uint8_t* pubKey);
 // Returns false if the peer could not be registered (e.g. registry full).
-using RegisterPeerFn = std::function<bool(const uint8_t* mac, const uint8_t* pubKey32)>;
+// Plain function pointer (post-Phase-G audit item H): the only production
+// binding (Mesh::processJoinAck) goes through a static trampoline
+// (Mesh::registerPeerWithKeyTrampoline) instead of a `[this]`-capturing
+// lambda, since a capturing lambda cannot convert to a function pointer.
+using RegisterPeerFn = bool (*)(const uint8_t* mac, const uint8_t* pubKey32);
 
 class Enrollment {
 public:

--- a/firmware/main/src/mesh/MbedtlsGuard.h
+++ b/firmware/main/src/mesh/MbedtlsGuard.h
@@ -2,6 +2,9 @@
 #include <mbedtls/ecdh.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecp.h>
+#include <mbedtls/bignum.h>
+#include <mbedtls/chachapoly.h>
 
 // RAII guards for mbedtls contexts used across E2ECrypto.h / MeshCrypto.h.
 //
@@ -44,6 +47,48 @@ struct CtrDrbgCtx {
   CtrDrbgCtx(const CtrDrbgCtx&) = delete;
   CtrDrbgCtx& operator=(const CtrDrbgCtx&) = delete;
   operator mbedtls_ctr_drbg_context*() { return &ctx; }
+};
+
+// Post-Phase-G audit item P: MeshCrypto.h::generateKeypair and
+// E2ECrypto.h::sealPayload/openPayload were left hand-managed when this file
+// was introduced (Phase E) — same UNIT_TEST-unwind leak class: an
+// err::fatal() between init and free throws under UNIT_TEST instead of
+// halting the device, skipping the free. These four close that gap.
+
+struct EcpGroupCtx {
+  mbedtls_ecp_group ctx;
+  EcpGroupCtx() { mbedtls_ecp_group_init(&ctx); }
+  ~EcpGroupCtx() { mbedtls_ecp_group_free(&ctx); }
+  EcpGroupCtx(const EcpGroupCtx&) = delete;
+  EcpGroupCtx& operator=(const EcpGroupCtx&) = delete;
+  operator mbedtls_ecp_group*() { return &ctx; }
+};
+
+struct MpiCtx {
+  mbedtls_mpi ctx;
+  MpiCtx() { mbedtls_mpi_init(&ctx); }
+  ~MpiCtx() { mbedtls_mpi_free(&ctx); }
+  MpiCtx(const MpiCtx&) = delete;
+  MpiCtx& operator=(const MpiCtx&) = delete;
+  operator mbedtls_mpi*() { return &ctx; }
+};
+
+struct EcpPointCtx {
+  mbedtls_ecp_point ctx;
+  EcpPointCtx() { mbedtls_ecp_point_init(&ctx); }
+  ~EcpPointCtx() { mbedtls_ecp_point_free(&ctx); }
+  EcpPointCtx(const EcpPointCtx&) = delete;
+  EcpPointCtx& operator=(const EcpPointCtx&) = delete;
+  operator mbedtls_ecp_point*() { return &ctx; }
+};
+
+struct ChaChaPolyCtx {
+  mbedtls_chachapoly_context ctx;
+  ChaChaPolyCtx() { mbedtls_chachapoly_init(&ctx); }
+  ~ChaChaPolyCtx() { mbedtls_chachapoly_free(&ctx); }
+  ChaChaPolyCtx(const ChaChaPolyCtx&) = delete;
+  ChaChaPolyCtx& operator=(const ChaChaPolyCtx&) = delete;
+  operator mbedtls_chachapoly_context*() { return &ctx; }
 };
 
 // Note: no MdCtx here. mbedtls_md_* usage in E2ECrypto.h (mbedtls_md_info_from_type)

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -1,5 +1,6 @@
 #include "Mesh.h"
 #include "src/network/MacAddress.h"
+#include "src/network/hw_mac.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h" // unified error
 #include "src/persistence/EepromManager.h"
@@ -67,6 +68,9 @@ void Mesh::readMacAddress() {
         lattice::core::ErrorTypeDigit::HARDWARE, lattice::core::ModuleDigit::MESH, 1,
         (String("MESH: Failed to read MAC address: ") + esp_err_to_name(ret)).c_str());
   } else {
+    // Prime the boot-time cache (item F) so every adapter's readOwnMac() call
+    // is a memcpy instead of a repeat esp_wifi_get_mac() syscall.
+    lattice::hw::cacheDeviceMac(deviceMacAddress);
     LATTICE_LOG("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
     LATTICE_LOGLN("MESH", lattice::utils::MacAddress(deviceMacAddress).toString(),
                   LogLevel::LOG_DEBUG);

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -1032,10 +1032,11 @@ void Mesh::processJoinAck(const mesh_message& msg) {
     LATTICE_LOGLN("MESH", "JOIN_ACK addressed to master — ignoring", LogLevel::LOG_WARN);
     return;
   }
-  enrollment.processJoinAck(msg, deviceMacAddress,
-                            [this](const uint8_t* mac, const uint8_t* pubKey32) {
-                              return registerPeerWithKey(mac, pubKey32, /*allowRekey=*/false);
-                            });
+  enrollment.processJoinAck(msg, deviceMacAddress, &Mesh::registerPeerWithKeyTrampoline);
+}
+
+bool Mesh::registerPeerWithKeyTrampoline(const uint8_t* mac, const uint8_t* publicKey32) {
+  return instance->registerPeerWithKey(mac, publicKey32, /*allowRekey=*/false);
 }
 
 void Mesh::addPeer(const uint8_t* mac) {

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -1,5 +1,6 @@
 #include "Mesh.h"
 #include "src/network/MacAddress.h"
+#include "src/network/MacEq.h"
 #include "src/network/hw_mac.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h" // unified error
@@ -85,7 +86,7 @@ PeerInfo* Mesh::findNextHopToMaster() {
   // the common single-hop case) — keeps the existing behavior and E2E peering.
   PeerInfo* direct = peers.find(currentMaster.mac);
   if (direct && currentMaster.distance == 1 && peers.isPeerInRange(direct->mac) &&
-      lattice::utils::MacAddress(direct->mac) != lattice::utils::MacAddress(deviceMacAddress))
+      !lattice::mac::eq(direct->mac, deviceMacAddress))
     return direct;
 
   // Multi-hop (spec §3): pick the freshest neighbor strictly closer to the
@@ -93,7 +94,7 @@ PeerInfo* Mesh::findNextHopToMaster() {
   uint8_t hopMac[6];
   if (!neighbors.selectNextHop(currentMaster.distance, millis(), hopMac))
     return nullptr;
-  if (lattice::utils::MacAddress(hopMac) == lattice::utils::MacAddress(deviceMacAddress))
+  if (lattice::mac::eq(hopMac, deviceMacAddress))
     return nullptr;
 
   // Bound the auto-registered forwarding peer to exactly one (spec §2:
@@ -106,10 +107,10 @@ PeerInfo* Mesh::findNextHopToMaster() {
   // are managed exclusively by the enrollment path.
   static const uint8_t kZeroMac[6] = {0, 0, 0, 0, 0, 0};
   bool isNewRelay =
-      lattice::utils::MacAddress(forwardingPeer) != lattice::utils::MacAddress(hopMac);
-  bool forwardingPeerSet = memcmp(forwardingPeer, kZeroMac, 6) != 0;
+      !lattice::mac::eq(forwardingPeer, hopMac);
+  bool forwardingPeerSet = !lattice::mac::eq(forwardingPeer, kZeroMac);
   if (forwardingPeerSet && isNewRelay && !peers.find(forwardingPeer) &&
-      lattice::utils::MacAddress(forwardingPeer) != lattice::utils::MacAddress(currentMaster.mac)) {
+      !lattice::mac::eq(forwardingPeer, currentMaster.mac)) {
     if (esp_now_is_peer_exist(forwardingPeer))
       esp_now_del_peer(forwardingPeer);
   }
@@ -129,7 +130,7 @@ void Mesh::registerDownlinkPeer(const uint8_t* mac) {
   // never track or evict them via this LRU.
   bool isCurrentMaster =
       currentMaster.distance != 0xFF &&
-      lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(currentMaster.mac);
+      lattice::mac::eq(mac, currentMaster.mac);
   if (peers.find(mac) || isCurrentMaster) {
     // Defense-in-depth (issue #47 item 5): if this MAC was already parked in
     // the downlink forwarding-peer LRU from earlier churn (before it became
@@ -139,7 +140,7 @@ void Mesh::registerDownlinkPeer(const uint8_t* mac) {
     // the LRU-touch loop below), so without this eviction a stale entry
     // would sit in downlinkPeerLru indefinitely instead of freeing its slot.
     for (size_t i = 0; i < downlinkPeerLruCount; ++i) {
-      if (lattice::utils::MacAddress(downlinkPeerLru[i]) == lattice::utils::MacAddress(mac)) {
+      if (lattice::mac::eq(downlinkPeerLru[i], mac)) {
         for (size_t j = i; j + 1 < downlinkPeerLruCount; ++j)
           memcpy(downlinkPeerLru[j], downlinkPeerLru[j + 1], 6);
         downlinkPeerLruCount--;
@@ -152,7 +153,7 @@ void Mesh::registerDownlinkPeer(const uint8_t* mac) {
 
   // Already tracked: touch (move to front) and ensure still registered.
   for (size_t i = 0; i < downlinkPeerLruCount; ++i) {
-    if (lattice::utils::MacAddress(downlinkPeerLru[i]) == lattice::utils::MacAddress(mac)) {
+    if (lattice::mac::eq(downlinkPeerLru[i], mac)) {
       uint8_t touched[6];
       memcpy(touched, downlinkPeerLru[i], 6);
       for (size_t j = i; j > 0; --j)
@@ -409,7 +410,7 @@ void IRAM_ATTR Mesh::dataRecvTrampoline(const esp_now_recv_info* mac_addr, const
 }
 
 void Mesh::sendMessage(const uint8_t* target, const mesh_message& msg) {
-  if (lattice::utils::MacAddress(target) == lattice::utils::MacAddress(deviceMacAddress)) {
+  if (lattice::mac::eq(target, deviceMacAddress)) {
     LATTICE_LOGLN("MESH", "Not sending to self. Skipped.", LogLevel::LOG_DEBUG);
     return;
   }
@@ -428,7 +429,7 @@ void Mesh::broadcastToAllPeers(const mesh_message& msg) {
     return;
   }
   for (size_t i = 0; i < peers.peerCount; ++i) {
-    if (memcmp(peers.peerMacs[i].mac, deviceMacAddress, 6) == 0)
+    if (lattice::mac::eq(peers.peerMacs[i].mac, deviceMacAddress))
       continue; // Skip self
     sendMessage(peers.peerMacs[i].mac, msg);
   }
@@ -463,7 +464,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
     msg = buildMessage(type, data, msgType);
   }
 
-  bool selfOriginated = (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0);
+  bool selfOriginated = (lattice::mac::eq(msg.origin_mac_address, deviceMacAddress));
 
   // Only a self-originated uplink sets its own target to the master. A relayed
   // frame (msgOverride, foreign origin) is already sealed against the origin's
@@ -505,7 +506,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
   // Routing: always use next hop if possible
   PeerInfo* nextHop = findNextHopToMaster();
   if (nextHop &&
-      lattice::utils::MacAddress(nextHop->mac) != lattice::utils::MacAddress(deviceMacAddress)) {
+      !lattice::mac::eq(nextHop->mac, deviceMacAddress)) {
     sendMessage(nextHop->mac, msg);
   } else {
     // No route to master is a routine, self-healing transient: a node that has
@@ -717,7 +718,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   // Guard: ignore echoes of our own beacon relayed back by neighbours (relays are
   // broadcast, so the originating master hears them too). Without this the master
   // would TOFU-learn itself as knownMasterMac and record a bogus route to itself.
-  if (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0)
+  if (lattice::mac::eq(msg.origin_mac_address, deviceMacAddress))
     return;
 
   // Master MAC pin (Phase D, #42): the beacon's origin_mac_address must match
@@ -743,9 +744,9 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 
   // --- TOFU master MAC enforcement ---
   bool fromPrimary =
-      enrollment.hasMasterMac && memcmp(msg.origin_mac_address, enrollment.knownMasterMac, 6) == 0;
+      enrollment.hasMasterMac && lattice::mac::eq(msg.origin_mac_address, enrollment.knownMasterMac);
   bool fromSecondary = _dualMasterMode && enrollment.hasMasterMacSecondary &&
-                       memcmp(msg.origin_mac_address, enrollment.knownMasterMacSecondary, 6) == 0;
+                       lattice::mac::eq(msg.origin_mac_address, enrollment.knownMasterMacSecondary);
 
   if (!enrollment.hasMasterMac) {
     // First beacon ever — TOFU (fallback if JOIN_ACK path not taken, e.g. master node itself)
@@ -776,8 +777,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     }
   }
 
-  if (lattice::utils::MacAddress(lastSeenMasterMac) !=
-          lattice::utils::MacAddress(msg.origin_mac_address) &&
+  if (!lattice::mac::eq(lastSeenMasterMac, msg.origin_mac_address) &&
       lastSeenMasterMac[0] != 0) {
     if (_dualMasterMode) {
       LATTICE_LOGLN("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
@@ -843,10 +843,10 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
 
 void Mesh::processAdapterData(const mesh_message& msg) {
   // OP_CONFIG_SET = 0xC1 (from lib/lattice-protocol/opcodes.h)
-  bool addressedToSelf = (memcmp(msg.target_mac_address, deviceMacAddress, 6) == 0);
-  bool isBroadcastTarget = (memcmp(msg.target_mac_address, BROADCAST_MAC, 6) == 0);
+  bool addressedToSelf = (lattice::mac::eq(msg.target_mac_address, deviceMacAddress));
+  bool isBroadcastTarget = (lattice::mac::eq(msg.target_mac_address, BROADCAST_MAC));
   bool addressedToMaster =
-      enrollment.hasMasterMac && (memcmp(msg.target_mac_address, currentMaster.mac, 6) == 0);
+      enrollment.hasMasterMac && (lattice::mac::eq(msg.target_mac_address, currentMaster.mac));
 
   if (!isMaster && !addressedToSelf && !isBroadcastTarget) {
     if (addressedToMaster) {
@@ -865,7 +865,7 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     // fall back to the flood.
     if (msg.route_len > 0 && msg.route_len <= lattice::config::MAX_HOPS) {
       for (uint8_t i = 0; i < msg.route_len; ++i) {
-        if (memcmp(&msg.route_path[static_cast<size_t>(i) * 6], deviceMacAddress, 6) == 0) {
+        if (lattice::mac::eq(&msg.route_path[static_cast<size_t>(i) * 6], deviceMacAddress)) {
           if (msg.hop_count >= lattice::config::MAX_HOPS)
             return;
           mesh_message fwd = msg;
@@ -950,10 +950,10 @@ void Mesh::processAdapterData(const mesh_message& msg) {
     return;
   }
   if (isConfigOpcode && enrollment.hasMasterMac) {
-    bool fromPrimary = memcmp(opened.origin_mac_address, enrollment.knownMasterMac, 6) == 0;
+    bool fromPrimary = lattice::mac::eq(opened.origin_mac_address, enrollment.knownMasterMac);
     bool fromSecondary =
         enrollment.hasMasterMacSecondary &&
-        memcmp(opened.origin_mac_address, enrollment.knownMasterMacSecondary, 6) == 0;
+        lattice::mac::eq(opened.origin_mac_address, enrollment.knownMasterMacSecondary);
     if (!fromPrimary && !fromSecondary) {
       LATTICE_LOGLN("MESH", "CONFIG_SET from non-master MAC rejected", LogLevel::LOG_WARN);
       return;
@@ -978,7 +978,7 @@ void Mesh::relayDownlink(const mesh_message& msg) {
   relay.hop_count++;
   memcpy(relay.last_hop_mac_address, deviceMacAddress, 6);
   for (size_t i = 0; i < peers.peerCount; ++i) {
-    if (memcmp(peers.peerMacs[i].mac, deviceMacAddress, 6) == 0)
+    if (lattice::mac::eq(peers.peerMacs[i].mac, deviceMacAddress))
       continue;
     sendMessage(peers.peerMacs[i].mac, relay);
   }
@@ -986,7 +986,7 @@ void Mesh::relayDownlink(const mesh_message& msg) {
 
 void Mesh::relayEnrollmentUplink(const mesh_message& msg) {
   // Never relay our own outbound request echoed back to us over the air.
-  if (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0)
+  if (lattice::mac::eq(msg.origin_mac_address, deviceMacAddress))
     return;
   // Bound relay depth (mirrors the ADAPTER_DATA uplink guard).
   if (msg.hop_count >= lattice::config::MAX_HOPS)
@@ -1014,8 +1014,8 @@ void Mesh::processJoinAck(const mesh_message& msg) {
   // safety: never re-broadcast a JOIN_ACK we originated (only masters originate
   // them, so this stops the master looping on its own echo), and bound depth by
   // MAX_HOPS as a backstop for cyclic topologies.
-  if (memcmp(msg.target_mac_address, deviceMacAddress, 6) != 0) {
-    if (memcmp(msg.origin_mac_address, deviceMacAddress, 6) == 0)
+  if (!lattice::mac::eq(msg.target_mac_address, deviceMacAddress)) {
+    if (lattice::mac::eq(msg.origin_mac_address, deviceMacAddress))
       return;
     if (msg.hop_count >= lattice::config::MAX_HOPS)
       return;

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -106,8 +106,7 @@ PeerInfo* Mesh::findNextHopToMaster() {
   // evict an enrolled peer (master or sensor) — those live in `peers` and
   // are managed exclusively by the enrollment path.
   static const uint8_t kZeroMac[6] = {0, 0, 0, 0, 0, 0};
-  bool isNewRelay =
-      !lattice::mac::eq(forwardingPeer, hopMac);
+  bool isNewRelay = !lattice::mac::eq(forwardingPeer, hopMac);
   bool forwardingPeerSet = !lattice::mac::eq(forwardingPeer, kZeroMac);
   if (forwardingPeerSet && isNewRelay && !peers.find(forwardingPeer) &&
       !lattice::mac::eq(forwardingPeer, currentMaster.mac)) {
@@ -128,9 +127,7 @@ void Mesh::registerDownlinkPeer(const uint8_t* mac) {
   // Enrolled peers and the current master are managed exclusively by their
   // own paths (PeerRegistry / enrollment) — just register (idempotent) and
   // never track or evict them via this LRU.
-  bool isCurrentMaster =
-      currentMaster.distance != 0xFF &&
-      lattice::mac::eq(mac, currentMaster.mac);
+  bool isCurrentMaster = currentMaster.distance != 0xFF && lattice::mac::eq(mac, currentMaster.mac);
   if (peers.find(mac) || isCurrentMaster) {
     // Defense-in-depth (issue #47 item 5): if this MAC was already parked in
     // the downlink forwarding-peer LRU from earlier churn (before it became
@@ -505,8 +502,7 @@ void Mesh::transmitCore(const adapter_types type, const uint8_t* data, MeshMessa
 
   // Routing: always use next hop if possible
   PeerInfo* nextHop = findNextHopToMaster();
-  if (nextHop &&
-      !lattice::mac::eq(nextHop->mac, deviceMacAddress)) {
+  if (nextHop && !lattice::mac::eq(nextHop->mac, deviceMacAddress)) {
     sendMessage(nextHop->mac, msg);
   } else {
     // No route to master is a routine, self-healing transient: a node that has
@@ -743,8 +739,8 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   }
 
   // --- TOFU master MAC enforcement ---
-  bool fromPrimary =
-      enrollment.hasMasterMac && lattice::mac::eq(msg.origin_mac_address, enrollment.knownMasterMac);
+  bool fromPrimary = enrollment.hasMasterMac &&
+                     lattice::mac::eq(msg.origin_mac_address, enrollment.knownMasterMac);
   bool fromSecondary = _dualMasterMode && enrollment.hasMasterMacSecondary &&
                        lattice::mac::eq(msg.origin_mac_address, enrollment.knownMasterMacSecondary);
 
@@ -777,8 +773,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     }
   }
 
-  if (!lattice::mac::eq(lastSeenMasterMac, msg.origin_mac_address) &&
-      lastSeenMasterMac[0] != 0) {
+  if (!lattice::mac::eq(lastSeenMasterMac, msg.origin_mac_address) && lastSeenMasterMac[0] != 0) {
     if (_dualMasterMode) {
       LATTICE_LOGLN("MESH", "Two masters active (dual master mode)", LogLevel::LOG_DEBUG);
     } else {

--- a/firmware/main/src/mesh/Mesh.h
+++ b/firmware/main/src/mesh/Mesh.h
@@ -120,6 +120,12 @@ private:
   // peer could not be added.
   bool registerPeerWithKey(const uint8_t* mac, const uint8_t* publicKey32, bool allowRekey);
 
+  // Static trampoline binding registerPeerWithKey(allowRekey=false) to
+  // Enrollment::RegisterPeerFn's plain-function-pointer signature (item H) —
+  // routes through the singleton `instance` the same way dataRecvTrampoline
+  // does for esp_now_register_recv_cb. Used only by processJoinAck().
+  static bool registerPeerWithKeyTrampoline(const uint8_t* mac, const uint8_t* publicKey32);
+
   // Replay protection (composed)
   ReplayCache replay;
 

--- a/firmware/main/src/mesh/MeshCrypto.h
+++ b/firmware/main/src/mesh/MeshCrypto.h
@@ -33,15 +33,14 @@ inline void registerPeerWithEspNow(const uint8_t mac[6]) {
 inline void generateKeypair(uint8_t* priv32Out, uint8_t* pub32Out) {
   // Use the low-level ECP API directly to avoid the opaque ecdh context internals
   // that are private in the mbedTLS 3.x non-legacy context.
-  mbedtls_ecp_group grp;
-  mbedtls_mpi d;
-  mbedtls_ecp_point Q;
+  // RAII guards (item P): every err::fatal() below throws under UNIT_TEST
+  // instead of halting the device, unwinding past whatever manual _free()
+  // calls would otherwise sit at the end of this function.
+  lattice::mesh::mbedtls_guard::EcpGroupCtx grp;
+  lattice::mesh::mbedtls_guard::MpiCtx d;
+  lattice::mesh::mbedtls_guard::EcpPointCtx Q;
   lattice::mesh::mbedtls_guard::EntropyCtx entropy;
   lattice::mesh::mbedtls_guard::CtrDrbgCtx ctr_drbg;
-
-  mbedtls_ecp_group_init(&grp);
-  mbedtls_mpi_init(&d);
-  mbedtls_ecp_point_init(&Q);
 
   const char* pers = "lattice_keygen";
   int ret;
@@ -52,26 +51,22 @@ inline void generateKeypair(uint8_t* priv32Out, uint8_t* pub32Out) {
                         "MESH: keypair gen — entropy seed failed");
   }
 
-  ret = mbedtls_ecp_group_load(&grp, MBEDTLS_ECP_DP_CURVE25519);
+  ret = mbedtls_ecp_group_load(grp, MBEDTLS_ECP_DP_CURVE25519);
   if (ret != 0) {
     lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 2,
                         "MESH: keypair gen — ecp_group_load failed");
   }
 
-  ret = mbedtls_ecdh_gen_public(&grp, &d, &Q, mbedtls_ctr_drbg_random, ctr_drbg);
+  ret = mbedtls_ecdh_gen_public(grp, d, Q, mbedtls_ctr_drbg_random, ctr_drbg);
   if (ret != 0) {
     lattice::err::fatal(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::MESH, 3,
                         "MESH: keypair gen — ecdh_gen_public failed");
   }
 
   // Export private scalar (d) — 32 bytes big-endian (NEVER printed to serial)
-  mbedtls_mpi_write_binary(&d, priv32Out, 32);
+  mbedtls_mpi_write_binary(d, priv32Out, 32);
   // Export public key X coordinate — 32 bytes (Curve25519 public key is X only)
-  mbedtls_mpi_write_binary(&Q.MBEDTLS_PRIVATE(X), pub32Out, 32);
-
-  mbedtls_ecp_group_free(&grp);
-  mbedtls_mpi_free(&d);
-  mbedtls_ecp_point_free(&Q);
+  mbedtls_mpi_write_binary(&Q.ctx.MBEDTLS_PRIVATE(X), pub32Out, 32);
 }
 
 } // namespace crypto

--- a/firmware/main/src/mesh/NeighborTable.h
+++ b/firmware/main/src/mesh/NeighborTable.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstring>
 #include "../../project_config.h"
+#include "src/network/MacEq.h"
 
 namespace lattice {
 namespace mesh {
@@ -82,7 +83,7 @@ public:
 
   bool contains(const uint8_t* mac) const {
     for (size_t i = 0; i < config::LATTICE_NEIGHBOR_MAX; ++i)
-      if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0)
+      if (entries[i].valid && lattice::mac::eq(entries[i].mac, mac))
         return true;
     return false;
   }
@@ -100,7 +101,7 @@ private:
 
   Entry* findSlot(const uint8_t* mac) {
     for (size_t i = 0; i < config::LATTICE_NEIGHBOR_MAX; ++i)
-      if (entries[i].valid && memcmp(entries[i].mac, mac, 6) == 0)
+      if (entries[i].valid && lattice::mac::eq(entries[i].mac, mac))
         return &entries[i];
     return nullptr;
   }

--- a/firmware/main/src/mesh/PeerRegistry.cpp
+++ b/firmware/main/src/mesh/PeerRegistry.cpp
@@ -1,6 +1,7 @@
 #include "PeerRegistry.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
+#include "src/network/MacEq.h"
 #include <esp_now.h>
 #include <cstring>
 
@@ -20,7 +21,7 @@ void PeerRegistry::setDeviceMac(const uint8_t* mac) {
 
 PeerInfo* PeerRegistry::find(const uint8_t* mac) {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (memcmp(peerMacs[i].mac, mac, 6) == 0) {
+    if (lattice::mac::eq(peerMacs[i].mac, mac)) {
       return &peerMacs[i];
     }
   }
@@ -29,7 +30,7 @@ PeerInfo* PeerRegistry::find(const uint8_t* mac) {
 
 const PeerInfo* PeerRegistry::find(const uint8_t* mac) const {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (memcmp(peerMacs[i].mac, mac, 6) == 0) {
+    if (lattice::mac::eq(peerMacs[i].mac, mac)) {
       return &peerMacs[i];
     }
   }
@@ -45,7 +46,7 @@ bool PeerRegistry::append(const PeerInfo& peer) {
 
 void PeerRegistry::remove(const uint8_t* mac) {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (lattice::utils::MacAddress(peerMacs[i].mac) == lattice::utils::MacAddress(mac)) {
+    if (lattice::mac::eq(peerMacs[i].mac, mac)) {
       peerMacs[i] = peerMacs[--peerCount];
       break;
     }
@@ -62,7 +63,7 @@ bool PeerRegistry::isPeerInRange(const uint8_t* mac) const {
 void PeerRegistry::updateLastSeen(const uint8_t* mac) {
   if (!mac)
     return;
-  if (lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(deviceMac))
+  if (lattice::mac::eq(mac, deviceMac))
     return;
   // Enrollment is the only path for new peers — do not auto-add unknown senders here.
   PeerInfo* p = find(mac);
@@ -128,7 +129,7 @@ void PeerRegistry::saveToEEPROM() {
 }
 
 void PeerRegistry::addAndPersist(const uint8_t* mac) {
-  if (find(mac) || lattice::utils::MacAddress(mac) == lattice::utils::MacAddress(deviceMac))
+  if (find(mac) || lattice::mac::eq(mac, deviceMac))
     return;
 
   if (peerCount >= MAX_PEERS) {
@@ -150,7 +151,7 @@ void PeerRegistry::addAndPersist(const uint8_t* mac) {
 
 void PeerRegistry::removeAndPersist(const uint8_t* mac) {
   for (size_t i = 0; i < peerCount; ++i) {
-    if (lattice::utils::MacAddress(peerMacs[i].mac) == lattice::utils::MacAddress(mac)) {
+    if (lattice::mac::eq(peerMacs[i].mac, mac)) {
       peerMacs[i] = peerMacs[--peerCount]; // swap with last, shrink count
       break;
     }

--- a/firmware/main/src/mesh/ReplayCache.h
+++ b/firmware/main/src/mesh/ReplayCache.h
@@ -3,6 +3,7 @@
 #include <cstring>
 #include "../../lib/lattice-protocol/c/mesh_message.h"
 #include "../../project_config.h"
+#include "src/network/MacEq.h"
 
 namespace lattice {
 namespace mesh {
@@ -46,7 +47,7 @@ struct ReplayCache {
   inline bool isReplay(const mesh_message& msg, uint32_t nowMs) {
     // 1. Find slot for this origin.
     for (size_t i = 0; i < config::LATTICE_REPLAY_MAX_ORIGINS; ++i) {
-      if (cache[i].used && memcmp(cache[i].mac, msg.origin_mac_address, 6) == 0) {
+      if (cache[i].used && lattice::mac::eq(cache[i].mac, msg.origin_mac_address)) {
         bool newer = (msg.epoch_num > cache[i].epoch) ||
                      (msg.epoch_num == cache[i].epoch && msg.seq_num > cache[i].seq);
         if (!newer)

--- a/firmware/main/src/mesh/RouteTable.h
+++ b/firmware/main/src/mesh/RouteTable.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstring>
 #include "../../project_config.h"
+#include "src/network/MacEq.h"
 
 namespace lattice {
 namespace mesh {
@@ -39,7 +40,7 @@ public:
   bool lookup(const uint8_t* nodeMac, uint8_t* pathOut, uint8_t* pathLenOut) const {
     for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i) {
       const Entry& e = entries[i];
-      if (e.valid && memcmp(e.nodeMac, nodeMac, 6) == 0) {
+      if (e.valid && lattice::mac::eq(e.nodeMac, nodeMac)) {
         *pathLenOut = e.pathLen;
         if (e.pathLen)
           memcpy(pathOut, e.path, static_cast<size_t>(e.pathLen) * 6);
@@ -63,7 +64,7 @@ private:
 
   Entry* findSlot(const uint8_t* nodeMac) {
     for (size_t i = 0; i < config::LATTICE_ROUTE_TABLE_MAX; ++i)
-      if (entries[i].valid && memcmp(entries[i].nodeMac, nodeMac, 6) == 0)
+      if (entries[i].valid && lattice::mac::eq(entries[i].nodeMac, nodeMac))
         return &entries[i];
     return nullptr;
   }

--- a/firmware/main/src/network/MacAddress.h
+++ b/firmware/main/src/network/MacAddress.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <cstring>
+#include "MacEq.h"
 
 namespace lattice {
 namespace utils {
@@ -14,7 +15,7 @@ struct MacAddress {
   explicit MacAddress(const uint8_t* mac) { memcpy(bytes, mac, 6); }
 
   // Comparison operators
-  bool operator==(const MacAddress& other) const { return memcmp(bytes, other.bytes, 6) == 0; }
+  bool operator==(const MacAddress& other) const { return lattice::mac::eq(bytes, other.bytes); }
   bool operator!=(const MacAddress& other) const { return !(*this == other); }
 
   // Utility

--- a/firmware/main/src/network/MacEq.h
+++ b/firmware/main/src/network/MacEq.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+
+// Canonical 6-byte MAC-address equality check (post-Phase-G audit item Q).
+//
+// Consolidates two competing idioms scattered across the mesh/adapter code:
+//   memcmp(a, b, 6) == 0                                              (~30 sites)
+//   lattice::utils::MacAddress(a) == lattice::utils::MacAddress(b)    (~13 sites,
+//     strictly worse than the memcmp form — constructs two temporary
+//     MacAddress objects, i.e. two extra 6-byte memcpys, just to compare)
+// One definition, one place to change if the comparison ever needs to.
+// lattice::utils::MacAddress::operator== (network/MacAddress.h) is
+// implemented in terms of this helper so there's exactly one memcmp in the
+// whole codebase.
+
+namespace lattice {
+namespace mac {
+
+inline bool eq(const uint8_t* a, const uint8_t* b) {
+  return memcmp(a, b, 6) == 0;
+}
+
+} // namespace mac
+} // namespace lattice

--- a/firmware/main/src/network/hw_mac.h
+++ b/firmware/main/src/network/hw_mac.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <cstring>
 #include <esp_wifi.h>
 
 // Canonical "read this node's own station MAC" helper, header-only.
@@ -7,13 +8,64 @@
 // Consolidates 3 identical `static void readOwnMac(uint8_t[6])` copies that used to live in
 // PirAdapter.cpp, SerialAdapter.cpp and SerialFraming.cpp (post-Phase-G audit item N). One
 // definition, one place to change if the interface (WIFI_IF_STA) ever does.
+//
+// Post-Phase-G audit item F: the station MAC never changes at runtime, but
+// esp_wifi_get_mac() is a syscall — Adapter.cpp and the callers below used to
+// re-issue it on every RX frame (up to once per received mesh message). Cache
+// it once, at boot, in g_deviceMac; every subsequent readOwnMac() call is a
+// 6-byte memcpy instead of a syscall. Mesh::readMacAddress() (the existing
+// single source of truth for the device MAC, Mesh.cpp) calls cacheDeviceMac()
+// right after its own esp_wifi_get_mac() succeeds, so the cache is primed
+// before any adapter's first RX. If something calls readOwnMac() before that
+// (shouldn't happen given boot order, but cheap to guard), it falls back to a
+// direct syscall and opportunistically caches the result.
+//
+// UNIT_TEST carve-out: the host test harness runs several *independent*
+// simulated nodes in one process by swapping a single global mock MAC
+// (esp_wifi_mock.h's mockDeviceMac) in and out per node (see
+// tests/e2e/harness/NodeContext.cpp swapIn/swapOut), and test_pir_adapter.cpp
+// changes mockDeviceMac mid-test to assert readOwnMac() reflects the CURRENT
+// value. A process-lifetime cache here would freeze every simulated node at
+// whichever MAC happened to be active on the first readOwnMac() call,
+// silently breaking that isolation. So under UNIT_TEST, always re-query —
+// the perf win is a firmware (real hardware) concern only; host tests don't
+// pay a syscall cost either way.
 
 namespace lattice {
 namespace hw {
 
+#ifndef UNIT_TEST
+
+namespace detail {
+inline uint8_t g_deviceMac[6] = {0, 0, 0, 0, 0, 0};
+inline bool g_deviceMacCached = false;
+} // namespace detail
+
+// Prime the boot-time cache. Called once from Mesh::readMacAddress().
+inline void cacheDeviceMac(const uint8_t mac[6]) {
+  memcpy(detail::g_deviceMac, mac, 6);
+  detail::g_deviceMacCached = true;
+}
+
+inline void readOwnMac(uint8_t out[6]) {
+  if (detail::g_deviceMacCached) {
+    memcpy(out, detail::g_deviceMac, 6);
+    return;
+  }
+  esp_wifi_get_mac(WIFI_IF_STA, out);
+  cacheDeviceMac(out);
+}
+
+#else // UNIT_TEST
+
+// No caching on host builds — see carve-out note above.
+inline void cacheDeviceMac(const uint8_t[6]) {}
+
 inline void readOwnMac(uint8_t out[6]) {
   esp_wifi_get_mac(WIFI_IF_STA, out);
 }
+
+#endif // UNIT_TEST
 
 } // namespace hw
 } // namespace lattice

--- a/firmware/main/src/persistence/EepromManager.cpp
+++ b/firmware/main/src/persistence/EepromManager.cpp
@@ -30,11 +30,13 @@ bool EepromManager::init() {
 
   uint8_t reason = _prefs.getUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
   if (reason == 0x00) {
-    _prefs.putUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
+    size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
+    _persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
   }
   uint8_t count = _prefs.getUChar(NVS_KEYS::REBOOT_COUNT, 0);
   if (count > 10) {
-    _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, 0);
+    size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, 0);
+    _persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
   }
 
   logOperation("Initialized", "NVS ready");
@@ -75,7 +77,8 @@ bool EepromManager::loadMasterFlag() {
 void EepromManager::saveMasterFlag(bool isMaster) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putBool(NVS_KEYS::MASTER_FLAG, isMaster);
+  size_t n = _prefs.putBool(NVS_KEYS::MASTER_FLAG, isMaster);
+  _persistOrEscalate(NVS_KEYS::MASTER_FLAG, n, 1, /*securityRelevant=*/false);
   logOperation("Master flag saved", isMaster ? "Master" : "Node");
 }
 
@@ -88,7 +91,8 @@ bool EepromManager::loadDevFlag() {
 void EepromManager::saveDevFlag(bool isDev) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putBool(NVS_KEYS::DEV_FLAG, isDev);
+  size_t n = _prefs.putBool(NVS_KEYS::DEV_FLAG, isDev);
+  _persistOrEscalate(NVS_KEYS::DEV_FLAG, n, 1, /*securityRelevant=*/false);
 }
 
 bool EepromManager::loadMeshKey(uint8_t* key, size_t keySize) {
@@ -132,7 +136,11 @@ void EepromManager::savePeerList(const uint8_t* peerRecords, size_t numPeers) {
   if (numPeers == 0) {
     _prefs.remove(NVS_KEYS::PEER_LIST);
   } else {
-    _prefs.putBytes(NVS_KEYS::PEER_LIST, peerRecords, numPeers * EEPROM_SIZES::PEER_RECORD_SIZE);
+    size_t want = numPeers * EEPROM_SIZES::PEER_RECORD_SIZE;
+    size_t n = _prefs.putBytes(NVS_KEYS::PEER_LIST, peerRecords, want);
+    // securityRelevant=true: each record carries a peer's E2E public key —
+    // trust material, same tier as MESH_KEY/KNOWN_MASTER_MAC below.
+    _persistOrEscalate(NVS_KEYS::PEER_LIST, n, want, /*securityRelevant=*/true);
   }
   logOperation("Peer list saved", String(numPeers).c_str());
 }
@@ -159,7 +167,8 @@ uint8_t EepromManager::loadAdapterType() {
 void EepromManager::saveAdapterType(uint8_t adapterType) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putUChar(NVS_KEYS::ADAPTER_TYPE, adapterType);
+  size_t n = _prefs.putUChar(NVS_KEYS::ADAPTER_TYPE, adapterType);
+  _persistOrEscalate(NVS_KEYS::ADAPTER_TYPE, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
 uint8_t EepromManager::loadRebootCount() {
@@ -171,13 +180,15 @@ uint8_t EepromManager::loadRebootCount() {
 void EepromManager::saveRebootCount(uint8_t count) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, count);
+  size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, count);
+  _persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
 void EepromManager::saveRebootReason(uint8_t reason) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putUChar(NVS_KEYS::REBOOT_REASON, reason);
+  size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_REASON, reason);
+  _persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
 uint8_t EepromManager::loadRebootReason() {
@@ -220,13 +231,18 @@ bool EepromManager::loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32) {
 void EepromManager::saveKeypair(const uint8_t* privateKey32, const uint8_t* publicKey32) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
-  _prefs.putBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
+  // securityRelevant=true on all three: this is the device's long-term
+  // identity keypair — the same tier as MESH_KEY/KNOWN_MASTER_MAC below.
+  size_t nPriv = _prefs.putBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
+  _persistOrEscalate(NVS_KEYS::PRIVATE_KEY, nPriv, 32, /*securityRelevant=*/true);
+  size_t nPub = _prefs.putBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
+  _persistOrEscalate(NVS_KEYS::PUBLIC_KEY, nPub, 32, /*securityRelevant=*/true);
   uint8_t both[64];
   memcpy(both, privateKey32, 32);
   memcpy(both + 32, publicKey32, 32);
   uint16_t crc = crc16(both, 64);
-  _prefs.putUInt(NVS_KEYS::KEYPAIR_CRC, static_cast<uint32_t>(crc));
+  size_t nCrc = _prefs.putUInt(NVS_KEYS::KEYPAIR_CRC, static_cast<uint32_t>(crc));
+  _persistOrEscalate(NVS_KEYS::KEYPAIR_CRC, nCrc, sizeof(uint32_t), /*securityRelevant=*/true);
   logOperation("Keypair saved");
 }
 
@@ -239,7 +255,8 @@ bool EepromManager::loadEnrolledFlag() {
 void EepromManager::saveEnrolledFlag(bool enrolled) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putBool(NVS_KEYS::ENROLLED_FLAG, enrolled);
+  size_t n = _prefs.putBool(NVS_KEYS::ENROLLED_FLAG, enrolled);
+  _persistOrEscalate(NVS_KEYS::ENROLLED_FLAG, n, 1, /*securityRelevant=*/false);
 }
 
 uint32_t EepromManager::loadBootEpoch() {
@@ -334,7 +351,8 @@ lattice::config::TxPowerPreset EepromManager::loadTxPowerPreset() {
 void EepromManager::saveTxPowerPreset(lattice::config::TxPowerPreset preset) {
   if (!ensureInitialized() || isDevMode)
     return;
-  _prefs.putUChar(NVS_KEYS::TX_POWER_PRESET, static_cast<uint8_t>(preset));
+  size_t n = _prefs.putUChar(NVS_KEYS::TX_POWER_PRESET, static_cast<uint8_t>(preset));
+  _persistOrEscalate(NVS_KEYS::TX_POWER_PRESET, n, sizeof(uint8_t), /*securityRelevant=*/false);
   logOperation("TX power preset saved");
 }
 
@@ -347,7 +365,8 @@ uint8_t EepromManager::loadNodeId() {
 void EepromManager::saveNodeId(uint8_t nodeId) {
   if (!ensureInitialized())
     return;
-  _prefs.putUChar(NVS_KEYS::NODE_ID, nodeId);
+  size_t n = _prefs.putUChar(NVS_KEYS::NODE_ID, nodeId);
+  _persistOrEscalate(NVS_KEYS::NODE_ID, n, sizeof(uint8_t), /*securityRelevant=*/false);
   logOperation("saveNodeId");
 }
 


### PR DESCRIPTION
## Summary

Task 5 of the Phase G memory-opt plan — nodes-side DRY/robustness bundle from the
post-Phase-G audit (`docs/superpowers/specs/2026-08-04-post-phaseG-audit-findings.md`),
items F/G/H/I/O/P/Q. Branched off main `ee95b79` (Tasks 1-3 shipped). No wire-format
changes; firmware-only. Each item is a separate commit with full regression
(223 unit + 41 e2e tests) run after it — 7 commits total.

- **Item F** — cache the device MAC at boot (`hw_mac.h`) instead of a per-RX-frame
  `esp_wifi_get_mac()` syscall. Compiled out under `UNIT_TEST`: the E2E harness
  simulates multiple nodes in one process by swapping a global mock MAC per node,
  and `test_pir_adapter.cpp` mutates it mid-test — a process-lifetime cache would
  have broken both, so host builds always re-query (matches prior behavior exactly).
- **Item G** — cache `Enrollment::isEnrolled()` (was an NVS read every call, 2-3x/loop).
- **Item H** — `Enrollment::RegisterPeerFn` std::function -> plain function pointer,
  via a static trampoline (same idiom as the existing `dataRecvTrampoline`).
  `EnrollmentRelayFn` was already a function pointer. **Deviation:** `externalRecvCallback`
  left as `std::function` — its test-harness bindings are `[this]`/`[&]`-capturing
  lambdas at ~15 sites, not captureless as the brief assumed; converting would mean
  threading userdata through the whole E2E harness, out of proportion to a
  "trivial/low" item.
- **Item I** — drop `virtual` on `GpioInput`/`GpioOutput::init()` (never dispatched
  through a base pointer — confirmed by grep first). `Adapter` hierarchy stays virtual.
- **Item O** — route all 18 `EepromManager.cpp` NVS put-sites through
  `_persistOrEscalate` (was 4 of 18). 8 total `securityRelevant=true` (identity/trust
  material: keypair, mesh key, known-master MACs, peer list), 10 `securityRelevant=false`
  (bookkeeping/config). Matches the existing `SaveRebootCount_ShortWrite_WarnsNoFatal`
  test's expectation.
- **Item P** — extend `MbedtlsGuard.h` with `EcpGroupCtx`/`MpiCtx`/`EcpPointCtx`/
  `ChaChaPolyCtx`; migrate `MeshCrypto.h::generateKeypair` (real UNIT_TEST-unwind leak
  fix — three `err::fatal()` calls sit between the old manual init/free) and
  `E2ECrypto.h::sealPayload`/`openPayload` (DRY/consistency).
- **Item Q** — new `lattice::mac::eq()` (`network/MacEq.h`) replaces two competing
  6-byte MAC-comparison idioms (`memcmp(...,6)==0`, 30 sites; `MacAddress==MacAddress`,
  14 sites — the latter strictly worse, two extra memcpys) across 9 files, 44 sites
  total. `MacAddress::operator==` now delegates to the same helper.

Full per-item file lists, exact before/after site counts, and rationale for both
deviations are in the local SDD tracking doc (`task-5-report.md`, gitignored).

## Pre-existing issue fixed to get a build baseline

The `lattice-protocol` submodule checkout was detached at v0.6.0 (ahead of this
branch's pinned v0.5.0 commit, likely left over from Task 4's parallel wire-consumer
work) and wouldn't compile against this branch's code. Ran `git submodule update --init`
to realign it with the committed pointer — **no submodule pin change is part of this
PR's diff.**

## Size delta

No local ESP32 toolchain in this environment — CI's `firmware-build.yml` `idf.py size`
job will report the before/after delta on this PR.

## Test plan

- [x] `cmake --build tests/build --parallel` — clean, after every commit
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 --label-exclude e2e` — 223/223 passed, every commit
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 -L e2e` — 41/41 passed, every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)