### PR TITLE
feat(display+button): non-blocking button debounce + display tick throttle (audit S+T)

### DIFF
--- a/firmware/main/src/app/DisplayManager.h
+++ b/firmware/main/src/app/DisplayManager.h
@@ -12,7 +12,18 @@ struct DisplayManager {
     static uint32_t lastToggleMs = 0;
     static bool dashVisible = false;
 
+    // Change-detection state (audit item S) — display.show()/showWithDP() only fire
+    // when the rendered value actually changes, instead of every tick(). _lastValue
+    // sentinel of -1 (out of the int8 nodeId range) forces a draw on the first
+    // enrolled tick and again whenever we re-enter the enrolled branch after a
+    // pre-enroll blink (isEnrolled flips false->true).
+    static int _lastValue = -1;
+    static uint8_t _lastNodeId = 0;
+    static bool _lastIsMaster = false;
+    static bool _wasEnrolled = false;
+
     if (!enrolled) {
+      _wasEnrolled = false; // force a redraw once we become enrolled again
       if (millis() - lastToggleMs >= 500) {
         lastToggleMs = static_cast<uint32_t>(millis());
         dashVisible = !dashVisible;
@@ -23,13 +34,28 @@ struct DisplayManager {
           display.clear();
         }
       }
-    } else if (nodeId == 0) {
+      return;
+    }
+
+    const int value = static_cast<int>(nodeId);
+    const bool changed =
+        !_wasEnrolled || value != _lastValue || nodeId != _lastNodeId || isMaster != _lastIsMaster;
+    if (!changed) {
+      return;
+    }
+
+    if (nodeId == 0) {
       display.show(0, false);
     } else if (isMaster) {
-      display.showWithDP(static_cast<int>(nodeId), false);
+      display.showWithDP(value, false);
     } else {
-      display.show(static_cast<int>(nodeId), false);
+      display.show(value, false);
     }
+
+    _lastValue = value;
+    _lastNodeId = nodeId;
+    _lastIsMaster = isMaster;
+    _wasEnrolled = true;
   }
 };
 

