### PR TITLE
fix(mesh+adapter+hardware): String → snprintf at LATTICE_LOG* sites (audit R)

### DIFF
--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -2,6 +2,7 @@
 #include "src/mesh/Mesh.h" // for full definition of mesh_message
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
+#include <cstdio>
 #include "src/adapter/AdapterFactory.h"
 #include "src/adapter/serial/SerialAdapter.h"
 #include "src/persistence/EepromManager.h"
@@ -83,7 +84,9 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
       if (isTarget) {
         uint8_t nodeId = message.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        LATTICE_LOGLN("ADAPTER", "Node ID assigned: " + String(nodeId), LogLevel::LOG_INFO);
+        char buf[32];
+        snprintf(buf, sizeof(buf), "Node ID assigned: %u", (unsigned)nodeId);
+        LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_INFO);
       }
     }
     // Other SERIAL_ADAPTER opcodes (e.g. OP_HEALTH_REQ) are Serial-node-specific;

--- a/firmware/main/src/adapter/AdapterFactory.cpp
+++ b/firmware/main/src/adapter/AdapterFactory.cpp
@@ -2,6 +2,7 @@
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include "src/persistence/EepromManager.h"
+#include <cstdio>
 // Include all adapter headers
 #include "src/adapter/pir/PirAdapter.h"
 #include "src/adapter/serial/SerialAdapter.h"
