### PR TITLE
refactor(adapter): shared control-op dispatch table + health-frame base (audit V+W)

### DIFF
--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -3,6 +3,8 @@
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include <cstdio>
+#include <cstring>
+#include <esp_wifi.h>
 #include "src/adapter/AdapterFactory.h"
 #include "src/adapter/serial/SerialAdapter.h"
 #include "src/persistence/EepromManager.h"
@@ -40,57 +42,20 @@ void Adapter::setTransmitFn(TransmitPtr fn) {
 }
 
 void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
-  // Handle OP_CONFIG_SET for ALL adapter types — server can reconfigure any node.
-  // This must run in the base class so virtual dispatch to per-type no-ops cannot
-  // swallow the opcode on PIR/LED/WiFi nodes.
-  // OP_CONFIG_SET = 0xC1 (from lib/lattice-protocol/opcodes.h)
+  // Control opcodes (OP_CONFIG_SET, OP_NODE_ID_SET, OP_HEALTH_REQ,
+  // OP_TX_POWER_SET) all travel as SERIAL_ADAPTER-typed data. CONFIG_SET and
+  // NODE_ID_SET must run here, in the base class, for ALL node types so that
+  // virtual dispatch to a per-type no-op (e.g. PIR's onMeshDataImpl) cannot
+  // swallow them — see dispatchControlOp/opConfigSet/opNodeIdSet below.
+  // HEALTH_REQ/TX_POWER_SET are meaningful only to a serial-attached master
+  // and no-op internally for other adapter types (opHealthReq/opTxPowerSet),
+  // reproducing the original behavior where they were reachable only via
+  // SerialAdapter's own code path.
   if (message.data_type == adapter_types::SERIAL_ADAPTER) {
-    const uint8_t op = message.data[0];
-    if (op == OP_CONFIG_SET) {
-      uint8_t ownMac[6];
-      lattice::hw::readOwnMac(ownMac);
-      // Accept broadcast (FF:FF:FF:FF:FF:FF) or unicast to our MAC
-      bool allFF = true;
-      for (int i = 0; i < 6; ++i) {
-        if (message.data[1 + i] != 0xFF) {
-          allFF = false;
-          break;
-        }
-      }
-      bool isTarget = allFF || lattice::mac::eq(&message.data[1], ownMac);
-      if (isTarget) {
-        adapter_types newType =
-            lattice::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
-        lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
-        LATTICE_LOGLN("ADAPTER", "CONFIG_SET received, restarting with new adapter type",
-                      LogLevel::LOG_INFO);
-        ESP.restart();
-      } else {
-        LATTICE_LOGLN("ADAPTER", "CONFIG_SET not targeted to this node, ignoring",
-                      LogLevel::LOG_DEBUG);
-      }
-    }
-    if (op == OP_NODE_ID_SET) {
-      uint8_t ownMac[6];
-      lattice::hw::readOwnMac(ownMac);
-      bool allFF = true;
-      for (int i = 0; i < 6; ++i) {
-        if (message.data[1 + i] != 0xFF) {
-          allFF = false;
-          break;
-        }
-      }
-      bool isTarget = allFF || lattice::mac::eq(&message.data[1], ownMac);
-      if (isTarget) {
-        uint8_t nodeId = message.data[7];
-        lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        char buf[32];
-        snprintf(buf, sizeof(buf), "Node ID assigned: %u", (unsigned)nodeId);
-        LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_INFO);
-      }
-    }
-    // Other SERIAL_ADAPTER opcodes (e.g. OP_HEALTH_REQ) are Serial-node-specific;
-    // fall through to onMeshDataImpl so Serial_Adapter can handle them.
+    dispatchControlOp(message, /*rebroadcastOnMaster=*/false);
+    // Other SERIAL_ADAPTER message types (i.e. not a recognized control
+    // opcode) are Serial-node-specific; fall through to onMeshDataImpl so
+    // Serial_Adapter can handle them (e.g. forwarding to the server).
     if (_adapterType != adapter_types::SERIAL_ADAPTER)
       return;
   }