--- a/firmware/main/src/hardware/input/Button.cpp
+++ b/firmware/main/src/hardware/input/Button.cpp
@@ -23,14 +23,21 @@ bool Button::init() {
 }
 
 bool Button::isPressed() {
-  uint8_t highCount = 0;
-  for (uint8_t i = 0; i < DEBOUNCE_READS; ++i) {
-    if (digitalRead(_pin) == HIGH)
-      ++highCount;
-    if (i < DEBOUNCE_READS - 1)
-      delay(DEBOUNCE_DELAY_MS);
+  // Rolling-vote debounce (audit item T): take at most one raw sample every
+  // DEBOUNCE_DELAY_MS, shifting it into a small history bitfield. Callers
+  // poll this repeatedly (e.g. once per main loop) instead of blocking here
+  // — the old implementation blocked for DEBOUNCE_DELAY_MS * (DEBOUNCE_READS
+  // - 1) = 10ms per call via delay().
+  uint32_t now = static_cast<uint32_t>(millis());
+  if (!_hasPolled || static_cast<uint32_t>(now - _lastPollMs) >= DEBOUNCE_DELAY_MS) {
+    _hasPolled = true;
+    _lastPollMs = now;
+    bool raw = (digitalRead(_pin) == HIGH);
+    _history = static_cast<uint8_t>((_history << 1) | (raw ? 1u : 0u));
   }
-  return highCount >= 2; // majority vote: 2 of 3 reads HIGH
+  // Pressed once the DEBOUNCE_READS most-recent samples (~DEBOUNCE_READS *
+  // DEBOUNCE_DELAY_MS <= 20ms window) are all HIGH.
+  return (_history & DEBOUNCE_HISTORY_MASK) == DEBOUNCE_HISTORY_MASK;
 }
 
 bool Button::waitForHold(uint32_t ms) {
@@ -40,7 +47,7 @@ bool Button::waitForHold(uint32_t ms) {
   while (isPressed()) {
     if (static_cast<uint32_t>(millis() - start) >= ms)
       return true;
-    delay(10); // debounce, yield to RTOS
+    delay(10); // yield to RTOS; isPressed() itself is non-blocking (item T)
   }
   return false;
 }

--- a/firmware/main/src/hardware/input/Button.h
+++ b/firmware/main/src/hardware/input/Button.h
@@ -11,14 +11,29 @@ public:
   explicit Button(uint8_t pin);
   // Initialize the button GPIO (uses internal PULL-DOWN)
   bool init();
-  // Returns true if the button is currently pressed (active HIGH)
+  // Returns true if the button is currently debounced-pressed (active HIGH).
+  // Non-blocking (audit item T): internally samples the pin at most once per
+  // DEBOUNCE_DELAY_MS and rolls the result into a small history bitfield;
+  // callers are expected to poll this every loop() iteration (as
+  // ButtonHandler does) rather than spin-wait on it.
   bool isPressed();
-  // Returns true if held for the given ms (blocking call)
+  // Returns true if held for the given ms. Still a blocking call by design —
+  // "wait" implies synchronous blocking until the hold completes or the
+  // button releases — and is NOT used anywhere in the non-blocking main
+  // loop (ButtonHandler polls isPressed() + tracks hold duration itself).
+  // Kept for API compatibility; internally now calls the non-blocking
+  // isPressed() so it no longer pays the old 10ms-per-read debounce cost,
+  // just the intentional poll-loop delay.
   bool waitForHold(uint32_t ms);
 
 private:
-  static constexpr uint8_t DEBOUNCE_READS = 3;
-  static constexpr uint8_t DEBOUNCE_DELAY_MS = 5;
+  static constexpr uint8_t DEBOUNCE_READS = 3;      // consecutive positive samples required
+  static constexpr uint8_t DEBOUNCE_DELAY_MS = 5;   // sample period
+  static constexpr uint8_t DEBOUNCE_HISTORY_MASK = (1u << DEBOUNCE_READS) - 1u; // last 3 samples
+
+  uint32_t _lastPollMs = 0;
+  uint8_t _history = 0;      // rolling bitfield of raw samples, newest in bit0
+  bool _hasPolled = false;   // true once the first sample has been taken
 };
 
 } // namespace hardware

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(FIRMWARE_SOURCES
   ../firmware/main/src/hardware/output/SevenSegDisplay.cpp
   ../firmware/main/src/hardware/input/GpioInput.cpp
   ../firmware/main/src/hardware/input/Pir.cpp
+  ../firmware/main/src/hardware/input/Button.cpp
   mocks/esp_now_mock.cpp
   mocks/esp_wifi_mock.cpp
   mocks/time_mock.cpp
@@ -108,6 +109,8 @@ add_unit_test(test_e2e_keystore       unit/test_e2e_keystore.cpp)
 add_unit_test(test_neighbor_table     unit/test_neighbor_table.cpp)
 add_unit_test(test_route_table        unit/test_route_table.cpp)
 add_unit_test(test_compact_message    unit/test_compact_message.cpp)
+add_unit_test(test_button             unit/test_button.cpp)
+add_unit_test(test_display_manager    unit/test_display_manager.cpp)
 
 # ---- E2E simulation target — SIMULATE_MODE recompiles all firmware sources ----
 add_executable(lattice_e2e

--- a/tests/mocks/Arduino.cpp
+++ b/tests/mocks/Arduino.cpp
@@ -1,3 +1,5 @@
 #include "Arduino.h"
 ESPClass ESP;
 int lattice_test_errFailCount = 0;
+int _mockDigitalPinState[MOCK_DIGITAL_PIN_COUNT] = {0};
+int _mockDigitalWriteCallCount = 0;

--- a/tests/mocks/Arduino.h
+++ b/tests/mocks/Arduino.h
@@ -11,8 +11,30 @@
 #endif
 
 // GPIO stubs
-inline int  digitalRead(int)           { return 0; }
-inline void digitalWrite(int, int)     {}
+// Mock digital pin state, settable via setMockDigitalRead() (used by Button
+// debounce tests). Defaults to LOW (0) for every pin, matching the prior
+// fixed-stub behavior for callers that never set anything.
+constexpr int MOCK_DIGITAL_PIN_COUNT = 64;
+extern int _mockDigitalPinState[MOCK_DIGITAL_PIN_COUNT];
+inline int digitalRead(int pin) {
+  return (pin >= 0 && pin < MOCK_DIGITAL_PIN_COUNT) ? _mockDigitalPinState[pin] : 0;
+}
+inline void setMockDigitalRead(int pin, int value) {
+  if (pin >= 0 && pin < MOCK_DIGITAL_PIN_COUNT)
+    _mockDigitalPinState[pin] = value;
+}
+// Reset all mock pin state back to LOW — call from test SetUp() so state
+// doesn't leak between tests sharing the same process.
+inline void resetMockDigitalPins() {
+  for (int i = 0; i < MOCK_DIGITAL_PIN_COUNT; ++i)
+    _mockDigitalPinState[i] = 0;
+}
+// Call counter for digitalWrite — used by DisplayManager tests to prove the
+// tick() throttle (item S) skips display writes when nothing changed,
+// without needing to decode the bit-banged 7-segment protocol itself.
+extern int _mockDigitalWriteCallCount;
+inline void digitalWrite(int, int)     { ++_mockDigitalWriteCallCount; }
+inline void resetMockDigitalWriteCallCount() { _mockDigitalWriteCallCount = 0; }
 inline void pinMode(int, int)          {}
 inline void analogWrite(int, int)      {}
 inline void attachInterrupt(int, void(*)(), int) {}

--- a/tests/unit/test_button.cpp
+++ b/tests/unit/test_button.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include "hardware/input/Button.h"
+#include "time_mock.h"
+#include "Arduino.h" // setMockDigitalRead / resetMockDigitalPins / HIGH / LOW
+
+using lattice::hardware::Button;
+
+// Pin 27 is a valid input pin per GpioInput::isValidInputPin (matches
+// tests/unit/test_pir_adapter.cpp convention).
+static constexpr uint8_t kTestPin = 27;
+
+class ButtonTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    resetMillis();
+    resetMockDigitalPins();
+  }
+};
+
+// Item T: isPressed() must not block. With delay() a no-op under UNIT_TEST,
+// a call that still internally blocked via delay() would return instantly
+// regardless — so the real proof-of-non-blocking is that isPressed() only
+// takes a fresh sample once per DEBOUNCE_DELAY_MS (5ms) of *simulated*
+// millis(), not on every call. We drive that via advanceMillis() rather than
+// wall-clock time.
+TEST_F(ButtonTest, NotPressedWhenPinLow) {
+  Button btn(kTestPin);
+  btn.init();
+  // Pin stays LOW (default). Poll several times, advancing the mock clock
+  // past the debounce window each time.
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_FALSE(btn.isPressed());
+    advanceMillis(5);
+  }
+}
+
+TEST_F(ButtonTest, RequiresConsecutiveHighSamplesBeforeReportingPressed) {
+  Button btn(kTestPin);
+  btn.init();
+  setMockDigitalRead(kTestPin, HIGH);
+
+  // First sample taken immediately (not yet debounced: only 1 positive sample).
+  EXPECT_FALSE(btn.isPressed());
+
+  // A second poll before 5ms has elapsed must NOT take a new sample — still
+  // only 1 positive sample banked, so still not pressed.
+  EXPECT_FALSE(btn.isPressed());
+
+  advanceMillis(5); // 2nd sample window
+  EXPECT_FALSE(btn.isPressed());
+
+  advanceMillis(5); // 3rd sample window -> 3 consecutive HIGH samples
+  EXPECT_TRUE(btn.isPressed());
+}
+
+TEST_F(ButtonTest, ReleaseResetsTheDebounceStreak) {
+  Button btn(kTestPin);
+  btn.init();
+  setMockDigitalRead(kTestPin, HIGH);
+
+  btn.isPressed();
+  advanceMillis(5);
+  btn.isPressed();
+  advanceMillis(5);
+  ASSERT_TRUE(btn.isPressed());
+
+  // Pin goes LOW — next sampled poll should immediately un-latch (a single
+  // LOW sample breaks the "consecutive" requirement).
+  setMockDigitalRead(kTestPin, LOW);
+  advanceMillis(5);
+  EXPECT_FALSE(btn.isPressed());
+}
+
+// Sanity: a call between two mock-clock advances that lands inside the same
+// 5ms sample window returns the same cached vote (proves isPressed() isn't
+// blocking-and-resampling every call, which was the pre-item-T behavior).
+TEST_F(ButtonTest, DoesNotResampleWithinDebounceWindow) {
+  Button btn(kTestPin);
+  btn.init();
+  setMockDigitalRead(kTestPin, HIGH);
+
+  btn.isPressed();
+  advanceMillis(5);
+  btn.isPressed();
+  advanceMillis(5);
+  ASSERT_TRUE(btn.isPressed()); // latched pressed
+
+  // Flip the pin LOW but do NOT advance the mock clock — within the same
+  // debounce window the cached (pressed) vote must still hold.
+  setMockDigitalRead(kTestPin, LOW);
+  EXPECT_TRUE(btn.isPressed());
+}