@@ -16,8 +17,7 @@ bool AdapterFactory::isDevMode_ = false;
 
 void AdapterFactory::setDevMode(bool isDev) {
   isDevMode_ = isDev;
-  LATTICE_LOGLN("Factory", String("Dev mode ") + (isDev ? "enabled" : "disabled"),
-                LogLevel::LOG_INFO);
+  LATTICE_LOGLN("Factory", isDev ? "Dev mode enabled" : "Dev mode disabled", LogLevel::LOG_INFO);
 }
 
 Adapter* AdapterFactory::createAdapter(adapter_types type, uint8_t pin) {

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -37,12 +37,12 @@ void SerialAdapter::sendHealthReport() {
   data[10] = static_cast<uint8_t>((uptimeSec >> 16) & 0xFF);
   data[11] = static_cast<uint8_t>((uptimeSec >> 24) & 0xFF);
 
-  LATTICE_LOGLN("Serial_Adapter",
-                String("Health report - MAC: ") + String(mac[0], HEX) + ":" + String(mac[1], HEX) +
-                    ":" + String(mac[2], HEX) + ":" + String(mac[3], HEX) + ":" +
-                    String(mac[4], HEX) + ":" + String(mac[5], HEX) +
-                    " Uptime: " + String(uptimeSec) + "s",
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[80];
+    snprintf(buf, sizeof(buf), "Health report - MAC: %02X:%02X:%02X:%02X:%02X:%02X Uptime: %lus",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], (unsigned long)uptimeSec);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
 
   // This report is ABOUT this node, so use transmitSelfOriginated(): on a
   // master node, plain transmit() would only broadcast it to mesh peers
@@ -55,8 +55,9 @@ void SerialAdapter::sendHealthReport() {
 SerialAdapter::SerialAdapter(uint8_t pin) : Adapter(pin), lastReportedHopCount(0) {
   _adapterType = adapter_types::SERIAL_ADAPTER;
 
-  LATTICE_LOGLN("Serial_Adapter", "Serial_Adapter constructed with pin " + String(pin),
-                LogLevel::LOG_INFO);
+  char buf[48];
+  snprintf(buf, sizeof(buf), "Serial_Adapter constructed with pin %u", (unsigned)pin);
+  LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
 }
 
 bool SerialAdapter::init() {
@@ -73,11 +74,17 @@ void SerialAdapter::loop() {
 
   if (stateChanged || millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
     lastHealthMillis = static_cast<uint32_t>(millis());
-    LATTICE_LOGLN("Serial_Adapter",
-                  String(stateChanged ? "Health report triggered by state change (hopCount: "
-                                      : "Sending periodic health report (hopCount: ") +
-                      String(currentHopCount) + ")",
-                  LogLevel::LOG_DEBUG);
+    {
+      char buf[80];
+      if (stateChanged) {
+        snprintf(buf, sizeof(buf), "Health report triggered by state change (hopCount: %lu)",
+                 (unsigned long)currentHopCount);
+      } else {
+        snprintf(buf, sizeof(buf), "Sending periodic health report (hopCount: %lu)",
+                 (unsigned long)currentHopCount);
+      }
+      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+    }
     sendHealthReport();
     lastReportedHopCount = currentHopCount;
   }
@@ -91,12 +98,14 @@ void SerialAdapter::loop() {
 }
 
 void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
-  LATTICE_LOGLN(
-      "Serial_Adapter",
-      "Processing incoming mesh message - Type: " + String((uint8_t)message.message_type) +
-          " DataType: " + String(static_cast<int32_t>(message.data_type)) +
-          " HopCount: " + String(message.hop_count),
-      LogLevel::LOG_DEBUG);
+  {
+    char buf[96];
+    snprintf(buf, sizeof(buf),
+             "Processing incoming mesh message - Type: %u DataType: %ld HopCount: %u",
+             (unsigned)message.message_type, (long)message.data_type,
+             (unsigned)message.hop_count);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
 
   // Handle control opcodes received via mesh.
   // NOTE: OP_CONFIG_SET is now handled in Adapter::onMeshData() (base class) so it reaches
@@ -118,8 +127,9 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
         esp_err_t txErr = esp_wifi_set_max_tx_power(
             static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
-          LATTICE_LOGLN("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
-                        LogLevel::LOG_WARN);
+          char buf[64];
+          snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
+          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
         } else {
           LATTICE_LOGLN("Serial_Adapter", "TX power preset applied from mesh", LogLevel::LOG_INFO);
         }
@@ -139,9 +149,11 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
     return;
   }
 
-  LATTICE_LOGLN("Serial_Adapter",
-                "Encoded mesh message to " + String(n) + " bytes, sending to serial",
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "Encoded mesh message to %u bytes, sending to serial", (unsigned)n);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
 
   // 2-byte little-endian length prefix
   uint8_t lenLE[2] = {static_cast<uint8_t>(n & 0xFF), static_cast<uint8_t>((n >> 8) & 0xFF)};
@@ -173,8 +185,11 @@ void SerialAdapter::relayEnrollmentToServer(const uint8_t* mac, const uint8_t* p
 }
 
 void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
-  LATTICE_LOGLN("Serial_Adapter", "Handling complete frame of " + String(len) + " bytes",
-                LogLevel::LOG_INFO);
+  {
+    char buf[48];
+    snprintf(buf, sizeof(buf), "Handling complete frame of %u bytes", (unsigned)len);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
+  }
 
 #if SIMULATE_MODE
   if (len >= 1) {
@@ -224,10 +239,12 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     return;
   }
 
-  LATTICE_LOGLN("Serial_Adapter",
-                "Decoded message - Type: " + String((uint8_t)msg.message_type) +
-                    " DataType: " + String(static_cast<int32_t>(msg.data_type)),
-                LogLevel::LOG_INFO);
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "Decoded message - Type: %u DataType: %ld",
+             (unsigned)msg.message_type, (long)msg.data_type);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
+  }
 
   // JOIN_ACK (type=4): server responded to an enrollment request
   if (msg.message_type == MESH_TYPE_JOIN_ACK) {
@@ -308,16 +325,19 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           destMac, static_cast<adapter_types>(msg.data_type), fwdData);
     }
   } else {
-    LATTICE_LOGLN("Serial_Adapter", "Unknown message type: " + String(msg.message_type),
-                  LogLevel::LOG_WARN);
+    char buf[48];
+    snprintf(buf, sizeof(buf), "Unknown message type: %u", (unsigned)msg.message_type);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
   }
 
   // Handle control opcodes: CONFIG_SET, HEALTH_REQ
   if (msg.data_type == adapter_types::SERIAL_ADAPTER) {
     uint8_t op = msg.data[0];
-    LATTICE_LOGLN("Serial_Adapter",
-                  "Processing SERIAL_ADAPTER control opcode: 0x" + String(op, HEX),
-                  LogLevel::LOG_DEBUG);
+    {
+      char buf[64];
+      snprintf(buf, sizeof(buf), "Processing SERIAL_ADAPTER control opcode: 0x%02X", op);
+      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+    }
 
     if (op == OP_HEALTH_REQ) {
       LATTICE_LOGLN("Serial_Adapter", "Received health request, sending health report",
@@ -339,10 +359,13 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
 
       if (isTarget) {
         adapter_types newType = AdapterFactory::adapterTypeFromEEPROM(msg.data[7]);
-        LATTICE_LOGLN("Serial_Adapter",
-                      "Configuration applies to this node, setting adapter type to: " +
-                          String(static_cast<int32_t>(newType)),
-                      LogLevel::LOG_INFO);
+        {
+          char buf[80];
+          snprintf(buf, sizeof(buf),
+                   "Configuration applies to this node, setting adapter type to: %ld",
+                   (long)static_cast<int32_t>(newType));
+          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
+        }
 
         lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
         LATTICE_LOGLN("Serial_Adapter", "Adapter type saved to EEPROM successfully",
@@ -368,8 +391,9 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
         esp_err_t txErr = esp_wifi_set_max_tx_power(
             static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
         if (txErr != ESP_OK) {
-          LATTICE_LOGLN("Serial_Adapter", String("TX power set failed: ") + esp_err_to_name(txErr),
-                        LogLevel::LOG_WARN);
+          char buf[64];
+          snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
+          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
         } else {
           LATTICE_LOGLN("Serial_Adapter", "TX power preset updated", LogLevel::LOG_INFO);
         }
@@ -399,11 +423,14 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       if (isTarget) {
         uint8_t nodeId = msg.data[7];
         lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        LATTICE_LOGLN("Serial_Adapter", "Node ID set: " + String(nodeId), LogLevel::LOG_INFO);
+        char buf[32];
+        snprintf(buf, sizeof(buf), "Node ID set: %u", (unsigned)nodeId);
+        LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
       }
     } else {
-      LATTICE_LOGLN("Serial_Adapter", "Unknown SERIAL_ADAPTER opcode: 0x" + String(op, HEX),
-                    LogLevel::LOG_WARN);
+      char buf[64];
+      snprintf(buf, sizeof(buf), "Unknown SERIAL_ADAPTER opcode: 0x%02X", op);
+      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
     }
   }
 

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -7,6 +7,7 @@
 #include "src/error/Error.h"
 #include "src/network/hw_mac.h"
 #include <cstring>
+#include <cstdio>
 
 namespace lattice {
 namespace adapter {
@@ -16,11 +17,12 @@ using lattice::hw::readOwnMac;
 
 size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen) {
   using namespace lattice::utils;
-  LATTICE_LOGLN("Serial_Adapter",
-                "Encoding mesh message - Type: " + String((uint8_t)msg.message_type) +
-                    " DataType: " + String(static_cast<int32_t>(msg.data_type)) +
-                    " HopCount: " + String(msg.hop_count),
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[80];
+    snprintf(buf, sizeof(buf), "Encoding mesh message - Type: %u DataType: %ld HopCount: %u",
+             (unsigned)msg.message_type, (long)msg.data_type, (unsigned)msg.hop_count);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
 
   mesh_MeshMessage pbMsg = mesh_MeshMessage_init_zero;
   pbMsg.messageType = static_cast<uint32_t>(msg.message_type);
@@ -89,16 +91,22 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     return 0;
   }
 
-  LATTICE_LOGLN("Serial_Adapter",
-                "Successfully encoded mesh message to " + String(stream.bytes_written) + " bytes",
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "Successfully encoded mesh message to %u bytes",
+             (unsigned)stream.bytes_written);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
   return stream.bytes_written;
 }
 
 bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& outMsg) {
   using namespace lattice::utils;
-  LATTICE_LOGLN("Serial_Adapter", "Decoding protobuf message of " + String(len) + " bytes",
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "Decoding protobuf message of %u bytes", (unsigned)len);
+    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+  }
 
   memset(&outMsg, 0, sizeof(outMsg));
 

--- a/firmware/main/src/app/ButtonHandler.h
+++ b/firmware/main/src/app/ButtonHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Arduino.h>
+#include <cstdio>
 #include "src/hardware/input/Button.h"
 #include "src/hardware/output/Led.h"
 #include "src/mesh/Mesh.h"
@@ -37,18 +38,23 @@ private:
           bool newMaster = !mesh.getIsMaster();
           mesh.setIsMaster(newMaster);
           devMasterFlag = newMaster;
-          LATTICE_LOGLN("MAIN",
-                        String("DEV MODE: Role toggled. Now ") + (newMaster ? "MASTER" : "NODE"),
-                        lattice::utils::LogLevel::LOG_INFO);
+          {
+            char buf[48];
+            snprintf(buf, sizeof(buf), "DEV MODE: Role toggled. Now %s",
+                     newMaster ? "MASTER" : "NODE");
+            LATTICE_LOGLN("MAIN", buf, lattice::utils::LogLevel::LOG_INFO);
+          }
           greenLed.blink(newMaster ? 3 : 2, 150, 150);
         } else {
           bool wasMaster = em.loadMasterFlag();
           bool newMaster = !wasMaster;
           em.saveMasterFlag(newMaster);
-          LATTICE_LOGLN("MAIN",
-                        String("Button held 5s: CONFIG TOGGLED. Now ") +
-                            (newMaster ? "MASTER" : "NODE"),
-                        lattice::utils::LogLevel::LOG_INFO);
+          {
+            char buf[64];
+            snprintf(buf, sizeof(buf), "Button held 5s: CONFIG TOGGLED. Now %s",
+                     newMaster ? "MASTER" : "NODE");
+            LATTICE_LOGLN("MAIN", buf, lattice::utils::LogLevel::LOG_INFO);
+          }
           LATTICE_LOGLN("MAIN", "Restarting in 2 seconds for new role...",
                         lattice::utils::LogLevel::LOG_INFO);
           greenLed.blink(newMaster ? 3 : 2, 200, 200);

--- a/firmware/main/src/error/Error.h
+++ b/firmware/main/src/error/Error.h
@@ -6,6 +6,7 @@
 #include "../logging/Logger.h"
 #include <esp_err.h>
 #include <cstdint>
+#include <cstdio>
 #ifdef UNIT_TEST
 #include <stdexcept>
 extern int lattice_test_errFailCount;
@@ -78,7 +79,9 @@ inline bool check(bool condition, utils::ErrorType type, const char* msg) {
 inline bool checkEsp(esp_err_t status, utils::ErrorType type, const char* msg) {
   if (status == ESP_OK)
     return true;
-  LATTICE_LOGLN("ESP", String(msg) + ": " + esp_err_to_name(status), utils::LogLevel::LOG_ERROR);
+  char buf[96];
+  snprintf(buf, sizeof(buf), "%s: %s", msg ? msg : "", esp_err_to_name(status));
+  LATTICE_LOGLN("ESP", buf, utils::LogLevel::LOG_ERROR);
   return fail(type, msg);
 }
 } // namespace err

--- a/firmware/main/src/error/ErrorCore.cpp
+++ b/firmware/main/src/error/ErrorCore.cpp
@@ -2,6 +2,7 @@
 #include "Error.h"
 #include "../logging/Logger.h"
 #include <esp_system.h>
+#include <cstdio>
 using lattice::core::ErrorTypeDigit;
 using lattice::core::makeErrorCode;
 using lattice::core::ModuleDigit;
@@ -45,8 +46,11 @@ void ErrorCore::signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const 
   signalError(lt, msg);
 }
 void ErrorCore::signalError(ErrorType type, const char* msg) {
-  if (msg)
-    LATTICE_LOGLN("Error", String("ERROR: ") + msg, LogLevel::LOG_ERROR);
+  if (msg) {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "ERROR: %s", msg);
+    LATTICE_LOGLN("Error", buf, LogLevel::LOG_ERROR);
+  }
   if (_initialized && _errorLed) {
     if (_inCallbackContext) {
       // Defer blink to main loop — never block in callback context

--- a/firmware/main/src/hardware/output/Led.cpp
+++ b/firmware/main/src/hardware/output/Led.cpp
@@ -1,6 +1,7 @@
 #include "Led.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
+#include <cstdio>
 
 namespace lattice {
 namespace hardware {
@@ -29,12 +30,18 @@ bool Led::init() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
                          "Led: Invalid pin number");
     }
-    LATTICE_LOGLN("Led", "ERROR: Invalid pin number for LED: " + String(_pin), LogLevel::LOG_ERROR);
+    char buf[48];
+    snprintf(buf, sizeof(buf), "ERROR: Invalid pin number for LED: %u", (unsigned)_pin);
+    LATTICE_LOGLN("Led", buf, LogLevel::LOG_ERROR);
     return false;
   }
   digitalWrite(_pin, LOW);
   _isOn = false;
-  LATTICE_LOGLN("Led", "Initialized LED on pin " + String(_pin), LogLevel::LOG_INFO);
+  {
+    char buf[48];
+    snprintf(buf, sizeof(buf), "Initialized LED on pin %u", (unsigned)_pin);
+    LATTICE_LOGLN("Led", buf, LogLevel::LOG_INFO);
+  }
   return true;
 }
 
@@ -89,8 +96,11 @@ bool Led::setState(bool state) {
     return true;
   digitalWrite(_pin, state ? HIGH : LOW);
   _isOn = state;
-  LATTICE_LOGLN("Led", String("LED on pin ") + String(_pin) + (state ? " ON" : " OFF"),
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[48];
+    snprintf(buf, sizeof(buf), "LED on pin %u %s", (unsigned)_pin, state ? "ON" : "OFF");
+    LATTICE_LOGLN("Led", buf, LogLevel::LOG_DEBUG);
+  }
   return true;
 }
 
@@ -114,8 +124,11 @@ bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
     if (i < times - 1)
       delay(offTimeMs);
   }
-  LATTICE_LOGLN("Led", String("Blink pattern: ") + String(times) + "x on pin " + String(_pin),
-                LogLevel::LOG_DEBUG);
+  {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "Blink pattern: %ux on pin %u", (unsigned)times, (unsigned)_pin);
+    LATTICE_LOGLN("Led", buf, LogLevel::LOG_DEBUG);
+  }
   return true;
 }
 

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -9,6 +9,7 @@
 #include <esp_now.h>
 #include <WiFi.h>
 #include <cstring>
+#include <cstdio>
 #include "../../project_config.h"
 #include "lib/lattice-protocol/c/opcodes.h"
 #include "MeshCrypto.h"
@@ -73,8 +74,11 @@ void Mesh::readMacAddress() {
     // is a memcpy instead of a repeat esp_wifi_get_mac() syscall.
     lattice::hw::cacheDeviceMac(deviceMacAddress);
     LATTICE_LOG("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
-    LATTICE_LOGLN("MESH", lattice::utils::MacAddress(deviceMacAddress).toString(),
-                  LogLevel::LOG_DEBUG);
+    char macBuf[18];
+    snprintf(macBuf, sizeof(macBuf), "%02X:%02X:%02X:%02X:%02X:%02X", deviceMacAddress[0],
+             deviceMacAddress[1], deviceMacAddress[2], deviceMacAddress[3], deviceMacAddress[4],
+             deviceMacAddress[5]);
+    LATTICE_LOGLN("MESH", macBuf, LogLevel::LOG_DEBUG);
   }
 }
 
@@ -229,7 +233,11 @@ bool Mesh::init() {
   uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
   EepromManager::getInstance().saveBootEpoch(epoch);
   replay.init(epoch);
-  LATTICE_LOGLN("MESH", "Boot epoch: " + String(replay.bootEpoch), LogLevel::LOG_INFO);
+  {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "Boot epoch: %lu", (unsigned long)replay.bootEpoch);
+    LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
+  }
 
   // Phase D (#42): DEV_MODE bypasses the beacon origin-MAC pin (dev firmware
   // regenerates a fresh keypair/MAC each boot, so pinning would reject the
@@ -249,8 +257,9 @@ bool Mesh::init() {
     uint8_t txPowerVal = lattice::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
     esp_err_t txErr = esp_wifi_set_max_tx_power(static_cast<int8_t>(txPowerVal));
     if (txErr != ESP_OK) {
-      LATTICE_LOGLN("MESH", String("TX power set failed: ") + esp_err_to_name(txErr),
-                    LogLevel::LOG_WARN);
+      char buf[64];
+      snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
+      LATTICE_LOGLN("MESH", buf, LogLevel::LOG_WARN);
     } else {
       LATTICE_LOGLN("MESH", "TX power preset applied", LogLevel::LOG_INFO);
     }
@@ -322,8 +331,10 @@ bool Mesh::setupEspNow() {
 // ------------------------------------------------
 
 void Mesh::onDataSentCallback(const wifi_tx_info_t* mac_addr, esp_now_send_status_t status) {
-  String statusStr = (status == ESP_NOW_SEND_SUCCESS) ? "Delivery Success" : "Delivery Fail";
-  LATTICE_LOGLN("MESH", "Last Packet Send Status: " + statusStr, LogLevel::LOG_DEBUG);
+  const char* statusStr = (status == ESP_NOW_SEND_SUCCESS) ? "Delivery Success" : "Delivery Fail";
+  char buf[48];
+  snprintf(buf, sizeof(buf), "Last Packet Send Status: %s", statusStr);
+  LATTICE_LOGLN("MESH", buf, LogLevel::LOG_DEBUG);
 }
 
 void IRAM_ATTR Mesh::onDataRecvCallback(const esp_now_recv_info* info, const uint8_t* incomingData,
@@ -562,7 +573,7 @@ void Mesh::broadcastMasterBeacon() {
   // esp_now_send(nullptr, …) only delivers to already-registered unicast peers.
   esp_err_t br =
       esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&beacon), sizeof(beacon));
-  LATTICE_LOGLN("MESH", String("Beacon broadcast ") + (br == ESP_OK ? "OK" : "FAIL"),
+  LATTICE_LOGLN("MESH", br == ESP_OK ? "Beacon broadcast OK" : "Beacon broadcast FAIL",
                 LogLevel::LOG_DEBUG);
 }
 
@@ -684,13 +695,12 @@ void Mesh::debugDumpRadio() {
     return;
   uint8_t ch;
   esp_wifi_get_channel(&ch, nullptr);
-  String out = String("DBG Channel=") + String(ch) + " Key=";
-  for (int i = 0; i < MESH_KEY_SIZE; ++i) {
-    if (meshKey[i] < 0x10)
-      out += "0";
-    out += String(meshKey[i], HEX) + " ";
+  char buf[96];
+  int off = snprintf(buf, sizeof(buf), "DBG Channel=%u Key=", (unsigned)ch);
+  for (int i = 0; i < MESH_KEY_SIZE && off > 0 && off < (int)sizeof(buf); ++i) {
+    off += snprintf(buf + off, sizeof(buf) - off, "%02X ", meshKey[i]);
   }
-  LATTICE_LOGLN("MESH", out, LogLevel::LOG_INFO);
+  LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
 }
 
 void Mesh::checkMasterTimeout() {
@@ -804,7 +814,9 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   uint8_t derived = (min_d == 0xFF) ? 0xFF : static_cast<uint8_t>(min_d + 1);
   if (derived != currentMaster.distance) {
     currentMaster.distance = derived;
-    LATTICE_LOGLN("MESH", "Route distance derived: " + String(derived), LogLevel::LOG_INFO);
+    char buf[40];
+    snprintf(buf, sizeof(buf), "Route distance derived: %u", (unsigned)derived);
+    LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
   }
 
   if (!isMaster) {
@@ -1298,8 +1310,9 @@ void Mesh::loop() {
     esp_err_t res = esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&relayPendingMsg),
                                  sizeof(relayPendingMsg));
     if (res != ESP_OK) {
-      LATTICE_LOGLN("MESH", String("Beacon relay broadcast failed: ") + esp_err_to_name(res),
-                    LogLevel::LOG_WARN);
+      char buf[64];
+      snprintf(buf, sizeof(buf), "Beacon relay broadcast failed: %s", esp_err_to_name(res));
+      LATTICE_LOGLN("MESH", buf, LogLevel::LOG_WARN);
     }
   }
 

--- a/firmware/main/src/persistence/EepromManager.cpp
+++ b/firmware/main/src/persistence/EepromManager.cpp
@@ -1,5 +1,6 @@
 #include "EepromManager.h"
 #include "src/error/Error.h"
+#include <cstdio>
 
 namespace lattice {
 namespace utils {
@@ -62,7 +63,9 @@ bool EepromManager::ensureInitialized() {
 
 void EepromManager::logOperation(const char* operation, const char* details) {
   if (details) {
-    LATTICE_LOGLN("NVS", String(operation) + ": " + details, LogLevel::LOG_DEBUG);
+    char buf[80];
+    snprintf(buf, sizeof(buf), "%s: %s", operation, details);
+    LATTICE_LOGLN("NVS", buf, LogLevel::LOG_DEBUG);
   } else {
     LATTICE_LOGLN("NVS", operation, LogLevel::LOG_DEBUG);
   }
@@ -120,9 +123,17 @@ bool EepromManager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
   if (maxPeers > EEPROM_SIZES::MAX_PEERS)
     return false;
   size_t maxBytes = maxPeers * EEPROM_SIZES::PEER_RECORD_SIZE;
+  // Pre-fill the whole output buffer with the "empty slot" sentinel (0xFF)
+  // before reading: a persisted list shorter than maxBytes (fewer peers were
+  // ever saved than MAX_PEERS) leaves getBytes() writing only the first
+  // `read` bytes, and the caller (PeerRegistry::loadFromEEPROM) scans every
+  // record up to maxPeers regardless of how many bytes came back. Without
+  // this prefill, the untouched tail of the caller's uninitialized stack
+  // buffer was read as real peer records — an uninitialized-memory bug that
+  // could inject bogus peers with garbage MAC/public-key bytes.
+  memset(peerRecords, 0xFF, maxBytes);
   size_t read = _prefs.getBytes(NVS_KEYS::PEER_LIST, peerRecords, maxBytes);
   if (read == 0) {
-    memset(peerRecords, 0xFF, maxBytes);
     return false;
   }
   return true;
@@ -391,10 +402,12 @@ bool EepromManager::_persistOrEscalate(const char* key, size_t got, size_t want,
                        "NVS write failed (security-relevant key)");
     return false; // unreachable outside UNIT_TEST
   }
-  LATTICE_LOGLN("NVS",
-                String("write failed key=") + key + " got=" + String((unsigned)got) +
-                    " want=" + String((unsigned)want),
-                LogLevel::LOG_ERROR);
+  {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "write failed key=%s got=%u want=%u", key, (unsigned)got,
+             (unsigned)want);
+    LATTICE_LOGLN("NVS", buf, LogLevel::LOG_ERROR);
+  }
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Task 1 of the Phase H2 refactor sweep (audit item R): replaces every `LATTICE_LOG*(...String(...)...)` call site with a stack `char buf[N]; snprintf(...)` pattern, so the `String` temporaries drop out of the build entirely (even at production `LOG_NONE`, the args were still being built before the macro folded to void).
- Actual site count is **37**, not the brief's grep-estimated 23 — a proper paren-matching scan (string/comment-aware) found multi-line `LATTICE_LOG*` calls the single-line grep missed (`SerialAdapter.cpp`, `SerialFraming.cpp`, `app/ButtonHandler.h`) plus two `String` locals scoped only to feed one log call (`Mesh.cpp`'s `onDataSentCallback`/`debugDumpRadio`). All converted, same intent as the brief.
- Also fixes an unrelated **pre-existing bug** surfaced by e2e regression testing: `EepromManager::loadPeerList()` only zero-filled its output buffer when the read returned zero bytes, leaving the tail of a shorter-than-`MAX_PEERS` persisted list as uninitialized caller stack memory — later parsed by `PeerRegistry::loadFromEEPROM()` as a bogus peer with garbage public-key bytes. Confirmed pre-existing and stack-layout-sensitive (reproduced on an untouched baseline by adding one unrelated, unused local variable to `Mesh::init()`); not introduced by this refactor, just unmasked by its incidental stack-frame-size change. Fixed by always memsetting the full buffer to the `0xFF` empty-slot sentinel before the read.

Full writeup: `.superpowers/sdd/2026-08-05-phaseH2-refactor-sweep/task-1-report.md` (gitignored, local to this checkout).

## Test plan
- [x] `cmake --build tests/build --parallel 2` — clean build (only pre-existing unrelated `sprintf`-deprecation warning in untouched `network/MacAddress.h`)
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 2 --label-exclude e2e` — 222/222 passed
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 2 -L e2e` — 41/41 passed (re-run 3x for stability)
- [x] Full-tree scan confirms zero remaining `LATTICE_LOG*` sites with `String` in the message argument
- [x] No wire/protocol changes; all changes under `firmware/main/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)