@@ -113,6 +78,160 @@ void Adapter::onMeshData(const lattice::mesh::mesh_message& message) {
 
 void Adapter::onMeshDataImpl(const lattice::mesh::mesh_message& /*message*/) {
   // Default no-op in base; subclasses optionally override
+}
+
+// ---------------------------------------------------------------------------
+// Phase H2 audit item W: health-report frame builder + shared interval tick.
+// ---------------------------------------------------------------------------
+
+void Adapter::buildHealthFrame(uint8_t opcode, uint8_t* buf, size_t bufsize) const {
+  if (buf == nullptr || bufsize < 12)
+    return;
+  memset(buf, 0, bufsize);
+  buf[0] = opcode;
+  buf[1] = lattice::adapter::AdapterFactory::adapterTypeToEEPROM(_adapterType);
+
+  uint8_t mac[6];
+  lattice::hw::readOwnMac(mac);
+  memcpy(&buf[2], mac, 6);
+
+  uint32_t uptimeSec = millis() / 1000;
+  buf[8] = static_cast<uint8_t>(uptimeSec & 0xFF);
+  buf[9] = static_cast<uint8_t>((uptimeSec >> 8) & 0xFF);
+  buf[10] = static_cast<uint8_t>((uptimeSec >> 16) & 0xFF);
+  buf[11] = static_cast<uint8_t>((uptimeSec >> 24) & 0xFF);
+}
+
+void Adapter::sendSelfHealthReport() const {
+  uint8_t data[64] = {0};
+  buildHealthFrame(OP_HEALTH_REPORT, data, sizeof(data));
+  // This report is ABOUT this node, so use transmitSelfOriginated(): on a
+  // master node, plain transmit() would only broadcast it to mesh peers
+  // (who don't need it) and never deliver it to the master's own serial
+  // port — the only place the server can ever see it.
+  lattice::mesh::Mesh::transmitSelfOriginated(adapter_types::SERIAL_ADAPTER, data);
+  LATTICE_LOGLN("Adapter", "Health report sent via self-originated transmit", LogLevel::LOG_DEBUG);
+}
+
+bool Adapter::healthTickDue(uint32_t now) {
+  if (now - _lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
+    _lastHealthMillis = now;
+    return true;
+  }
+  return false;
+}
+
+void Adapter::resetHealthTick(uint32_t now) {
+  _lastHealthMillis = now;
+}
+
+// ---------------------------------------------------------------------------
+// Phase H2 audit item V: shared control-op dispatch table.
+// ---------------------------------------------------------------------------
+
+bool Adapter::isTargetedAtSelf(const uint8_t* candidateMac) {
+  uint8_t ownMac[6];
+  lattice::hw::readOwnMac(ownMac);
+  // Accept broadcast (FF:FF:FF:FF:FF:FF) or unicast to our MAC
+  bool allFF = true;
+  for (int i = 0; i < 6; ++i) {
+    if (candidateMac[i] != 0xFF) {
+      allFF = false;
+      break;
+    }
+  }
+  return allFF || lattice::mac::eq(candidateMac, ownMac);
+}
+
+void Adapter::opConfigSet(const lattice::mesh::mesh_message& message, bool /*rebroadcastOnMaster*/) {
+  // Wire format: [C1][6B targetMac][1B adapterType] (opcodes.h).
+  if (!isTargetedAtSelf(&message.data[1])) {
+    LATTICE_LOGLN("ADAPTER", "CONFIG_SET not targeted to this node, ignoring", LogLevel::LOG_DEBUG);
+    return;
+  }
+  adapter_types newType = lattice::adapter::AdapterFactory::adapterTypeFromEEPROM(message.data[7]);
+  lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
+  LATTICE_LOGLN("ADAPTER", "CONFIG_SET received, restarting with new adapter type",
+                LogLevel::LOG_INFO);
+  ESP.restart();
+}
+
+void Adapter::opNodeIdSet(const lattice::mesh::mesh_message& message, bool /*rebroadcastOnMaster*/) {
+  // Wire format: [C0][6B targetMAC][1B nodeId] (opcodes.h).
+  if (!isTargetedAtSelf(&message.data[1]))
+    return;
+  uint8_t nodeId = message.data[7];
+  lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
+  char buf[32];
+  snprintf(buf, sizeof(buf), "Node ID set: %u", (unsigned)nodeId);
+  LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_INFO);
+}
+
+void Adapter::opHealthReq(const lattice::mesh::mesh_message& /*message*/,
+                          bool /*rebroadcastOnMaster*/) {
+  // Only the serial-attached master answers HEALTH_REQ over its own serial link.
+  if (_adapterType != adapter_types::SERIAL_ADAPTER)
+    return;
+  LATTICE_LOGLN("ADAPTER", "Received health request, sending health report", LogLevel::LOG_INFO);
+  sendSelfHealthReport();
+}
+
+void Adapter::opTxPowerSet(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster) {
+  // TX power is a radio-wide setting owned by the serial-attached master.
+  if (_adapterType != adapter_types::SERIAL_ADAPTER)
+    return;
+
+  uint8_t presetByte = message.data[1];
+  if (presetByte > 2) {
+    LATTICE_LOGLN("ADAPTER", "Invalid TX power preset, ignoring", LogLevel::LOG_WARN);
+    return;
+  }
+
+  auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
+  lattice::utils::EepromManager::getInstance().saveTxPowerPreset(preset);
+  esp_err_t txErr = esp_wifi_set_max_tx_power(
+      static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
+  if (txErr != ESP_OK) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
+    LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_WARN);
+  } else {
+    LATTICE_LOGLN("ADAPTER", "TX power preset applied", LogLevel::LOG_INFO);
+  }
+
+  // Only propagate onward when the change originated locally (direct-serial
+  // entry point) — a mesh-received TX_POWER_SET has already been broadcast
+  // once and must not be re-broadcast (would loop).
+  if (!rebroadcastOnMaster)
+    return;
+  lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
+  if (meshPtr && meshPtr->getIsMaster()) {
+    uint8_t fwdData[64] = {};
+    fwdData[0] = OP_TX_POWER_SET;
+    fwdData[1] = presetByte;
+    lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER, fwdData);
+    LATTICE_LOGLN("ADAPTER", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
+  }
+}
+
+const Adapter::ControlOpEntry Adapter::kControlOps[] = {
+    {OP_CONFIG_SET, &Adapter::opConfigSet},
+    {OP_NODE_ID_SET, &Adapter::opNodeIdSet},
+    {OP_HEALTH_REQ, &Adapter::opHealthReq},
+    {OP_TX_POWER_SET, &Adapter::opTxPowerSet},
+};
+const size_t Adapter::kControlOpCount = sizeof(kControlOps) / sizeof(kControlOps[0]);
+
+bool Adapter::dispatchControlOp(const lattice::mesh::mesh_message& message,
+                                bool rebroadcastOnMaster) {
+  const uint8_t op = message.data[0];
+  for (size_t i = 0; i < kControlOpCount; ++i) {
+    if (kControlOps[i].opcode == op) {
+      (this->*kControlOps[i].handler)(message, rebroadcastOnMaster);
+      return true;
+    }
+  }
+  return false;
 }
 
 bool Adapter::init() {

--- a/firmware/main/src/adapter/Adapter.h
+++ b/firmware/main/src/adapter/Adapter.h
@@ -2,6 +2,7 @@
 #define ADAPTER_H
 
 #include <Arduino.h>
+#include <cstddef>
 
 // Include generated mesh message type — no circular dependency since lattice-protocol
 // headers only include standard types and each other, not local firmware headers.
@@ -57,6 +58,79 @@ public:
 protected:
   // Implement in subclasses: only called when message.dataType == this adapter's type
   virtual void onMeshDataImpl(const lattice::mesh::mesh_message& message);
+
+  // ------------------------------------------------------------------------
+  // Phase H2 audit item W: health-report frame builder + shared interval tick.
+  // ------------------------------------------------------------------------
+
+  // Builds the health-report payload shared by every adapter's periodic
+  // health report: [opcode][1B adapterType][6B MAC][4B little-endian
+  // uptime-seconds]. Only fills bytes — callers own transmission, since that
+  // differs by adapter (PIR routes through the mesh to reach the master via
+  // sendDataThroughMesh; the serial/master adapter injects directly into its
+  // own outbound serial pipeline via Mesh::transmitSelfOriginated, see
+  // sendSelfHealthReport() below). No-op if bufsize < 12.
+  void buildHealthFrame(uint8_t opcode, uint8_t* buf, size_t bufsize) const;
+
+  // Builds an OP_HEALTH_REPORT frame and delivers it via
+  // Mesh::transmitSelfOriginated. Meaningful only for a node acting as the
+  // serial-attached master (the only adapter with a direct serial link to
+  // the server); shared by SerialAdapter's periodic health tick and the
+  // OP_HEALTH_REQ control-op handler (see dispatchControlOp below).
+  void sendSelfHealthReport() const;
+
+  // Shared "has the health-report interval elapsed" tick used by every
+  // adapter's loop(). Returns true exactly once per HEALTH_REPORT_INTERVAL_MS
+  // and resets the internal timer when it does. Callers that need to reset
+  // the timer early for another reason (e.g. SerialAdapter firing a report
+  // immediately on hop-count change) should call resetHealthTick() themselves
+  // once they've sent.
+  bool healthTickDue(uint32_t now);
+  void resetHealthTick(uint32_t now);
+
+  // ------------------------------------------------------------------------
+  // Phase H2 audit item V: shared control-op dispatch table.
+  // ------------------------------------------------------------------------
+  //
+  // OP_CONFIG_SET / OP_NODE_ID_SET / OP_HEALTH_REQ / OP_TX_POWER_SET are each
+  // handled in exactly one place (below) and reached from both entry points
+  // that see them: the mesh-received path (onMeshData, above) and
+  // SerialAdapter's direct-serial path (handleCompleteFrame). Target-mac
+  // addressing for CONFIG_SET/NODE_ID_SET always comes from the opcode's own
+  // payload (data[1..6] — see lattice-protocol/c/opcodes.h), which both
+  // entry points populate identically, so handlers don't need it supplied
+  // separately. OP_HEALTH_REQ/OP_TX_POWER_SET are meaningful only for a node
+  // acting as the serial-attached master, so those two handlers no-op when
+  // _adapterType isn't SERIAL_ADAPTER — this reproduces the original
+  // behavior where they lived exclusively in SerialAdapter's code path.
+  //
+  // rebroadcastOnMaster: OP_TX_POWER_SET must re-broadcast to the rest of
+  // the mesh only when the preset change was just introduced locally by the
+  // server over direct serial — a TX_POWER_SET received via the mesh has
+  // already been broadcast once and must not be re-broadcast (would loop).
+  using ControlOpFn = void (Adapter::*)(const lattice::mesh::mesh_message&, bool);
+  struct ControlOpEntry {
+    uint8_t opcode;
+    ControlOpFn handler;
+  };
+  static const ControlOpEntry kControlOps[];
+  static const size_t kControlOpCount;
+
+  void opConfigSet(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster);
+  void opNodeIdSet(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster);
+  void opHealthReq(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster);
+  void opTxPowerSet(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster);
+
+  // Looks up message.data[0] in kControlOps and, if present, invokes the
+  // matching handler. Returns true iff a handler ran.
+  bool dispatchControlOp(const lattice::mesh::mesh_message& message, bool rebroadcastOnMaster);
+
+private:
+  // True if candidateMac (a 6-byte MAC) is either this node's own station MAC
+  // or the FF:FF:FF:FF:FF:FF broadcast placeholder.
+  static bool isTargetedAtSelf(const uint8_t* candidateMac);
+
+  uint32_t _lastHealthMillis = 0;
 };
 
 } // namespace adapter