--- a/tests/unit/test_display_manager.cpp
+++ b/tests/unit/test_display_manager.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+#include "app/DisplayManager.h"
+#include "hardware/output/SevenSegDisplay.h"
+#include "time_mock.h"
+#include "Arduino.h" // resetMockDigitalWriteCallCount / _mockDigitalWriteCallCount
+
+using lattice::app::DisplayManager;
+using lattice::hardware::SevenSegDisplay;
+
+// NOTE: DisplayManager::tick() carries its change-detection state in
+// function-local statics (matching the pre-existing lastToggleMs/dashVisible
+// pattern), so state persists across calls within a single test body — which
+// is exactly what these tests exercise. Each TEST_F below runs as its own
+// process via gtest_discover_tests()'s per-test --gtest_filter invocation,
+// so state does NOT leak between test cases.
+class DisplayManagerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    resetMillis();
+    resetMockDigitalWriteCallCount();
+  }
+};
+
+// Item S: repeated tick() calls with an unchanged (enrolled, isMaster,
+// nodeId) tuple must not re-issue the bit-banged display write.
+TEST_F(DisplayManagerTest, RepeatedTickWithSameValueDoesNotRewriteDisplay) {
+  SevenSegDisplay disp(4, 5);
+
+  DisplayManager::tick(disp, /*enrolled=*/true, /*isMaster=*/false, /*nodeId=*/3);
+  int afterFirst = _mockDigitalWriteCallCount;
+  EXPECT_GT(afterFirst, 0) << "first tick() with a real nodeId must draw something";
+
+  DisplayManager::tick(disp, true, false, 3);
+  EXPECT_EQ(_mockDigitalWriteCallCount, afterFirst) << "unchanged value must not redraw";
+
+  DisplayManager::tick(disp, true, false, 3);
+  EXPECT_EQ(_mockDigitalWriteCallCount, afterFirst) << "unchanged value must not redraw (again)";
+}
+
+TEST_F(DisplayManagerTest, NodeIdChangeTriggersRedraw) {
+  SevenSegDisplay disp(4, 5);
+
+  DisplayManager::tick(disp, true, false, 3);
+  int afterFirst = _mockDigitalWriteCallCount;
+
+  DisplayManager::tick(disp, true, false, 7);
+  EXPECT_GT(_mockDigitalWriteCallCount, afterFirst) << "nodeId change must redraw";
+}
+
+// isMaster can flip live at runtime (dev-mode button hold toggles
+// mesh.setIsMaster()); the throttle must not swallow that even when nodeId
+// is unchanged, since it changes which display method (show vs showWithDP)
+// is used.
+TEST_F(DisplayManagerTest, MasterFlagChangeTriggersRedrawEvenIfNodeIdSame) {
+  SevenSegDisplay disp(4, 5);
+
+  DisplayManager::tick(disp, true, false, 3);
+  int afterFirst = _mockDigitalWriteCallCount;
+
+  DisplayManager::tick(disp, true, true, 3);
+  EXPECT_GT(_mockDigitalWriteCallCount, afterFirst) << "isMaster change must redraw";
+}
+
+// The pre-enroll blink state keeps its own independent 500ms toggle timer
+// (unchanged by item S) and must keep working exactly as before. Note:
+// lastToggleMs and millis() both start at 0, so the very first call doesn't
+// cross the 500ms threshold yet — that's pre-existing behavior, unrelated to
+// item S, and preserved as-is.
+TEST_F(DisplayManagerTest, PreEnrollBlinkTogglesOnlyEvery500ms) {
+  SevenSegDisplay disp(4, 5);
+
+  DisplayManager::tick(disp, /*enrolled=*/false, false, 0);
+  EXPECT_EQ(_mockDigitalWriteCallCount, 0);
+
+  advanceMillis(500);
+  DisplayManager::tick(disp, false, false, 0);
+  int afterToggle = _mockDigitalWriteCallCount;
+  EXPECT_GT(afterToggle, 0) << "500ms elapsed must toggle dash blink";
+
+  // Still within the next 500ms window.
+  advanceMillis(100);
+  DisplayManager::tick(disp, false, false, 0);
+  EXPECT_EQ(_mockDigitalWriteCallCount, afterToggle);
+
+  advanceMillis(400);
+  DisplayManager::tick(disp, false, false, 0);
+  EXPECT_GT(_mockDigitalWriteCallCount, afterToggle) << "next 500ms window must toggle again";
+}
+
+// Re-entering the enrolled branch after a pre-enroll blink must redraw even
+// if nodeId happens to match whatever was last drawn before enrollment.
+TEST_F(DisplayManagerTest, RedrawsOnceEnrolledAfterPreEnrollBlink) {
+  SevenSegDisplay disp(4, 5);
+
+  DisplayManager::tick(disp, true, false, 5); // enrolled, draws nodeId 5
+  int afterEnrolledDraw = _mockDigitalWriteCallCount;
+  EXPECT_GT(afterEnrolledDraw, 0);
+
+  advanceMillis(500); // cross the blink toggle's 500ms threshold
+  DisplayManager::tick(disp, false, false, 0); // drop out of enrolled -> blink path
+  int afterBlink = _mockDigitalWriteCallCount;
+  EXPECT_GT(afterBlink, afterEnrolledDraw);
+
+  // Re-enroll with the SAME nodeId as before (5) — must still redraw since
+  // the display currently shows a blink dash, not the number.
+  DisplayManager::tick(disp, true, false, 5);
+  EXPECT_GT(_mockDigitalWriteCallCount, afterBlink);
+}


### PR DESCRIPTION
## Summary
Phase H2 Task 2 — audit items S + T (`docs/superpowers/specs/2026-08-05-phaseH2-refactor-sweep-design.md`).

- **S — `DisplayManager::tick` throttle**: `display.show()`/`showWithDP()` now only fire when the rendered (nodeId, isMaster) tuple actually changes, instead of every tick(). The 500ms pre-enroll blink timer is untouched. Also tracks `isMaster` and an enrolled-state transition flag beyond the literal brief text — `isMaster` is read live from `mesh.getIsMaster()` every loop and can flip at runtime via the dev-mode button hold, so gating on nodeId alone would silently drop the decimal-point redraw.
- **T — non-blocking `Button::isPressed`**: replaces the old `delay(5)*2` = 10ms blocking majority-vote read with a rolling-vote debounce — samples the pin at most once per 5ms via `millis()`, requires 3 consecutive HIGH samples (<=15ms, inside the 20ms window) before reporting pressed. No `delay()` inside `isPressed()` anymore. `waitForHold()` (confirmed zero callers anywhere in the codebase) is documented as intentionally still blocking.

## Test coverage
Neither file had unit coverage before (`Button.cpp` wasn't even wired into the CMake build). Added:
- `tests/unit/test_button.cpp` (4 tests) — proves the debounce requires 3 consecutive samples, resets on release, and doesn't resample within the 5ms window (non-blocking proof).
- `tests/unit/test_display_manager.cpp` (5 tests) — proves the throttle skips redundant redraws, redraws on nodeId/isMaster change, and the pre-enroll blink timer is unaffected.
- Extended `tests/mocks/Arduino.{h,cpp}` (test-only) with a settable `digitalRead` (was a fixed `return 0` stub) and a `digitalWrite` call counter, needed to observe pin state / display writes from tests. Default behavior (LOW pin, no-op-equivalent writes) is preserved for every existing caller.

## Test plan
- [x] `cmake --build tests/build --parallel` — clean build (0 exit)
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 --label-exclude e2e` — **231/231 passed** (was 222; +9 new)
- [x] `ctest --test-dir tests/build --output-on-failure --parallel 4 -L e2e` — **41/41 passed**, unchanged

No wire changes, firmware-only, no dynamic allocation. Does not touch Task 1 (String elimination, already merged into this branch's base) or Task 3-6 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)