--- a/firmware/main/src/adapter/pir/PirAdapter.cpp
+++ b/firmware/main/src/adapter/pir/PirAdapter.cpp
@@ -1,24 +1,20 @@
 #include "PirAdapter.h"
 #include "lib/lattice-protocol/c/opcodes.h"
 #include <cstdint>
-#include <cstring>
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include "src/mesh/Mesh.h"
-#include "src/adapter/AdapterFactory.h"
-#include "src/network/hw_mac.h"
 
 namespace lattice {
 namespace adapter {
 
 using namespace lattice::utils;
-using lattice::hw::readOwnMac;
 
 PirAdapter* PirAdapter::instance = nullptr;
 
 PirAdapter::PirAdapter(uint8_t pin)
     : Adapter(pin), _pir(pin), _lastTrigger(0), _state(PirState::IDLE), _interruptEnabled(false),
-      _initialized(false), _lastHealthMillis(0) {
+      _initialized(false) {
   _adapterType = adapter_types::PIR_ADAPTER;
 }
 
@@ -66,20 +62,17 @@ void PirAdapter::detectMotion() {
   _pir.detachInterrupt();
 }
 
+// Phase H2 item W: byte layout now built once, in the shared base
+// Adapter::buildHealthFrame(). PIR keeps its own send path (routes through
+// the mesh via sendDataThroughMesh to reach the master) since — unlike
+// SerialAdapter, which has a direct serial link — it has no self-originated
+// transmit path.
 void PirAdapter::sendNodeHealth() {
+  if (!instance)
+    return;
   uint8_t data[64] = {0};
-  data[0] = OP_NODE_HEALTH;
-  data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::PIR_ADAPTER);
-  uint8_t mac[6];
-  readOwnMac(mac);
-  memcpy(&data[2], mac, 6);
-  uint32_t uptimeSec = millis() / 1000;
-  data[8] = static_cast<uint8_t>(uptimeSec & 0xFF);
-  data[9] = static_cast<uint8_t>((uptimeSec >> 8) & 0xFF);
-  data[10] = static_cast<uint8_t>((uptimeSec >> 16) & 0xFF);
-  data[11] = static_cast<uint8_t>((uptimeSec >> 24) & 0xFF);
-  if (instance)
-    instance->sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, data);
+  instance->buildHealthFrame(OP_NODE_HEALTH, data, sizeof(data));
+  instance->sendDataThroughMesh(adapter_types::SERIAL_ADAPTER, data);
 }
 
 void PirAdapter::loop() {
@@ -114,8 +107,8 @@ void PirAdapter::loop() {
     _interruptEnabled = true;
   }
 
-  if (now - _lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
-    _lastHealthMillis = now;
+  // Phase H2 item W: interval tick lives in the shared Adapter base.
+  if (healthTickDue(now)) {
     sendNodeHealth();
   }
 }

--- a/firmware/main/src/adapter/pir/PirAdapter.h
+++ b/firmware/main/src/adapter/pir/PirAdapter.h
@@ -44,7 +44,8 @@ private:
   PirState _state{PirState::IDLE};
   bool _interruptEnabled;
   bool _initialized;
-  uint32_t _lastHealthMillis;
+  // Phase H2 item W: the health-report interval timer moved to the shared
+  // Adapter base (_lastHealthMillis there, driven via healthTickDue()).
 
 #ifdef UNIT_TEST
 public:

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -1,10 +1,7 @@
 #include "SerialAdapter.h"
-#include "src/adapter/AdapterFactory.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
-#include <esp_wifi.h>
 #include "src/mesh/Mesh.h"
-#include "src/network/hw_mac.h"
 #include "src/network/MacEq.h"
 #include <cstring>
 #include <cstdio>
@@ -16,39 +13,13 @@ namespace lattice {
 namespace adapter {
 
 using namespace lattice::utils;
-using lattice::hw::readOwnMac;
 
-uint32_t SerialAdapter::lastHealthMillis = 0;
-
+// Phase H2 item W: frame-building + transmission now live in the shared base
+// Adapter::sendSelfHealthReport() (uses Adapter::buildHealthFrame). This
+// wrapper stays because loop() needs its own callsite/log line.
 void SerialAdapter::sendHealthReport() {
   LATTICE_LOGLN("Serial_Adapter", "Sending health report", LogLevel::LOG_INFO);
-
-  uint8_t data[64] = {0};
-  data[0] = OP_HEALTH_REPORT;
-  data[1] = AdapterFactory::adapterTypeToEEPROM(adapter_types::SERIAL_ADAPTER);
-
-  uint8_t mac[6];
-  readOwnMac(mac);
-  memcpy(&data[2], mac, 6);
-
-  uint32_t uptimeSec = millis() / 1000;
-  data[8] = static_cast<uint8_t>(uptimeSec & 0xFF);
-  data[9] = static_cast<uint8_t>((uptimeSec >> 8) & 0xFF);
-  data[10] = static_cast<uint8_t>((uptimeSec >> 16) & 0xFF);
-  data[11] = static_cast<uint8_t>((uptimeSec >> 24) & 0xFF);
-
-  {
-    char buf[80];
-    snprintf(buf, sizeof(buf), "Health report - MAC: %02X:%02X:%02X:%02X:%02X:%02X Uptime: %lus",
-             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], (unsigned long)uptimeSec);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
-
-  // This report is ABOUT this node, so use transmitSelfOriginated(): on a
-  // master node, plain transmit() would only broadcast it to mesh peers
-  // (who don't need it) and never deliver it to the master's own serial
-  // port — the only place the server can ever see it.
-  lattice::mesh::Mesh::transmitSelfOriginated(adapter_types::SERIAL_ADAPTER, data);
+  sendSelfHealthReport();
   LATTICE_LOGLN("Serial_Adapter", "Health report sent via mesh", LogLevel::LOG_DEBUG);
 }
 
@@ -67,13 +38,21 @@ bool SerialAdapter::init() {
 }
 
 void SerialAdapter::loop() {
-  // Health report: send periodically every 30s, or immediately on hop count change
+  // Health report: send periodically every 30s, or immediately on hop count change.
+  // The interval tick itself (Phase H2 item W) lives in the shared Adapter
+  // base — healthTickDue() both checks and (if due) resets the timer.
   lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
   uint32_t currentHopCount = meshPtr ? meshPtr->getHopCount() : 0;
   bool stateChanged = (currentHopCount != lastReportedHopCount);
 
-  if (stateChanged || millis() - lastHealthMillis >= lattice::config::HEALTH_REPORT_INTERVAL_MS) {
-    lastHealthMillis = static_cast<uint32_t>(millis());
+  uint32_t now = static_cast<uint32_t>(millis());
+  bool intervalDue = healthTickDue(now);
+  if (stateChanged || intervalDue) {
+    // Interval didn't fire on its own but the hop-count change triggers a
+    // report anyway — reset the shared timer so the next periodic report is
+    // still a full interval out, matching the original combined check.
+    if (!intervalDue)
+      resetHealthTick(now);
     {
       char buf[80];
       if (stateChanged) {
@@ -107,35 +86,10 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
     LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
   }
 
-  // Handle control opcodes received via mesh.
-  // NOTE: OP_CONFIG_SET is now handled in Adapter::onMeshData() (base class) so it reaches
-  // ALL node types. Only SerialAdapter-specific opcodes remain here.
-  if (message.data_type == adapter_types::SERIAL_ADAPTER) {
-    uint8_t op = message.data[0];
-    if (op == OP_HEALTH_REQ) {
-      LATTICE_LOGLN("Serial_Adapter", "Received health request via mesh, sending health report",
-                    LogLevel::LOG_INFO);
-      sendHealthReport();
-    } else if (op == OP_TX_POWER_SET) {
-      uint8_t presetByte = message.data[1];
-      if (presetByte > 2) {
-        LATTICE_LOGLN("Serial_Adapter", "Invalid TX power preset from mesh, ignoring",
-                      LogLevel::LOG_WARN);
-      } else {
-        auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
-        EepromManager::getInstance().saveTxPowerPreset(preset);
-        esp_err_t txErr = esp_wifi_set_max_tx_power(
-            static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
-        if (txErr != ESP_OK) {
-          char buf[64];
-          snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
-          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
-        } else {
-          LATTICE_LOGLN("Serial_Adapter", "TX power preset applied from mesh", LogLevel::LOG_INFO);
-        }
-      }
-    }
-  }
+  // Control opcodes (CONFIG_SET/NODE_ID_SET/HEALTH_REQ/TX_POWER_SET) received
+  // via mesh are all handled once, in Adapter::onMeshData() (base class),
+  // before onMeshDataImpl() is ever invoked — see the shared dispatch table
+  // in Adapter.h/.cpp (Phase H2 item V). Nothing left to do for them here.
 
   // Forward message to server via serial (existing encoding logic)
   uint8_t encoded[256];
@@ -330,7 +284,13 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
   }
 
-  // Handle control opcodes: CONFIG_SET, HEALTH_REQ
+  // Control opcodes (CONFIG_SET/NODE_ID_SET/HEALTH_REQ/TX_POWER_SET), sent by
+  // the server directly to this (master) node over serial. Phase H2 item V:
+  // shared with the mesh-received path through Adapter::dispatchControlOp
+  // (see Adapter.h/.cpp) instead of being handled again here.
+  // rebroadcastOnMaster=true: a TX_POWER_SET originating here (direct serial)
+  // must still propagate to the rest of the mesh, unlike one arriving via the
+  // mesh itself (already broadcast once).
   if (msg.data_type == adapter_types::SERIAL_ADAPTER) {
     uint8_t op = msg.data[0];
     {
@@ -339,95 +299,8 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
       LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
     }
 
-    if (op == OP_HEALTH_REQ) {
-      LATTICE_LOGLN("Serial_Adapter", "Received health request, sending health report",
-                    LogLevel::LOG_INFO);
-      sendHealthReport();
-    } else if (op == OP_CONFIG_SET) {
-      LATTICE_LOGLN("Serial_Adapter", "Received configuration set request", LogLevel::LOG_INFO);
-
-      // Apply only if targeted to me (or broadcast FF:..:FF)
-      uint8_t myMac[6];
-      readOwnMac(myMac);
-      bool allFF = true;
-      for (int i = 0; i < 6; ++i)
-        if (msg.target_mac_address[i] != 0xFF) {
-          allFF = false;
-          break;
-        }
-      bool isTarget = allFF || lattice::mac::eq(msg.target_mac_address, myMac);
-
-      if (isTarget) {
-        adapter_types newType = AdapterFactory::adapterTypeFromEEPROM(msg.data[7]);
-        {
-          char buf[80];
-          snprintf(buf, sizeof(buf),
-                   "Configuration applies to this node, setting adapter type to: %ld",
-                   (long)static_cast<int32_t>(newType));
-          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
-        }
-
-        lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(newType);
-        LATTICE_LOGLN("Serial_Adapter", "Adapter type saved to EEPROM successfully",
-                      LogLevel::LOG_INFO);
-        // Pin is automatically inferred from adapter type - no need to store it
-        // Let main recreate adapter on next boot or we could soft-switch by signaling
-        // error-led+restart
-        LATTICE_LOGLN("Serial_Adapter", "Restarting device to apply new configuration",
-                      LogLevel::LOG_INFO);
-        ESP.restart();
-      } else {
-        LATTICE_LOGLN("Serial_Adapter", "Configuration not targeted to this node, ignoring",
-                      LogLevel::LOG_DEBUG);
-      }
-    } else if (op == OP_TX_POWER_SET) {
-      LATTICE_LOGLN("Serial_Adapter", "Received TX power preset update", LogLevel::LOG_INFO);
-      uint8_t presetByte = msg.data[1];
-      if (presetByte > 2) {
-        LATTICE_LOGLN("Serial_Adapter", "Invalid TX power preset, ignoring", LogLevel::LOG_WARN);
-      } else {
-        auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
-        EepromManager::getInstance().saveTxPowerPreset(preset);
-        esp_err_t txErr = esp_wifi_set_max_tx_power(
-            static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
-        if (txErr != ESP_OK) {
-          char buf[64];
-          snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
-          LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
-        } else {
-          LATTICE_LOGLN("Serial_Adapter", "TX power preset updated", LogLevel::LOG_INFO);
-        }
-
-        // Broadcast to all enrolled nodes so entire mesh updates
-        lattice::mesh::Mesh* meshPtr = lattice::mesh::Mesh::getInstance();
-        bool isMasterNode = meshPtr && meshPtr->getIsMaster();
-        if (isMasterNode) {
-          uint8_t fwdData[64] = {};
-          fwdData[0] = OP_TX_POWER_SET;
-          fwdData[1] = presetByte;
-          lattice::mesh::Mesh::broadcastAdapterDataStatic(adapter_types::SERIAL_ADAPTER, fwdData);
-          LATTICE_LOGLN("Serial_Adapter", "TX power preset broadcast to mesh", LogLevel::LOG_INFO);
-        }
-      }
-    } else if (op == OP_NODE_ID_SET) {
-      LATTICE_LOGLN("Serial_Adapter", "Received node ID set request", LogLevel::LOG_INFO);
-      uint8_t myMac[6];
-      readOwnMac(myMac);
-      bool allFF = true;
-      for (int i = 0; i < 6; ++i)
-        if (msg.data[1 + i] != 0xFF) {
-          allFF = false;
-          break;
-        }
-      bool isTarget = allFF || lattice::mac::eq(&msg.data[1], myMac);
-      if (isTarget) {
-        uint8_t nodeId = msg.data[7];
-        lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
-        char buf[32];
-        snprintf(buf, sizeof(buf), "Node ID set: %u", (unsigned)nodeId);
-        LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
-      }
-    } else {
+    bool handled = dispatchControlOp(msg, /*rebroadcastOnMaster=*/true);
+    if (!handled) {
       char buf[64];
       snprintf(buf, sizeof(buf), "Unknown SERIAL_ADAPTER opcode: 0x%02X", op);
       LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);

--- a/firmware/main/src/adapter/serial/SerialAdapter.h
+++ b/firmware/main/src/adapter/serial/SerialAdapter.h
@@ -38,6 +38,11 @@ public:
   // Relay a completed enrollment public key to the server over serial
   static void relayEnrollmentToServer(const uint8_t* mac, const uint8_t* pubKey);
 
+  // Phase H2 item V: OP_CONFIG_SET/OP_NODE_ID_SET/OP_HEALTH_REQ/OP_TX_POWER_SET
+  // handling now lives once, in the shared Adapter::dispatchControlOp table
+  // (see Adapter.h/.cpp), reached from both onMeshData() (mesh-received) and
+  // handleCompleteFrame() (direct serial) below.
+
 #if SIMULATE_MODE
   // WARNING: SIMULATE_MODE opcodes 0xD0-0xD2 overlap with OP_LED_SOLID/OFF/BLINK from the
   // shared protocol. SIMULATE_MODE must never be enabled alongside LED output handling.
@@ -58,15 +63,9 @@ private:
   // MESH_TYPE_SERIAL_CMD_BROADCAST (3) : broadcast adapter data via mesh (server→device)
   // MESH_TYPE_JOIN_ACK (4)             : server approved or rejected enrollment (server→device)
 
-  // Health reporter
-  static void sendHealthReport();
-
-#ifdef UNIT_TEST
-public:
-#else
-private:
-#endif
-  static uint32_t lastHealthMillis;
+  // Health reporter — thin wrapper around the shared Adapter::sendSelfHealthReport()
+  // (Phase H2 item W); kept as its own method since it's called from loop().
+  void sendHealthReport();
 
 private:
   uint32_t lastReportedHopCount;

--- a/tests/e2e/harness/NodeContext.cpp
+++ b/tests/e2e/harness/NodeContext.cpp
@@ -71,7 +71,6 @@ void swapIn(NodeContext& ctx) {
   ESP._restartRequested = ctx.espRestartRequested;
   lattice::mesh::Mesh::instance = ctx.meshInstance;
   lattice::adapter::PirAdapter::instance = ctx.pirInstance;
-  lattice::adapter::SerialAdapter::lastHealthMillis = ctx.serialAdapterLastHealthMillis;
   loadImage(lattice::utils::EepromManager::getInstance(), ctx.eepromManagerImage);
   loadImage(lattice::utils::ErrorCore::getInstance(), ctx.errorCoreImage);
 }
@@ -90,7 +89,6 @@ void swapOut(NodeContext& ctx) {
   ctx.espRestartRequested = ESP._restartRequested;
   ctx.meshInstance = lattice::mesh::Mesh::instance;
   ctx.pirInstance = lattice::adapter::PirAdapter::instance;
-  ctx.serialAdapterLastHealthMillis = lattice::adapter::SerialAdapter::lastHealthMillis;
   saveImage(lattice::utils::EepromManager::getInstance(), ctx.eepromManagerImage);
   saveImage(lattice::utils::ErrorCore::getInstance(), ctx.errorCoreImage);
 }

--- a/tests/e2e/harness/NodeContext.h
+++ b/tests/e2e/harness/NodeContext.h
@@ -40,7 +40,11 @@ struct NodeContext {
   // Firmware statics
   lattice::mesh::Mesh* meshInstance = nullptr;
   lattice::adapter::PirAdapter* pirInstance = nullptr;
-  uint32_t serialAdapterLastHealthMillis = 0;
+  // Phase H2 item W: the health-report interval timer moved from a
+  // SerialAdapter-static (process-global, needed swapping here) to a plain
+  // Adapter instance member (Adapter::_lastHealthMillis). Each SimNode owns
+  // its own Adapter object (see SimNode::adapter_), so that state is already
+  // node-isolated and no longer needs a slot here.
   // Singleton object byte-images (EepromManager, ErrorCore hold per-node flags/pointers;
   // copy ctors are deleted so we snapshot raw bytes — states are flat PODs + raw pointers)
   std::vector<uint8_t> eepromManagerImage;


### PR DESCRIPTION
## Summary
- **V**: `OP_CONFIG_SET`/`OP_NODE_ID_SET`/`OP_HEALTH_REQ`/`OP_TX_POWER_SET` were each handled twice across `Adapter::onMeshData` and `SerialAdapter`'s two entry points (~150 duplicated lines). Collapsed into one static `{opcode -> handler}` table on `Adapter`, shared by both the mesh-received and direct-serial paths (`Adapter::dispatchControlOp`). `OP_TX_POWER_SET`'s mesh-rebroadcast (only correct when the change originates on the direct-serial path, to avoid a loop) is preserved via an explicit `rebroadcastOnMaster` flag per call site.
- **W**: `PirAdapter::sendNodeHealth`/`SerialAdapter::sendHealthReport` built an identical health-report byte layout by hand. Extracted `Adapter::buildHealthFrame` (opcode + adapterType + MAC + LE-32 uptime) and moved the `_lastHealthMillis` interval tick to the `Adapter` base (`healthTickDue`/`resetHealthTick`); each adapter keeps its own transmission path (PIR routes through the mesh, Serial injects directly via `transmitSelfOriginated`).
- Fallout: updated `tests/e2e/harness/NodeContext.{h,cpp}` — the `SerialAdapter`-static `lastHealthMillis` the harness swapped per simulated node no longer exists now that the timer is a plain `Adapter` instance member (each `SimNode` already owns its own `Adapter`, so no swap is needed).

One judgment call worth a second look: `SerialAdapter::handleCompleteFrame`'s original `OP_CONFIG_SET` handler used the top-level `target_mac_address` envelope field, while every other CONFIG_SET/NODE_ID_SET site used the opcode's own payload field (`data[1..6]`, matching the documented wire format). Traced every constructor of a CONFIG_SET frame in the tree — all set both fields identically — and normalized onto the payload field so the shared handler doesn't need a caller-supplied target pointer. Full writeup of this and the TX_POWER_SET rebroadcast preservation in the task report (not included in this PR — local/gitignored).

## Test plan
- [x] `cmake --build tests/build --parallel 2` — clean, no new warnings
- [x] `ctest --test-dir tests/build --parallel 1 --output-on-failure` — **278/278 passed**, including `PIRHealthTest.*`, `FakeHubTest.ReceivesHealthReportAndAnswersHealthReq`, `ServerBroadcastTest.ConfigSetReachesNodeAdapterAndPersists`, `MasterHealthTest.*`, `MeshSimTest.ConfigSetForOtherNodeIsIgnored`, `MeshSimTest.MasterSendsSealedConfigSetThroughRelayToLeaf`, `MeshSimTest.PirNodeHealthReachesHub`, `DualMasterTest.ConfigSetFromSecondaryMasterIsHonoredAfterFailover`, `ConfigOpcodeInjectionTest.*`
- [ ] `idf.py build` — skipped, no ESP-IDF toolchain in this environment (`$HOME/esp/esp-idf` absent, `idf.py`/`pio` not on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)