### PR TITLE
refactor(persistence+error): singleton -> namespace (item AA)

### DIFF
--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -58,7 +58,7 @@ constexpr int NUM_DEFAULT_PEERS = lattice::config::NUM_DEFAULT_PEERS;
 // Validate configuration for server communication
 static inline void validateServerConfiguration() {
   // Check if this is a master node intended for server communication
-  bool isMasterNode = isDevMode ? devMasterFlag : EepromManager::getInstance().loadMasterFlag();
+  bool isMasterNode = isDevMode ? devMasterFlag : lattice::eeprom::loadMasterFlag();
   bool hasSerialAdapter = (adapter && adapter->getAdapterType() == lattice::adapter::adapter_types::SERIAL_ADAPTER);
   bool loggingDisabled = (lattice::config::DEFAULT_LOG_LEVEL == lattice::utils::LogLevel::LOG_NONE);
   
@@ -96,8 +96,8 @@ void setup() {
 
   // Check and log reset reason; escalate if WDT looping
   // Must init EEPROM before BootManager::check — saveRebootReason/saveRebootCount no-op if not initialized
-  EepromManager::getInstance().init();
-  lattice::app::BootManager::check(EepromManager::getInstance());
+  lattice::eeprom::init();
+  lattice::app::BootManager::check();
 
   Logger::logln("MAIN", "Logger initialized", LogLevel::LOG_INFO);
 
@@ -121,9 +121,9 @@ void setup() {
   // Seven segment conditional init
   if (lattice::config::ENABLE_SEVSEG_DISPLAY) {
     sevenSeg.init();
-    lattice::utils::ErrorCore::getInstance().init(&redLed, &sevenSeg);
+    lattice::err_core::init(&redLed, &sevenSeg);
   } else {
-    lattice::utils::ErrorCore::getInstance().init(&redLed, nullptr);
+    lattice::err_core::init(&redLed, nullptr);
   }
 
   if (!greenLed.isInitialized()) {
@@ -147,7 +147,7 @@ void setup() {
   }
 
   // Initialize EEPROM Manager
-  if (!EepromManager::getInstance().init()) {
+  if (!lattice::eeprom::init()) {
     Logger::logln("MAIN", "Failed to initialize EEPROM Manager", LogLevel::LOG_ERROR);
     lattice::err::fatal(lattice::core::ErrorTypeDigit::MEMORY,
                           lattice::core::ModuleDigit::CORE,
@@ -161,19 +161,19 @@ void setup() {
   isDevMode = DEV_MODE;
   if (!isDevMode) {
     // If not compile-time dev mode, check EEPROM
-    isDevMode = EepromManager::getInstance().loadDevFlag();
+    isDevMode = lattice::eeprom::loadDevFlag();
   }
 
   Logger::logln("MAIN", String("Running in ") + (isDevMode ? "DEV" : "PRODUCTION") + " mode", LogLevel::LOG_INFO);
 
   // Set dev mode in AdapterFactory and EEPROM Manager
   lattice::adapter::AdapterFactory::setDevMode(isDevMode);
-  EepromManager::getInstance().setDevMode(isDevMode);
+  lattice::eeprom::setDevMode(isDevMode);
 
   // Declare peers to EEPROM (only if not in dev mode and EEPROM is empty)
-  if (!isDevMode && !EepromManager::getInstance().hasPeers()) {
+  if (!isDevMode && !lattice::eeprom::hasPeers()) {
     // Write default peers to EEPROM
-    EepromManager::getInstance().savePeerList(
+    lattice::eeprom::savePeerList(
       reinterpret_cast<const uint8_t*>(defaultPeerList),
       NUM_DEFAULT_PEERS);
     Logger::logln("MAIN", "Wrote default peer MACs to EEPROM.", LogLevel::LOG_INFO);
@@ -252,7 +252,7 @@ void setup() {
     Logger::logln("MAIN", String("DEV mode: starting as ") + (isMaster ? "MASTER" : "NODE"), LogLevel::LOG_INFO);
   } else {
     // In production mode, load from EEPROM
-    isMaster = EepromManager::getInstance().loadMasterFlag();
+    isMaster = lattice::eeprom::loadMasterFlag();
   }
 
   // Master keeps 240MHz for serial USB reliability
@@ -284,7 +284,7 @@ void setup() {
 }
 
 void loop() {
-  lattice::utils::ErrorCore::getInstance().drainPendingBlink();
+  lattice::err_core::drainPendingBlink();
 
   static bool startupBlinkDone = false;
   if (!startupBlinkDone) {
@@ -300,7 +300,7 @@ void loop() {
   // Display state machine: show node identity on 7-segment display
   if (lattice::config::ENABLE_SEVSEG_DISPLAY) {
     bool enrolled = mesh.isEnrolled() || mesh.getIsMaster();
-    uint8_t nodeId = lattice::utils::EepromManager::getInstance().loadNodeId();
+    uint8_t nodeId = lattice::eeprom::loadNodeId();
     lattice::app::DisplayManager::tick(sevenSeg, enrolled, mesh.getIsMaster(), nodeId);
   }
 
@@ -325,7 +325,6 @@ void loop() {
   }
 
   lattice::app::ButtonHandler::tick(configButton, resetButton, mesh,
-    lattice::utils::EepromManager::getInstance(),
     greenLed, redLed, isDevMode, devMasterFlag);
   // REMOVED: periodic health report was here.
   // Serial_Adapter::loop() handles this correctly when adapter type is SERIAL_ADAPTER.

--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -161,7 +161,7 @@ void Adapter::opNodeIdSet(const lattice::mesh::mesh_message& message, bool /*reb
   if (!isTargetedAtSelf(&message.data[1]))
     return;
   uint8_t nodeId = message.data[7];
-  lattice::utils::EepromManager::getInstance().saveNodeId(nodeId);
+  lattice::eeprom::saveNodeId(nodeId);
   char buf[32];
   snprintf(buf, sizeof(buf), "Node ID set: %u", (unsigned)nodeId);
   LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_INFO);
@@ -188,7 +188,7 @@ void Adapter::opTxPowerSet(const lattice::mesh::mesh_message& message, bool rebr
   }
 
   auto preset = static_cast<lattice::config::TxPowerPreset>(presetByte);
-  lattice::utils::EepromManager::getInstance().saveTxPowerPreset(preset);
+  lattice::eeprom::saveTxPowerPreset(preset);
   esp_err_t txErr = esp_wifi_set_max_tx_power(
       static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
   if (txErr != ESP_OK) {

--- a/firmware/main/src/adapter/AdapterFactory.cpp
+++ b/firmware/main/src/adapter/AdapterFactory.cpp
@@ -55,7 +55,7 @@ adapter_types AdapterFactory::loadAdapterTypeFromEEPROM() {
     return adapter_types::PIR_ADAPTER; // Always return default in dev mode
   }
 
-  uint8_t adapterType = EepromManager::getInstance().loadAdapterType();
+  uint8_t adapterType = lattice::eeprom::loadAdapterType();
   return adapterTypeFromEEPROM(adapterType);
 }
 
@@ -66,7 +66,7 @@ void AdapterFactory::saveAdapterTypeToEEPROM(adapter_types type) {
     return; // Don't save to EEPROM in dev mode
   }
 
-  EepromManager::getInstance().saveAdapterType(adapterTypeToEEPROM(type));
+  lattice::eeprom::saveAdapterType(adapterTypeToEEPROM(type));
 }
 
 Adapter* AdapterFactory::createFromEEPROM() {
@@ -82,9 +82,9 @@ void AdapterFactory::initializeDefaultsIfUnset() {
   }
 
   // Check if adapter type is unset (0xFF) and set default if needed
-  uint8_t currentType = EepromManager::getInstance().loadAdapterType();
+  uint8_t currentType = lattice::eeprom::loadAdapterType();
   if (currentType == 0xFF) {
-    EepromManager::getInstance().saveAdapterType(adapterTypeToEEPROM(adapter_types::PIR_ADAPTER));
+    lattice::eeprom::saveAdapterType(adapterTypeToEEPROM(adapter_types::PIR_ADAPTER));
   }
 }
 

--- a/firmware/main/src/app/BootManager.h
+++ b/firmware/main/src/app/BootManager.h
@@ -8,13 +8,13 @@ namespace lattice {
 namespace app {
 
 struct BootManager {
-  static void check(lattice::utils::EepromManager& em) {
+  static void check() {
     esp_reset_reason_t reason = esp_reset_reason();
-    em.saveRebootReason(static_cast<uint8_t>(reason));
+    lattice::eeprom::saveRebootReason(static_cast<uint8_t>(reason));
     if (reason == ESP_RST_WDT || reason == ESP_RST_TASK_WDT || reason == ESP_RST_INT_WDT) {
-      uint8_t count = em.loadRebootCount();
+      uint8_t count = lattice::eeprom::loadRebootCount();
       count++;
-      em.saveRebootCount(count);
+      lattice::eeprom::saveRebootCount(count);
       Serial.printf("[BOOT] WDT reset #%d (reason: %d)\n", count, (int)reason);
       if (count >= 5) {
         Serial.println("[BOOT] WDT loop detected — halting. Manual reset required.");
@@ -23,7 +23,7 @@ struct BootManager {
         }
       }
     } else {
-      em.saveRebootCount(0);
+      lattice::eeprom::saveRebootCount(0);
     }
   }
 };

--- a/firmware/main/src/app/ButtonHandler.h
+++ b/firmware/main/src/app/ButtonHandler.h
@@ -14,16 +14,16 @@ struct ButtonHandler {
   static constexpr unsigned long HOLD_MS = 5000;
 
   static void tick(lattice::hardware::Button& configBtn, lattice::hardware::Button& resetBtn,
-                   lattice::mesh::Mesh& mesh, lattice::utils::EepromManager& em,
+                   lattice::mesh::Mesh& mesh,
                    lattice::hardware::Led& greenLed, lattice::hardware::Led& redLed, bool isDevMode,
                    bool& devMasterFlag) {
-    tickConfig(configBtn, mesh, em, greenLed, isDevMode, devMasterFlag);
-    tickReset(resetBtn, em, greenLed, redLed);
+    tickConfig(configBtn, mesh, greenLed, isDevMode, devMasterFlag);
+    tickReset(resetBtn, greenLed, redLed);
   }
 
 private:
   static void tickConfig(lattice::hardware::Button& btn, lattice::mesh::Mesh& mesh,
-                         lattice::utils::EepromManager& em, lattice::hardware::Led& greenLed,
+                         lattice::hardware::Led& greenLed,
                          bool isDevMode, bool& devMasterFlag) {
     static bool wasPressed = false;
     static unsigned long holdStart = 0;
@@ -46,9 +46,9 @@ private:
           }
           greenLed.blink(newMaster ? 3 : 2, 150, 150);
         } else {
-          bool wasMaster = em.loadMasterFlag();
+          bool wasMaster = lattice::eeprom::loadMasterFlag();
           bool newMaster = !wasMaster;
-          em.saveMasterFlag(newMaster);
+          lattice::eeprom::saveMasterFlag(newMaster);
           {
             char buf[64];
             snprintf(buf, sizeof(buf), "Button held 5s: CONFIG TOGGLED. Now %s",
@@ -59,7 +59,7 @@ private:
                         lattice::utils::LogLevel::LOG_INFO);
           greenLed.blink(newMaster ? 3 : 2, 200, 200);
           delay(2000);
-          em.forceFlush();
+          lattice::eeprom::forceFlush();
           ESP.restart();
         }
       }
@@ -68,7 +68,7 @@ private:
     }
   }
 
-  static void tickReset(lattice::hardware::Button& btn, lattice::utils::EepromManager& em,
+  static void tickReset(lattice::hardware::Button& btn,
                         lattice::hardware::Led& greenLed, lattice::hardware::Led& redLed) {
     static bool wasPressed = false;
     static unsigned long holdStart = 0;
@@ -91,11 +91,11 @@ private:
           confirmPending = false;
           LATTICE_LOGLN("MAIN", "EEPROM wipe confirmed. Clearing all...",
                         lattice::utils::LogLevel::LOG_WARN);
-          em.clearAll();
+          lattice::eeprom::clearAll();
           redLed.blink(5, 100, 100);
           greenLed.blink(5, 100, 100);
           delay(3000);
-          em.forceFlush();
+          lattice::eeprom::forceFlush();
           ESP.restart();
         }
       }

--- a/firmware/main/src/error/Error.h
+++ b/firmware/main/src/error/Error.h
@@ -50,7 +50,7 @@ inline bool fail(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit
   ++::lattice_test_errFailCount;
 #endif
   LATTICE_LOGLN("ERROR", msg, utils::LogLevel::LOG_ERROR);
-  utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
+  err_core::signalError(t, m, sub, msg);
   return false;
 }
 
@@ -61,7 +61,7 @@ inline bool fail(utils::ErrorType type, const char* msg) {
 [[noreturn]] inline void fatal(::lattice::core::ErrorTypeDigit t, ::lattice::core::ModuleDigit m,
                                uint8_t sub, const char* msg) {
   LATTICE_LOGLN("FATAL", msg, utils::LogLevel::LOG_ERROR);
-  utils::ErrorCore::getInstance().signalError(t, m, sub, msg);
+  err_core::signalError(t, m, sub, msg);
 #ifdef UNIT_TEST
   throw FatalError(msg ? msg : "fatal");
 #else

--- a/firmware/main/src/error/ErrorCore.cpp
+++ b/firmware/main/src/error/ErrorCore.cpp
@@ -6,71 +6,16 @@
 using lattice::core::ErrorTypeDigit;
 using lattice::core::makeErrorCode;
 using lattice::core::ModuleDigit;
-namespace lattice {
-namespace utils {
-ErrorCore::ErrorCore()
-    : _errorLed(nullptr), _display(nullptr), _initialized(false), _pendingBlink(false),
-      _pendingBlinkType(ErrorType::GENERIC), _inCallbackContext(false) {}
-ErrorCore& ErrorCore::getInstance() {
-  static ErrorCore i;
-  return i;
-}
-void ErrorCore::init(hardware::Led* led, hardware::SevenSegDisplay* display) {
-  _errorLed = led;
-  _display = display;
-  _initialized = (_errorLed != nullptr);
-  auto r = esp_reset_reason();
-  if (r != ESP_RST_POWERON && r != ESP_RST_SW && r != ESP_RST_EXT) {
-    signalError(ErrorTypeDigit::HARDWARE, ModuleDigit::CORE, 1, "Unexpected reset");
-  }
-  LATTICE_LOGLN("ErrorCore", "Initialized", LogLevel::LOG_INFO);
-}
-void ErrorCore::signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const char* msg) {
-  uint16_t code = makeErrorCode(t, m, sub);
-  if (_display)
-    _display->show(static_cast<int>(code));
-  ErrorType lt = ErrorType::GENERIC;
-  if (t == ErrorTypeDigit::HARDWARE)
-    lt = ErrorType::HARDWARE_FAILURE;
-  else if (t == ErrorTypeDigit::COMM)
-    lt = ErrorType::COMMUNICATION_FAIL;
-  else if (t == ErrorTypeDigit::MEMORY)
-    lt = ErrorType::MEMORY_ERROR;
-  else if (t == ErrorTypeDigit::CONFIG)
-    lt = ErrorType::CONFIG_ERROR;
-  else if (t == ErrorTypeDigit::CRYPTO)
-    // AEAD/ECDH failures (e.g. Phase A epoch-rollback guard) are security-
-    // critical and must halt the node, same as a hardware fault — there is no
-    // safe way to continue running past a would-be AEAD nonce reuse.
-    lt = ErrorType::HARDWARE_FAILURE;
-  signalError(lt, msg);
-}
-void ErrorCore::signalError(ErrorType type, const char* msg) {
-  if (msg) {
-    char buf[96];
-    snprintf(buf, sizeof(buf), "ERROR: %s", msg);
-    LATTICE_LOGLN("Error", buf, LogLevel::LOG_ERROR);
-  }
-  if (_initialized && _errorLed) {
-    if (_inCallbackContext) {
-      // Defer blink to main loop — never block in callback context
-      _pendingBlink = true;
-      _pendingBlinkType = type;
-    } else {
-      blinkPattern(type);
-    }
-  }
-  if (shouldRestart(type))
-    restartDevice();
-}
+using lattice::utils::ErrorType;
 
-void ErrorCore::drainPendingBlink() {
-  if (_pendingBlink) {
-    _pendingBlink = false;
-    blinkPattern(_pendingBlinkType);
-  }
-}
-void ErrorCore::blinkPattern(ErrorType t) {
+namespace lattice {
+namespace err_core {
+
+namespace {
+
+detail::State _state;
+
+void blinkPattern(ErrorType t) {
   int b = 1;
   switch (t) {
   case ErrorType::GENERIC:
@@ -100,19 +45,92 @@ void ErrorCore::blinkPattern(ErrorType t) {
   default:
     b = 1;
   }
-  if (_errorLed && _errorLed->isInitialized())
-    _errorLed->blink(b, 200, 200);
+  if (_state.errorLed && _state.errorLed->isInitialized())
+    _state.errorLed->blink(b, 200, 200);
 }
-bool ErrorCore::shouldRestart(ErrorType t) const {
+
+bool shouldRestart(ErrorType t) {
   return t == ErrorType::MEMORY_ERROR || t == ErrorType::HARDWARE_FAILURE;
 }
-[[noreturn]] void ErrorCore::restartDevice() {
-  LATTICE_LOGLN("ErrorCore", "Restarting device...", LogLevel::LOG_WARN);
+
+[[noreturn]] void restartDevice() {
+  LATTICE_LOGLN("ErrorCore", "Restarting device...", lattice::utils::LogLevel::LOG_WARN);
 #ifdef UNIT_TEST
   throw lattice::err::FatalError("ErrorCore::restartDevice");
 #else
   ESP.restart();
 #endif
 }
-} // namespace utils
+
+} // namespace
+
+void init(hardware::Led* led, hardware::SevenSegDisplay* display) {
+  _state.errorLed = led;
+  _state.display = display;
+  _state.initialized = (_state.errorLed != nullptr);
+  auto r = esp_reset_reason();
+  if (r != ESP_RST_POWERON && r != ESP_RST_SW && r != ESP_RST_EXT) {
+    signalError(ErrorTypeDigit::HARDWARE, ModuleDigit::CORE, 1, "Unexpected reset");
+  }
+  LATTICE_LOGLN("ErrorCore", "Initialized", lattice::utils::LogLevel::LOG_INFO);
+}
+
+void signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const char* msg) {
+  uint16_t code = makeErrorCode(t, m, sub);
+  if (_state.display)
+    _state.display->show(static_cast<int>(code));
+  ErrorType lt = ErrorType::GENERIC;
+  if (t == ErrorTypeDigit::HARDWARE)
+    lt = ErrorType::HARDWARE_FAILURE;
+  else if (t == ErrorTypeDigit::COMM)
+    lt = ErrorType::COMMUNICATION_FAIL;
+  else if (t == ErrorTypeDigit::MEMORY)
+    lt = ErrorType::MEMORY_ERROR;
+  else if (t == ErrorTypeDigit::CONFIG)
+    lt = ErrorType::CONFIG_ERROR;
+  else if (t == ErrorTypeDigit::CRYPTO)
+    // AEAD/ECDH failures (e.g. Phase A epoch-rollback guard) are security-
+    // critical and must halt the node, same as a hardware fault — there is no
+    // safe way to continue running past a would-be AEAD nonce reuse.
+    lt = ErrorType::HARDWARE_FAILURE;
+  signalError(lt, msg);
+}
+
+void signalError(ErrorType type, const char* msg) {
+  if (msg) {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "ERROR: %s", msg);
+    LATTICE_LOGLN("Error", buf, lattice::utils::LogLevel::LOG_ERROR);
+  }
+  if (_state.initialized && _state.errorLed) {
+    if (_state.inCallbackContext) {
+      // Defer blink to main loop — never block in callback context
+      _state.pendingBlink = true;
+      _state.pendingBlinkType = type;
+    } else {
+      blinkPattern(type);
+    }
+  }
+  if (shouldRestart(type))
+    restartDevice();
+}
+
+void setCallbackContext(bool inCallback) {
+  _state.inCallbackContext = inCallback;
+}
+
+void drainPendingBlink() {
+  if (_state.pendingBlink) {
+    _state.pendingBlink = false;
+    blinkPattern(_state.pendingBlinkType);
+  }
+}
+
+#ifdef UNIT_TEST
+detail::State& debugStateForTest() {
+  return _state;
+}
+#endif
+
+} // namespace err_core
 } // namespace lattice

--- a/firmware/main/src/error/ErrorCore.h
+++ b/firmware/main/src/error/ErrorCore.h
@@ -18,30 +18,43 @@ enum class ErrorType : uint8_t {
   USER_ERROR = 6,
   TIMEOUT_ERROR = 7
 };
-class ErrorCore {
-public:
-  static ErrorCore& getInstance();
-  void init(lattice::hardware::Led* led, lattice::hardware::SevenSegDisplay* display = nullptr);
-  void signalError(core::ErrorTypeDigit t, core::ModuleDigit m, uint8_t sub,
-                   const char* msg = nullptr);
-  void signalError(ErrorType type, const char* msg = nullptr);
-  void setCallbackContext(bool inCallback) { _inCallbackContext = inCallback; }
-  void drainPendingBlink(); // Call from main loop
-  ErrorCore(const ErrorCore&) = delete;
-  ErrorCore& operator=(const ErrorCore&) = delete;
-
-private:
-  ErrorCore();
-  lattice::hardware::Led* _errorLed;
-  lattice::hardware::SevenSegDisplay* _display;
-  bool _initialized;
-  volatile bool _pendingBlink;
-  ErrorType _pendingBlinkType;
-  bool _inCallbackContext; // set true when inside ESP-NOW recv task
-  void blinkPattern(ErrorType);
-  bool shouldRestart(ErrorType) const;
-  [[noreturn]] void restartDevice();
-};
 } // namespace utils
 } // namespace lattice
+
+// Phase H2 item AA: Meyers singleton -> namespace of free functions backed by
+// file-static state (ErrorCore.cpp). Named err_core (not err) to avoid
+// colliding with the existing lattice::err namespace (Error.h's
+// fail/fatal/check helpers, which call into this module).
+namespace lattice {
+namespace err_core {
+
+namespace detail {
+// Groups the module's mutable state into one struct so the e2e test harness
+// (tests/e2e/harness/NodeContext.cpp) can still snapshot/restore it as a flat
+// byte image per simulated node -- the same technique it used against the
+// old singleton object.
+struct State {
+  lattice::hardware::Led* errorLed = nullptr;
+  lattice::hardware::SevenSegDisplay* display = nullptr;
+  bool initialized = false;
+  volatile bool pendingBlink = false;
+  lattice::utils::ErrorType pendingBlinkType = lattice::utils::ErrorType::GENERIC;
+  bool inCallbackContext = false; // set true when inside ESP-NOW recv task
+};
+} // namespace detail
+
+void init(lattice::hardware::Led* led, lattice::hardware::SevenSegDisplay* display = nullptr);
+void signalError(lattice::core::ErrorTypeDigit t, lattice::core::ModuleDigit m, uint8_t sub,
+                 const char* msg = nullptr);
+void signalError(lattice::utils::ErrorType type, const char* msg = nullptr);
+void setCallbackContext(bool inCallback);
+void drainPendingBlink(); // Call from main loop
+
+#ifdef UNIT_TEST
+detail::State& debugStateForTest();
+#endif
+
+} // namespace err_core
+} // namespace lattice
+
 #endif

--- a/firmware/main/src/mesh/Enrollment.cpp
+++ b/firmware/main/src/mesh/Enrollment.cpp
@@ -34,24 +34,23 @@ Enrollment::Enrollment() {
 // Host test builds compile them for real against a host-built mbedtls (see tests/CMakeLists.txt).
 
 void Enrollment::init() {
-  auto& em = EepromManager::getInstance();
-  if (em.loadKeypair(devicePrivateKey, devicePublicKey)) {
+  if (lattice::eeprom::loadKeypair(devicePrivateKey, devicePublicKey)) {
     LATTICE_LOGLN("MESH", "Device keypair loaded from EEPROM", LogLevel::LOG_INFO);
   } else {
     LATTICE_LOGLN("MESH", "Generating new Curve25519 keypair...", LogLevel::LOG_INFO);
     lattice::mesh::crypto::generateKeypair(devicePrivateKey, devicePublicKey);
-    em.saveKeypair(devicePrivateKey, devicePublicKey);
+    lattice::eeprom::saveKeypair(devicePrivateKey, devicePublicKey);
     LATTICE_LOGLN("MESH", "New keypair generated and saved", LogLevel::LOG_INFO);
   }
-  hasMasterMac = em.loadKnownMasterMac(knownMasterMac);
+  hasMasterMac = lattice::eeprom::loadKnownMasterMac(knownMasterMac);
   if (hasMasterMac) {
     LATTICE_LOGLN("MESH", "Known master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
-  hasMasterMacSecondary = em.loadKnownMasterMacSecondary(knownMasterMacSecondary);
+  hasMasterMacSecondary = lattice::eeprom::loadKnownMasterMacSecondary(knownMasterMacSecondary);
   if (hasMasterMacSecondary) {
     LATTICE_LOGLN("MESH", "Known secondary master MAC loaded from EEPROM", LogLevel::LOG_INFO);
   }
-  _enrolled = em.loadEnrolledFlag();
+  _enrolled = lattice::eeprom::loadEnrolledFlag();
 }
 
 bool Enrollment::isEnrolled() const {
@@ -147,14 +146,14 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
   }
 
   LATTICE_LOGLN("MESH", "Enrollment approved! Saving enrolled flag.", LogLevel::LOG_INFO);
-  EepromManager::getInstance().saveEnrolledFlag(true);
+  lattice::eeprom::saveEnrolledFlag(true);
   _enrolled = true;
 
   // The node sending JOIN_ACK is the master — record its MAC (TOFU)
   if (!hasMasterMac) {
     memcpy(knownMasterMac, msg.origin_mac_address, 6);
     hasMasterMac = true;
-    EepromManager::getInstance().saveKnownMasterMac(knownMasterMac);
+    lattice::eeprom::saveKnownMasterMac(knownMasterMac);
     LATTICE_LOGLN("MESH", "Master MAC learned and saved (TOFU)", LogLevel::LOG_INFO);
   }
 
@@ -178,7 +177,7 @@ void Enrollment::processJoinAck(const mesh_message& msg, const uint8_t* /*device
     if (secondaryRegistered && !hasMasterMacSecondary) {
       memcpy(knownMasterMacSecondary, secondaryMasterMac, 6);
       hasMasterMacSecondary = true;
-      EepromManager::getInstance().saveKnownMasterMacSecondary(knownMasterMacSecondary);
+      lattice::eeprom::saveKnownMasterMacSecondary(knownMasterMacSecondary);
     }
   }
 }

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -193,7 +193,7 @@ uint16_t Mesh::nextSeqGuarded() {
     // and by this method), so bump from it directly rather than re-reading
     // EEPROM.
     uint32_t epoch = replay.bootEpoch + 1;
-    EepromManager::getInstance().saveBootEpoch(epoch);
+    lattice::eeprom::saveBootEpoch(epoch);
     replay.bootEpoch = epoch;
     seq = replay.nextSeq();
   }
@@ -231,8 +231,8 @@ bool Mesh::init() {
   reevaluateRouteTable();
 
   // 2. Increment and save boot epoch (replay protection)
-  uint32_t epoch = EepromManager::getInstance().loadBootEpoch() + 1;
-  EepromManager::getInstance().saveBootEpoch(epoch);
+  uint32_t epoch = lattice::eeprom::loadBootEpoch() + 1;
+  lattice::eeprom::saveBootEpoch(epoch);
   replay.init(epoch);
   {
     char buf[32];
@@ -254,7 +254,7 @@ bool Mesh::init() {
 
   // 3a. Apply TX power preset from EEPROM (deployment-specific)
   {
-    lattice::config::TxPowerPreset preset = EepromManager::getInstance().loadTxPowerPreset();
+    lattice::config::TxPowerPreset preset = lattice::eeprom::loadTxPowerPreset();
     uint8_t txPowerVal = lattice::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
     esp_err_t txErr = esp_wifi_set_max_tx_power(static_cast<int8_t>(txPowerVal));
     if (txErr != ESP_OK) {
@@ -579,7 +579,7 @@ void Mesh::broadcastMasterBeacon() {
 
 void Mesh::loadMeshKeyFromEEPROM() {
   // Attempt to load mesh key from EEPROM
-  if (!EepromManager::getInstance().loadMeshKey(meshKey, MESH_KEY_SIZE)) {
+  if (!lattice::eeprom::loadMeshKey(meshKey, MESH_KEY_SIZE)) {
     LATTICE_LOGLN("MESH", "EEPROM read failed, using default mesh key", LogLevel::LOG_WARN);
   }
 
@@ -607,7 +607,7 @@ void Mesh::loadMeshKeyFromEEPROM() {
 }
 
 void Mesh::saveMeshKeyToEEPROM(const uint8_t* key) {
-  EepromManager::getInstance().saveMeshKey(key, MESH_KEY_SIZE);
+  lattice::eeprom::saveMeshKey(key, MESH_KEY_SIZE);
 }
 
 void Mesh::broadcastAdapterData(adapter_types type, const uint8_t* data, bool deliverLocally) {
@@ -703,7 +703,7 @@ bool Mesh::sendBroadcast(const mesh_message& msg) {
 }
 
 void Mesh::debugDumpRadio() {
-  if (!EepromManager::getInstance().getDevMode())
+  if (!lattice::eeprom::getDevMode())
     return;
   uint8_t ch;
   esp_wifi_get_channel(&ch, nullptr);
@@ -770,7 +770,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
     // First beacon ever — TOFU (fallback if JOIN_ACK path not taken, e.g. master node itself)
     memcpy(enrollment.knownMasterMac, msg.origin_mac_address, 6);
     enrollment.hasMasterMac = true;
-    EepromManager::getInstance().saveKnownMasterMac(enrollment.knownMasterMac);
+    lattice::eeprom::saveKnownMasterMac(enrollment.knownMasterMac);
     LATTICE_LOGLN("MESH", "Master MAC learned from first beacon (TOFU fallback)",
                   LogLevel::LOG_INFO);
   } else if (!fromPrimary && !fromSecondary) {
@@ -779,7 +779,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
       // Second master TOFU — learn and save as secondary
       memcpy(enrollment.knownMasterMacSecondary, msg.origin_mac_address, 6);
       enrollment.hasMasterMacSecondary = true;
-      EepromManager::getInstance().saveKnownMasterMacSecondary(enrollment.knownMasterMacSecondary);
+      lattice::eeprom::saveKnownMasterMacSecondary(enrollment.knownMasterMacSecondary);
       LATTICE_LOGLN("MESH", "Secondary master MAC learned (TOFU)", LogLevel::LOG_INFO);
       // fall through to process this beacon as valid
     } else if (millis() - lastMasterBeaconReceivedMs < STALE_MASTER_THRESHOLD_MS) {
@@ -791,7 +791,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
       // All known masters stale — accept as new primary (hotswap)
       LATTICE_LOGLN("MESH", "Stale master — accepting new master MAC", LogLevel::LOG_INFO);
       memcpy(enrollment.knownMasterMac, msg.origin_mac_address, 6);
-      EepromManager::getInstance().saveKnownMasterMac(enrollment.knownMasterMac);
+      lattice::eeprom::saveKnownMasterMac(enrollment.knownMasterMac);
     }
   }
 
@@ -1294,7 +1294,7 @@ void Mesh::processRouteReport(const mesh_message& msg) {
 
 void Mesh::loop() {
   drainRecvQueue();
-  EepromManager::getInstance().flushIfDirty();
+  lattice::eeprom::flushIfDirty();
 
   // Drain enrollment relay queued from ESP-NOW receive callback (WiFi task context).
   // Serial.write() must not be called from that callback — safe to do here in loop().

--- a/firmware/main/src/mesh/PeerRegistry.cpp
+++ b/firmware/main/src/mesh/PeerRegistry.cpp
@@ -77,7 +77,7 @@ void PeerRegistry::loadFromEEPROM() {
 
   // Each record is PEER_RECORD_SIZE (38) bytes: 6 MAC + 32 public key
   uint8_t peerRecords[EEPROM_SIZES::MAX_PEERS * EEPROM_SIZES::PEER_RECORD_SIZE];
-  bool eepromOk = EepromManager::getInstance().loadPeerList(peerRecords, EEPROM_SIZES::MAX_PEERS);
+  bool eepromOk = lattice::eeprom::loadPeerList(peerRecords, EEPROM_SIZES::MAX_PEERS);
 
   if (eepromOk) {
     for (int i = 0; i < EEPROM_SIZES::MAX_PEERS; ++i) {
@@ -124,7 +124,7 @@ void PeerRegistry::saveToEEPROM() {
     memcpy(record + 6, peerMacs[i].publicKey, 32);
   }
 
-  EepromManager::getInstance().savePeerList(peerRecords, peerCount);
+  lattice::eeprom::savePeerList(peerRecords, peerCount);
 }
 
 void PeerRegistry::addAndPersist(const uint8_t* mac) {

--- a/firmware/main/src/persistence/EepromManager.cpp
+++ b/firmware/main/src/persistence/EepromManager.cpp
@@ -3,121 +3,158 @@
 #include <cstdio>
 
 namespace lattice {
-namespace utils {
+namespace eeprom {
 
-EepromManager::EepromManager() : isInitialized(false), isDevMode(false) {}
+using namespace lattice::utils;
 
-EepromManager::~EepromManager() {
-  if (isInitialized) {
-    _prefs.end();
+namespace {
+
+detail::State _state;
+
+// Runs at process-exit (static-storage-duration teardown), mirroring the old
+// EepromManager::~EepromManager()'s "close NVS if we ever opened it" behavior.
+struct Cleanup {
+  ~Cleanup() {
+    if (_state.isInitialized) {
+      _state.prefs.end();
+    }
+  }
+} _cleanup;
+
+bool ensureInitialized() {
+  if (!_state.isInitialized) {
+    LATTICE_LOGLN("NVS", "NVS not initialized", lattice::utils::LogLevel::LOG_ERROR);
+    return false;
+  }
+  return true;
+}
+
+void logOperation(const char* operation, const char* details = nullptr) {
+  if (details) {
+    char buf[80];
+    snprintf(buf, sizeof(buf), "%s: %s", operation, details);
+    LATTICE_LOGLN("NVS", buf, lattice::utils::LogLevel::LOG_DEBUG);
+  } else {
+    LATTICE_LOGLN("NVS", operation, lattice::utils::LogLevel::LOG_DEBUG);
   }
 }
 
-EepromManager& EepromManager::getInstance() {
-  static EepromManager instance;
-  return instance;
+uint16_t crc16(const uint8_t* data, size_t len) {
+  uint16_t crc = 0xFFFF;
+  for (size_t i = 0; i < len; ++i) {
+    crc ^= static_cast<uint16_t>(data[i]) << 8;
+    for (int j = 0; j < 8; ++j)
+      crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
+  }
+  return crc;
 }
 
-bool EepromManager::init() {
-  if (isInitialized)
+// Tiered NVS write-return handling (issue #43). `got`/`want` are the bytes
+// actually written vs. requested by the preceding put* call. securityRelevant=true
+// escalates a short write via lattice::err::fail (halts the node); false logs
+// at ERROR and lets the caller continue.
+bool persistOrEscalate(const char* key, size_t got, size_t want, bool securityRelevant) {
+  if (got == want) {
     return true;
-  if (!_prefs.begin(NVS_KEYS::NAMESPACE, false)) {
-    LATTICE_LOGLN("NVS", "Failed to open NVS namespace", LogLevel::LOG_ERROR);
+  }
+  if (securityRelevant) {
+    lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::EEPROM, 5,
+                       "NVS write failed (security-relevant key)");
+    return false; // unreachable outside UNIT_TEST
+  }
+  {
+    char buf[96];
+    snprintf(buf, sizeof(buf), "write failed key=%s got=%u want=%u", key, (unsigned)got,
+             (unsigned)want);
+    LATTICE_LOGLN("NVS", buf, lattice::utils::LogLevel::LOG_ERROR);
+  }
+  return false;
+}
+
+} // namespace
+
+bool init() {
+  if (_state.isInitialized)
+    return true;
+  if (!_state.prefs.begin(NVS_KEYS::NAMESPACE, false)) {
+    LATTICE_LOGLN("NVS", "Failed to open NVS namespace", lattice::utils::LogLevel::LOG_ERROR);
     lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::EEPROM, 1,
                        "EepromManager: NVS begin failed");
     return false;
   }
-  isInitialized = true;
+  _state.isInitialized = true;
 
-  uint8_t reason = _prefs.getUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
+  uint8_t reason = _state.prefs.getUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
   if (reason == 0x00) {
-    size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
-    _persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
+    size_t n = _state.prefs.putUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
+    persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
   }
-  uint8_t count = _prefs.getUChar(NVS_KEYS::REBOOT_COUNT, 0);
+  uint8_t count = _state.prefs.getUChar(NVS_KEYS::REBOOT_COUNT, 0);
   if (count > 10) {
-    size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, 0);
-    _persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
+    size_t n = _state.prefs.putUChar(NVS_KEYS::REBOOT_COUNT, 0);
+    persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
   }
 
   logOperation("Initialized", "NVS ready");
   return true;
 }
 
-void EepromManager::setDevMode(bool devMode) {
-  isDevMode = devMode;
+void setDevMode(bool devMode) {
+  _state.isDevMode = devMode;
   logOperation("Dev mode set", devMode ? "Development mode enabled" : "Production mode enabled");
 }
 
-bool EepromManager::getDevMode() const {
-  return isDevMode;
+bool getDevMode() {
+  return _state.isDevMode;
 }
 
-bool EepromManager::ensureInitialized() {
-  if (!isInitialized) {
-    LATTICE_LOGLN("NVS", "NVS not initialized", LogLevel::LOG_ERROR);
-    return false;
-  }
-  return true;
-}
-
-void EepromManager::logOperation(const char* operation, const char* details) {
-  if (details) {
-    char buf[80];
-    snprintf(buf, sizeof(buf), "%s: %s", operation, details);
-    LATTICE_LOGLN("NVS", buf, LogLevel::LOG_DEBUG);
-  } else {
-    LATTICE_LOGLN("NVS", operation, LogLevel::LOG_DEBUG);
-  }
-}
-
-bool EepromManager::loadMasterFlag() {
+bool loadMasterFlag() {
   if (!ensureInitialized())
     return false;
-  return _prefs.getBool(NVS_KEYS::MASTER_FLAG, false);
+  return _state.prefs.getBool(NVS_KEYS::MASTER_FLAG, false);
 }
 
-void EepromManager::saveMasterFlag(bool isMaster) {
-  if (!ensureInitialized() || isDevMode)
+void saveMasterFlag(bool isMaster) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putBool(NVS_KEYS::MASTER_FLAG, isMaster);
-  _persistOrEscalate(NVS_KEYS::MASTER_FLAG, n, 1, /*securityRelevant=*/false);
+  size_t n = _state.prefs.putBool(NVS_KEYS::MASTER_FLAG, isMaster);
+  persistOrEscalate(NVS_KEYS::MASTER_FLAG, n, 1, /*securityRelevant=*/false);
   logOperation("Master flag saved", isMaster ? "Master" : "Node");
 }
 
-bool EepromManager::loadDevFlag() {
+bool loadDevFlag() {
   if (!ensureInitialized())
     return false;
-  return _prefs.getBool(NVS_KEYS::DEV_FLAG, false);
+  return _state.prefs.getBool(NVS_KEYS::DEV_FLAG, false);
 }
 
-void EepromManager::saveDevFlag(bool isDev) {
-  if (!ensureInitialized() || isDevMode)
+void saveDevFlag(bool isDev) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putBool(NVS_KEYS::DEV_FLAG, isDev);
-  _persistOrEscalate(NVS_KEYS::DEV_FLAG, n, 1, /*securityRelevant=*/false);
+  size_t n = _state.prefs.putBool(NVS_KEYS::DEV_FLAG, isDev);
+  persistOrEscalate(NVS_KEYS::DEV_FLAG, n, 1, /*securityRelevant=*/false);
 }
 
-bool EepromManager::loadMeshKey(uint8_t* key, size_t keySize) {
+bool loadMeshKey(uint8_t* key, size_t keySize) {
   if (!ensureInitialized())
     return false;
   if (keySize != EEPROM_SIZES::MESH_KEY_SIZE)
     return false;
-  size_t read = _prefs.getBytes(NVS_KEYS::MESH_KEY, key, keySize);
+  size_t read = _state.prefs.getBytes(NVS_KEYS::MESH_KEY, key, keySize);
   return read == keySize;
 }
 
-void EepromManager::saveMeshKey(const uint8_t* key, size_t keySize) {
-  if (!ensureInitialized() || isDevMode)
+void saveMeshKey(const uint8_t* key, size_t keySize) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
   if (keySize != EEPROM_SIZES::MESH_KEY_SIZE)
     return;
-  size_t n = _prefs.putBytes(NVS_KEYS::MESH_KEY, key, keySize);
-  _persistOrEscalate(NVS_KEYS::MESH_KEY, n, keySize, /*securityRelevant=*/true);
+  size_t n = _state.prefs.putBytes(NVS_KEYS::MESH_KEY, key, keySize);
+  persistOrEscalate(NVS_KEYS::MESH_KEY, n, keySize, /*securityRelevant=*/true);
   logOperation("Mesh key saved");
 }
 
-bool EepromManager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
+bool loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
   if (!ensureInitialized())
     return false;
   if (maxPeers > EEPROM_SIZES::MAX_PEERS)
@@ -132,100 +169,90 @@ bool EepromManager::loadPeerList(uint8_t* peerRecords, size_t maxPeers) {
   // buffer was read as real peer records — an uninitialized-memory bug that
   // could inject bogus peers with garbage MAC/public-key bytes.
   memset(peerRecords, 0xFF, maxBytes);
-  size_t read = _prefs.getBytes(NVS_KEYS::PEER_LIST, peerRecords, maxBytes);
+  size_t read = _state.prefs.getBytes(NVS_KEYS::PEER_LIST, peerRecords, maxBytes);
   if (read == 0) {
     return false;
   }
   return true;
 }
 
-void EepromManager::savePeerList(const uint8_t* peerRecords, size_t numPeers) {
-  if (!ensureInitialized() || isDevMode)
+void savePeerList(const uint8_t* peerRecords, size_t numPeers) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
   if (numPeers > EEPROM_SIZES::MAX_PEERS)
     return;
   if (numPeers == 0) {
-    _prefs.remove(NVS_KEYS::PEER_LIST);
+    _state.prefs.remove(NVS_KEYS::PEER_LIST);
   } else {
     size_t want = numPeers * EEPROM_SIZES::PEER_RECORD_SIZE;
-    size_t n = _prefs.putBytes(NVS_KEYS::PEER_LIST, peerRecords, want);
+    size_t n = _state.prefs.putBytes(NVS_KEYS::PEER_LIST, peerRecords, want);
     // securityRelevant=true: each record carries a peer's E2E public key —
     // trust material, same tier as MESH_KEY/KNOWN_MASTER_MAC below.
-    _persistOrEscalate(NVS_KEYS::PEER_LIST, n, want, /*securityRelevant=*/true);
+    persistOrEscalate(NVS_KEYS::PEER_LIST, n, want, /*securityRelevant=*/true);
   }
   logOperation("Peer list saved", String(numPeers).c_str());
 }
 
-bool EepromManager::hasPeers() {
+bool hasPeers() {
   if (!ensureInitialized())
     return false;
-  return _prefs.isKey(NVS_KEYS::PEER_LIST);
+  return _state.prefs.isKey(NVS_KEYS::PEER_LIST);
 }
 
-void EepromManager::clearPeerList() {
+void clearPeerList() {
   if (!ensureInitialized())
     return;
-  _prefs.remove(NVS_KEYS::PEER_LIST);
+  _state.prefs.remove(NVS_KEYS::PEER_LIST);
   logOperation("Peer list cleared");
 }
 
-uint8_t EepromManager::loadAdapterType() {
+uint8_t loadAdapterType() {
   if (!ensureInitialized())
     return 0;
-  return _prefs.getUChar(NVS_KEYS::ADAPTER_TYPE, 0);
+  return _state.prefs.getUChar(NVS_KEYS::ADAPTER_TYPE, 0);
 }
 
-void EepromManager::saveAdapterType(uint8_t adapterType) {
-  if (!ensureInitialized() || isDevMode)
+void saveAdapterType(uint8_t adapterType) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putUChar(NVS_KEYS::ADAPTER_TYPE, adapterType);
-  _persistOrEscalate(NVS_KEYS::ADAPTER_TYPE, n, sizeof(uint8_t), /*securityRelevant=*/false);
+  size_t n = _state.prefs.putUChar(NVS_KEYS::ADAPTER_TYPE, adapterType);
+  persistOrEscalate(NVS_KEYS::ADAPTER_TYPE, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
-uint8_t EepromManager::loadRebootCount() {
+uint8_t loadRebootCount() {
   if (!ensureInitialized())
     return 0;
-  return _prefs.getUChar(NVS_KEYS::REBOOT_COUNT, 0);
+  return _state.prefs.getUChar(NVS_KEYS::REBOOT_COUNT, 0);
 }
 
-void EepromManager::saveRebootCount(uint8_t count) {
-  if (!ensureInitialized() || isDevMode)
+void saveRebootCount(uint8_t count) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_COUNT, count);
-  _persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
+  size_t n = _state.prefs.putUChar(NVS_KEYS::REBOOT_COUNT, count);
+  persistOrEscalate(NVS_KEYS::REBOOT_COUNT, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
-void EepromManager::saveRebootReason(uint8_t reason) {
-  if (!ensureInitialized() || isDevMode)
+void saveRebootReason(uint8_t reason) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putUChar(NVS_KEYS::REBOOT_REASON, reason);
-  _persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
+  size_t n = _state.prefs.putUChar(NVS_KEYS::REBOOT_REASON, reason);
+  persistOrEscalate(NVS_KEYS::REBOOT_REASON, n, sizeof(uint8_t), /*securityRelevant=*/false);
 }
 
-uint8_t EepromManager::loadRebootReason() {
+uint8_t loadRebootReason() {
   if (!ensureInitialized())
     return 0xFF;
-  return _prefs.getUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
+  return _state.prefs.getUChar(NVS_KEYS::REBOOT_REASON, 0xFF);
 }
 
-static uint16_t crc16(const uint8_t* data, size_t len) {
-  uint16_t crc = 0xFFFF;
-  for (size_t i = 0; i < len; ++i) {
-    crc ^= static_cast<uint16_t>(data[i]) << 8;
-    for (int j = 0; j < 8; ++j)
-      crc = (crc & 0x8000) ? (crc << 1) ^ 0x1021 : (crc << 1);
-  }
-  return crc;
-}
-
-bool EepromManager::loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32) {
+bool loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32) {
   if (!ensureInitialized())
     return false;
-  size_t privRead = _prefs.getBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
-  size_t pubRead = _prefs.getBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
+  size_t privRead = _state.prefs.getBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
+  size_t pubRead = _state.prefs.getBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
   if (privRead != 32 || pubRead != 32)
     return false;
-  uint32_t stored = _prefs.getUInt(NVS_KEYS::KEYPAIR_CRC, 0xFFFFFFFF);
+  uint32_t stored = _state.prefs.getUInt(NVS_KEYS::KEYPAIR_CRC, 0xFFFFFFFF);
   if (stored == 0xFFFFFFFF)
     return false;
   uint8_t both[64];
@@ -233,66 +260,66 @@ bool EepromManager::loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32) {
   memcpy(both + 32, publicKey32, 32);
   uint16_t computed = crc16(both, 64);
   if (static_cast<uint16_t>(stored) != computed) {
-    LATTICE_LOGLN("NVS", "Keypair CRC mismatch", LogLevel::LOG_WARN);
+    LATTICE_LOGLN("NVS", "Keypair CRC mismatch", lattice::utils::LogLevel::LOG_WARN);
     return false;
   }
   return true;
 }
 
-void EepromManager::saveKeypair(const uint8_t* privateKey32, const uint8_t* publicKey32) {
-  if (!ensureInitialized() || isDevMode)
+void saveKeypair(const uint8_t* privateKey32, const uint8_t* publicKey32) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
   // securityRelevant=true on all three: this is the device's long-term
   // identity keypair — the same tier as MESH_KEY/KNOWN_MASTER_MAC below.
-  size_t nPriv = _prefs.putBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
-  _persistOrEscalate(NVS_KEYS::PRIVATE_KEY, nPriv, 32, /*securityRelevant=*/true);
-  size_t nPub = _prefs.putBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
-  _persistOrEscalate(NVS_KEYS::PUBLIC_KEY, nPub, 32, /*securityRelevant=*/true);
+  size_t nPriv = _state.prefs.putBytes(NVS_KEYS::PRIVATE_KEY, privateKey32, 32);
+  persistOrEscalate(NVS_KEYS::PRIVATE_KEY, nPriv, 32, /*securityRelevant=*/true);
+  size_t nPub = _state.prefs.putBytes(NVS_KEYS::PUBLIC_KEY, publicKey32, 32);
+  persistOrEscalate(NVS_KEYS::PUBLIC_KEY, nPub, 32, /*securityRelevant=*/true);
   uint8_t both[64];
   memcpy(both, privateKey32, 32);
   memcpy(both + 32, publicKey32, 32);
   uint16_t crc = crc16(both, 64);
-  size_t nCrc = _prefs.putUInt(NVS_KEYS::KEYPAIR_CRC, static_cast<uint32_t>(crc));
-  _persistOrEscalate(NVS_KEYS::KEYPAIR_CRC, nCrc, sizeof(uint32_t), /*securityRelevant=*/true);
+  size_t nCrc = _state.prefs.putUInt(NVS_KEYS::KEYPAIR_CRC, static_cast<uint32_t>(crc));
+  persistOrEscalate(NVS_KEYS::KEYPAIR_CRC, nCrc, sizeof(uint32_t), /*securityRelevant=*/true);
   logOperation("Keypair saved");
 }
 
-bool EepromManager::loadEnrolledFlag() {
+bool loadEnrolledFlag() {
   if (!ensureInitialized())
     return false;
-  return _prefs.getBool(NVS_KEYS::ENROLLED_FLAG, false);
+  return _state.prefs.getBool(NVS_KEYS::ENROLLED_FLAG, false);
 }
 
-void EepromManager::saveEnrolledFlag(bool enrolled) {
-  if (!ensureInitialized() || isDevMode)
+void saveEnrolledFlag(bool enrolled) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putBool(NVS_KEYS::ENROLLED_FLAG, enrolled);
-  _persistOrEscalate(NVS_KEYS::ENROLLED_FLAG, n, 1, /*securityRelevant=*/false);
+  size_t n = _state.prefs.putBool(NVS_KEYS::ENROLLED_FLAG, enrolled);
+  persistOrEscalate(NVS_KEYS::ENROLLED_FLAG, n, 1, /*securityRelevant=*/false);
 }
 
-uint32_t EepromManager::loadBootEpoch() {
+uint32_t loadBootEpoch() {
   if (!ensureInitialized())
     return 0;
-  if (isDevMode)
-    return _devEpoch;
-  return _prefs.getUInt(NVS_KEYS::BOOT_EPOCH, 0);
+  if (_state.isDevMode)
+    return _state.devEpoch;
+  return _state.prefs.getUInt(NVS_KEYS::BOOT_EPOCH, 0);
 }
 
-void EepromManager::saveBootEpoch(uint32_t epoch) {
+void saveBootEpoch(uint32_t epoch) {
   if (!ensureInitialized())
     return;
-  if (isDevMode) {
-    _devEpoch = epoch;
+  if (_state.isDevMode) {
+    _state.devEpoch = epoch;
     return;
   }
-  size_t n = _prefs.putUInt(NVS_KEYS::BOOT_EPOCH, epoch);
-  _persistOrEscalate(NVS_KEYS::BOOT_EPOCH, n, sizeof(uint32_t), /*securityRelevant=*/true);
+  size_t n = _state.prefs.putUInt(NVS_KEYS::BOOT_EPOCH, epoch);
+  persistOrEscalate(NVS_KEYS::BOOT_EPOCH, n, sizeof(uint32_t), /*securityRelevant=*/true);
 }
 
-bool EepromManager::loadKnownMasterMac(uint8_t* mac) {
+bool loadKnownMasterMac(uint8_t* mac) {
   if (!ensureInitialized())
     return false;
-  size_t read = _prefs.getBytes(NVS_KEYS::KNOWN_MASTER_MAC, mac, 6);
+  size_t read = _state.prefs.getBytes(NVS_KEYS::KNOWN_MASTER_MAC, mac, 6);
   if (read != 6)
     return false;
   bool allFF = true;
@@ -305,25 +332,25 @@ bool EepromManager::loadKnownMasterMac(uint8_t* mac) {
   return !allFF;
 }
 
-void EepromManager::saveKnownMasterMac(const uint8_t* mac) {
-  if (!ensureInitialized() || isDevMode)
+void saveKnownMasterMac(const uint8_t* mac) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putBytes(NVS_KEYS::KNOWN_MASTER_MAC, mac, 6);
-  _persistOrEscalate(NVS_KEYS::KNOWN_MASTER_MAC, n, 6, /*securityRelevant=*/true);
+  size_t n = _state.prefs.putBytes(NVS_KEYS::KNOWN_MASTER_MAC, mac, 6);
+  persistOrEscalate(NVS_KEYS::KNOWN_MASTER_MAC, n, 6, /*securityRelevant=*/true);
   logOperation("Known master MAC saved");
 }
 
-void EepromManager::clearKnownMasterMac() {
-  if (!ensureInitialized() || isDevMode)
+void clearKnownMasterMac() {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  _prefs.remove(NVS_KEYS::KNOWN_MASTER_MAC);
+  _state.prefs.remove(NVS_KEYS::KNOWN_MASTER_MAC);
   logOperation("Known master MAC cleared");
 }
 
-bool EepromManager::loadKnownMasterMacSecondary(uint8_t* mac) {
+bool loadKnownMasterMacSecondary(uint8_t* mac) {
   if (!ensureInitialized())
     return false;
-  size_t read = _prefs.getBytes(NVS_KEYS::KNOWN_MASTER_MAC_SEC, mac, 6);
+  size_t read = _state.prefs.getBytes(NVS_KEYS::KNOWN_MASTER_MAC_SEC, mac, 6);
   if (read != 6)
     return false;
   bool allFF = true;
@@ -336,80 +363,71 @@ bool EepromManager::loadKnownMasterMacSecondary(uint8_t* mac) {
   return !allFF;
 }
 
-void EepromManager::saveKnownMasterMacSecondary(const uint8_t* mac) {
-  if (!ensureInitialized() || isDevMode)
+void saveKnownMasterMacSecondary(const uint8_t* mac) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putBytes(NVS_KEYS::KNOWN_MASTER_MAC_SEC, mac, 6);
-  _persistOrEscalate(NVS_KEYS::KNOWN_MASTER_MAC_SEC, n, 6, /*securityRelevant=*/true);
+  size_t n = _state.prefs.putBytes(NVS_KEYS::KNOWN_MASTER_MAC_SEC, mac, 6);
+  persistOrEscalate(NVS_KEYS::KNOWN_MASTER_MAC_SEC, n, 6, /*securityRelevant=*/true);
   logOperation("Known secondary master MAC saved");
 }
 
-void EepromManager::clearKnownMasterMacSecondary() {
-  if (!ensureInitialized() || isDevMode)
+void clearKnownMasterMacSecondary() {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  _prefs.remove(NVS_KEYS::KNOWN_MASTER_MAC_SEC);
+  _state.prefs.remove(NVS_KEYS::KNOWN_MASTER_MAC_SEC);
 }
 
-lattice::config::TxPowerPreset EepromManager::loadTxPowerPreset() {
+lattice::config::TxPowerPreset loadTxPowerPreset() {
   if (!ensureInitialized())
     return lattice::config::DEFAULT_TX_POWER_PRESET;
-  uint8_t val = _prefs.getUChar(NVS_KEYS::TX_POWER_PRESET, 0xFF);
+  uint8_t val = _state.prefs.getUChar(NVS_KEYS::TX_POWER_PRESET, 0xFF);
   if (val > 2)
     return lattice::config::DEFAULT_TX_POWER_PRESET;
   return static_cast<lattice::config::TxPowerPreset>(val);
 }
 
-void EepromManager::saveTxPowerPreset(lattice::config::TxPowerPreset preset) {
-  if (!ensureInitialized() || isDevMode)
+void saveTxPowerPreset(lattice::config::TxPowerPreset preset) {
+  if (!ensureInitialized() || _state.isDevMode)
     return;
-  size_t n = _prefs.putUChar(NVS_KEYS::TX_POWER_PRESET, static_cast<uint8_t>(preset));
-  _persistOrEscalate(NVS_KEYS::TX_POWER_PRESET, n, sizeof(uint8_t), /*securityRelevant=*/false);
+  size_t n = _state.prefs.putUChar(NVS_KEYS::TX_POWER_PRESET, static_cast<uint8_t>(preset));
+  persistOrEscalate(NVS_KEYS::TX_POWER_PRESET, n, sizeof(uint8_t), /*securityRelevant=*/false);
   logOperation("TX power preset saved");
 }
 
-uint8_t EepromManager::loadNodeId() {
+uint8_t loadNodeId() {
   if (!ensureInitialized())
     return 0;
-  return _prefs.getUChar(NVS_KEYS::NODE_ID, 0);
+  return _state.prefs.getUChar(NVS_KEYS::NODE_ID, 0);
 }
 
-void EepromManager::saveNodeId(uint8_t nodeId) {
+void saveNodeId(uint8_t nodeId) {
   if (!ensureInitialized())
     return;
-  size_t n = _prefs.putUChar(NVS_KEYS::NODE_ID, nodeId);
-  _persistOrEscalate(NVS_KEYS::NODE_ID, n, sizeof(uint8_t), /*securityRelevant=*/false);
+  size_t n = _state.prefs.putUChar(NVS_KEYS::NODE_ID, nodeId);
+  persistOrEscalate(NVS_KEYS::NODE_ID, n, sizeof(uint8_t), /*securityRelevant=*/false);
   logOperation("saveNodeId");
 }
 
-void EepromManager::clearAll() {
+void clearAll() {
   if (!ensureInitialized())
     return;
-  _prefs.clear();
+  _state.prefs.clear();
   logOperation("All NVS cleared");
 }
 
-void EepromManager::dumpEEPROM() {
-  LATTICE_LOGLN("NVS", "NVS dump not implemented (use idf.py nvs-dump)", LogLevel::LOG_INFO);
+void dumpEEPROM() {
+  LATTICE_LOGLN("NVS", "NVS dump not implemented (use idf.py nvs-dump)", lattice::utils::LogLevel::LOG_INFO);
 }
 
-bool EepromManager::_persistOrEscalate(const char* key, size_t got, size_t want,
-                                       bool securityRelevant) {
-  if (got == want) {
-    return true;
-  }
-  if (securityRelevant) {
-    lattice::err::fail(lattice::core::ErrorTypeDigit::MEMORY, lattice::core::ModuleDigit::EEPROM, 5,
-                       "NVS write failed (security-relevant key)");
-    return false; // unreachable outside UNIT_TEST
-  }
-  {
-    char buf[96];
-    snprintf(buf, sizeof(buf), "write failed key=%s got=%u want=%u", key, (unsigned)got,
-             (unsigned)want);
-    LATTICE_LOGLN("NVS", buf, LogLevel::LOG_ERROR);
-  }
-  return false;
+#ifdef UNIT_TEST
+bool isInitializedForTest() {
+  return _state.isInitialized;
 }
 
-} // namespace utils
+detail::State& debugStateForTest() {
+  return _state;
+}
+#endif
+
+} // namespace eeprom
 } // namespace lattice

--- a/firmware/main/src/persistence/EepromManager.h
+++ b/firmware/main/src/persistence/EepromManager.h
@@ -38,93 +38,92 @@ constexpr uint8_t PEER_RECORD_SIZE = PEER_MAC_SIZE + PEER_PUBLIC_KEY_SIZE; // 38
 constexpr uint16_t PEER_LIST_SIZE = MAX_PEERS * PEER_RECORD_SIZE;          // 380 bytes
 } // namespace EEPROM_SIZES
 
-class EepromManager {
-private:
-  bool isInitialized;
-  bool isDevMode;
-  Preferences _prefs;
-  uint32_t _devEpoch = 0; // DEV_MODE RAM-only monotonic boot-epoch seed (issue #43)
+} // namespace utils
+} // namespace lattice
 
-  EepromManager();
-  bool ensureInitialized();
-  void logOperation(const char* operation, const char* details = nullptr);
+// Phase H2 item AA: Meyers singleton -> namespace of free functions backed by
+// file-static state (EepromManager.cpp). Each unique EepromManager::getInstance()
+// callsite used to cost a __cxa_guard_acquire/release prologue (~40B + a byte
+// flag); free functions drop that entirely. Public API (function names +
+// signatures) is unchanged from the old class's methods.
+namespace lattice {
+namespace eeprom {
 
-  // Tiered NVS write-return handling (issue #43). `got`/`want` are the
-  // bytes actually written vs. requested by the preceding put* call.
-  // securityRelevant=true escalates a short write via lattice::err::fail
-  // (halts the node); false logs at ERROR and lets the caller continue.
-  bool _persistOrEscalate(const char* key, size_t got, size_t want, bool securityRelevant);
+namespace detail {
+// Groups the module's mutable state into one struct so the e2e test harness
+// (tests/e2e/harness/NodeContext.cpp) can still snapshot/restore it as a flat
+// byte image per simulated node -- the same technique it used against the
+// old singleton object.
+struct State {
+  bool isInitialized = false;
+  bool isDevMode = false;
+  Preferences prefs;
+  uint32_t devEpoch = 0; // DEV_MODE RAM-only monotonic boot-epoch seed (issue #43)
+};
+} // namespace detail
 
-public:
-  static EepromManager& getInstance();
+bool init();
+void setDevMode(bool devMode);
+bool getDevMode();
 
-  EepromManager(const EepromManager&) = delete;
-  EepromManager& operator=(const EepromManager&) = delete;
-  EepromManager(EepromManager&&) = delete;
-  EepromManager& operator=(EepromManager&&) = delete;
+bool loadMasterFlag();
+void saveMasterFlag(bool isMaster);
 
-  bool init();
-  void setDevMode(bool devMode);
-  bool getDevMode() const;
+bool loadDevFlag();
+void saveDevFlag(bool isDev);
 
-  bool loadMasterFlag();
-  void saveMasterFlag(bool isMaster);
+bool loadMeshKey(uint8_t* key, size_t keySize);
+void saveMeshKey(const uint8_t* key, size_t keySize);
 
-  bool loadDevFlag();
-  void saveDevFlag(bool isDev);
+bool loadPeerList(uint8_t* peerRecords, size_t maxPeers);
+void savePeerList(const uint8_t* peerRecords, size_t numPeers);
+bool hasPeers();
+void clearPeerList();
 
-  bool loadMeshKey(uint8_t* key, size_t keySize);
-  void saveMeshKey(const uint8_t* key, size_t keySize);
+uint8_t loadAdapterType();
+void saveAdapterType(uint8_t adapterType);
 
-  bool loadPeerList(uint8_t* peerRecords, size_t maxPeers);
-  void savePeerList(const uint8_t* peerRecords, size_t numPeers);
-  bool hasPeers();
-  void clearPeerList();
+uint8_t loadRebootCount();
+void saveRebootCount(uint8_t count);
+void saveRebootReason(uint8_t reason);
+uint8_t loadRebootReason();
 
-  uint8_t loadAdapterType();
-  void saveAdapterType(uint8_t adapterType);
+bool loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32);
+void saveKeypair(const uint8_t* privateKey32, const uint8_t* publicKey32);
+bool loadEnrolledFlag();
+void saveEnrolledFlag(bool enrolled);
 
-  uint8_t loadRebootCount();
-  void saveRebootCount(uint8_t count);
-  void saveRebootReason(uint8_t reason);
-  uint8_t loadRebootReason();
+uint32_t loadBootEpoch();
+void saveBootEpoch(uint32_t epoch);
 
-  bool loadKeypair(uint8_t* privateKey32, uint8_t* publicKey32);
-  void saveKeypair(const uint8_t* privateKey32, const uint8_t* publicKey32);
-  bool loadEnrolledFlag();
-  void saveEnrolledFlag(bool enrolled);
+bool loadKnownMasterMac(uint8_t* mac);
+void saveKnownMasterMac(const uint8_t* mac);
+void clearKnownMasterMac();
 
-  uint32_t loadBootEpoch();
-  void saveBootEpoch(uint32_t epoch);
+bool loadKnownMasterMacSecondary(uint8_t* mac);
+void saveKnownMasterMacSecondary(const uint8_t* mac);
+void clearKnownMasterMacSecondary();
 
-  bool loadKnownMasterMac(uint8_t* mac);
-  void saveKnownMasterMac(const uint8_t* mac);
-  void clearKnownMasterMac();
+lattice::config::TxPowerPreset loadTxPowerPreset();
+void saveTxPowerPreset(lattice::config::TxPowerPreset preset);
 
-  bool loadKnownMasterMacSecondary(uint8_t* mac);
-  void saveKnownMasterMacSecondary(const uint8_t* mac);
-  void clearKnownMasterMacSecondary();
+uint8_t loadNodeId();
+void saveNodeId(uint8_t nodeId);
 
-  lattice::config::TxPowerPreset loadTxPowerPreset();
-  void saveTxPowerPreset(lattice::config::TxPowerPreset preset);
+inline void flushIfDirty() {}
+inline void forceFlush() {}
 
-  uint8_t loadNodeId();
-  void saveNodeId(uint8_t nodeId);
-
-  void flushIfDirty() {}
-  void forceFlush() {}
-
-  void clearAll();
-  void dumpEEPROM();
-
-  ~EepromManager();
+void clearAll();
+void dumpEEPROM();
 
 #ifdef UNIT_TEST
-  bool isInitializedForTest() const { return isInitialized; }
+bool isInitializedForTest();
+// Raw access to the module's state blob for the e2e harness's byte-image
+// snapshot/restore (tests/e2e/harness/NodeContext.cpp).
+detail::State& debugStateForTest();
 #endif
-};
 
-} // namespace utils
+} // namespace eeprom
 } // namespace lattice
 
 #endif // EEPROM_MANAGER_H

--- a/tests/e2e/harness/NodeContext.cpp
+++ b/tests/e2e/harness/NodeContext.cpp
@@ -40,12 +40,12 @@ static void saveImage(T& obj, std::vector<uint8_t>& image) {
 static void initPristineImages(std::vector<uint8_t>& em, std::vector<uint8_t>& ec) {
   static std::vector<uint8_t> pristineEm = [] {
     std::vector<uint8_t> v;
-    saveImage(lattice::utils::EepromManager::getInstance(), v);
+    saveImage(lattice::eeprom::debugStateForTest(), v);
     return v;
   }();
   static std::vector<uint8_t> pristineEc = [] {
     std::vector<uint8_t> v;
-    saveImage(lattice::utils::ErrorCore::getInstance(), v);
+    saveImage(lattice::err_core::debugStateForTest(), v);
     return v;
   }();
   em = pristineEm;
@@ -71,8 +71,8 @@ void swapIn(NodeContext& ctx) {
   ESP._restartRequested = ctx.espRestartRequested;
   lattice::mesh::Mesh::instance = ctx.meshInstance;
   lattice::adapter::PirAdapter::instance = ctx.pirInstance;
-  loadImage(lattice::utils::EepromManager::getInstance(), ctx.eepromManagerImage);
-  loadImage(lattice::utils::ErrorCore::getInstance(), ctx.errorCoreImage);
+  loadImage(lattice::eeprom::debugStateForTest(), ctx.eepromManagerImage);
+  loadImage(lattice::err_core::debugStateForTest(), ctx.errorCoreImage);
 }
 
 void swapOut(NodeContext& ctx) {
@@ -89,8 +89,8 @@ void swapOut(NodeContext& ctx) {
   ctx.espRestartRequested = ESP._restartRequested;
   ctx.meshInstance = lattice::mesh::Mesh::instance;
   ctx.pirInstance = lattice::adapter::PirAdapter::instance;
-  saveImage(lattice::utils::EepromManager::getInstance(), ctx.eepromManagerImage);
-  saveImage(lattice::utils::ErrorCore::getInstance(), ctx.errorCoreImage);
+  saveImage(lattice::eeprom::debugStateForTest(), ctx.eepromManagerImage);
+  saveImage(lattice::err_core::debugStateForTest(), ctx.errorCoreImage);
 }
 
 } // namespace sim

--- a/tests/e2e/harness/SimNode.cpp
+++ b/tests/e2e/harness/SimNode.cpp
@@ -18,8 +18,6 @@
 
 namespace sim {
 
-using lattice::utils::EepromManager;
-
 SimNode::SimNode(const NodeConfig& cfg) : cfg_(cfg) {
   memcpy(ctx_.mac, cfg.mac, 6);
 }
@@ -41,10 +39,9 @@ void SimNode::boot() {
     Serial.begin(115200);
     lattice::utils::Logger::setLogLevel(lattice::utils::LogLevel::LOG_NONE);
 
-    auto& em = EepromManager::getInstance();
-    em.init();
-    lattice::app::BootManager::check(em);
-    em.setDevMode(false);
+    lattice::eeprom::init();
+    lattice::app::BootManager::check();
+    lattice::eeprom::setDevMode(false);
     lattice::adapter::AdapterFactory::setDevMode(false);
 
     greenLed_ = std::make_unique<lattice::hardware::Led>(lattice::config::GREEN_LED_PIN);
@@ -52,19 +49,19 @@ void SimNode::boot() {
     greenLed_->init();
     redLed_->init();
     lattice::hardware::Led::setSystemErrorLed(redLed_.get());
-    lattice::utils::ErrorCore::getInstance().init(redLed_.get(), nullptr);
+    lattice::err_core::init(redLed_.get(), nullptr);
 
     if (!booted_) {
       // First boot: seed role + adapter type (a provisioned device's EEPROM)
-      em.saveMasterFlag(cfg_.isMaster);
+      lattice::eeprom::saveMasterFlag(cfg_.isMaster);
       lattice::adapter::AdapterFactory::saveAdapterTypeToEEPROM(cfg_.adapterType);
       // Phase D (#42): seed a fixed keypair BEFORE mesh_->init() (below) calls
       // Enrollment::init(), so its loadKeypair() succeeds and skips generating a
       // fresh random one — see NodeConfig::seedPrivateKey32/seedPublicKey32.
       if (cfg_.seedPrivateKey32 && cfg_.seedPublicKey32) {
-        em.saveKeypair(cfg_.seedPrivateKey32, cfg_.seedPublicKey32);
+        lattice::eeprom::saveKeypair(cfg_.seedPrivateKey32, cfg_.seedPublicKey32);
       }
-      em.forceFlush();
+      lattice::eeprom::forceFlush();
     }
 
     lattice::adapter::AdapterFactory::initializeDefaultsIfUnset();
@@ -100,7 +97,7 @@ void SimNode::boot() {
     }
 
     mesh_->setEnrollmentRelayFn(lattice::adapter::SerialAdapter::relayEnrollmentToServer);
-    mesh_->setIsMaster(EepromManager::getInstance().loadMasterFlag());
+    mesh_->setIsMaster(lattice::eeprom::loadMasterFlag());
     adapter_->setTransmitFn(&lattice::mesh::Mesh::transmit);
     mesh_->linkDataRecvCallback([this](const mesh_message& m) {
       if (adapter_)
@@ -118,7 +115,7 @@ void SimNode::boot() {
 void SimNode::tick() {
   swapIn(ctx_);
   try {
-    lattice::utils::ErrorCore::getInstance().drainPendingBlink();
+    lattice::err_core::drainPendingBlink();
     mesh_->loop();
     mesh_->checkMasterTimeout();
 

--- a/tests/e2e/scenarios/test_harness_smoke.cpp
+++ b/tests/e2e/scenarios/test_harness_smoke.cpp
@@ -40,20 +40,20 @@ TEST(NodeContextSwap, FreshContextGetsPristineSingletons) {
   sim::NodeContext a, b;
 
   sim::swapIn(a);
-  EXPECT_FALSE(lattice::utils::EepromManager::getInstance().isInitializedForTest())
+  EXPECT_FALSE(lattice::eeprom::isInitializedForTest())
       << "sanity: singleton must start uninitialized before node A dirties it";
-  lattice::utils::EepromManager::getInstance().init(); // node A dirties singleton state
-  EXPECT_TRUE(lattice::utils::EepromManager::getInstance().isInitializedForTest());
+  lattice::eeprom::init(); // node A dirties singleton state
+  EXPECT_TRUE(lattice::eeprom::isInitializedForTest());
   sim::swapOut(a);
 
   sim::swapIn(b); // fresh context: must NOT inherit A's initialized state
-  EXPECT_FALSE(lattice::utils::EepromManager::getInstance().isInitializedForTest())
+  EXPECT_FALSE(lattice::eeprom::isInitializedForTest())
       << "node B's fresh context must restore pristine EepromManager state, "
       << "not silently inherit node A's initialized singleton";
   sim::swapOut(b);
 
   sim::swapIn(a);
-  EXPECT_TRUE(lattice::utils::EepromManager::getInstance().isInitializedForTest())
+  EXPECT_TRUE(lattice::eeprom::isInitializedForTest())
       << "swapping back to A must still see A's own initialized state";
   sim::swapOut(a);
 }

--- a/tests/e2e/scenarios/test_seq_wrap.cpp
+++ b/tests/e2e/scenarios/test_seq_wrap.cpp
@@ -67,7 +67,7 @@ TEST_F(MeshSimTest, SeqWrapBumpsEpochAndKeepsSealing) {
   // read reflect the leaf's own persisted BOOT_EPOCH rather than whichever
   // node's state happened to be live globally beforehand.
   uint32_t persistedEpoch = sensor->with([](lattice::mesh::Mesh&, lattice::adapter::Adapter*) {
-    return lattice::utils::EepromManager::getInstance().loadBootEpoch();
+    return lattice::eeprom::loadBootEpoch();
   });
   EXPECT_EQ(persistedEpoch, epochBefore + 1)
       << "the bumped epoch must be persisted to EEPROM, not just held in RAM — "

--- a/tests/unit/test_eeprom_manager.cpp
+++ b/tests/unit/test_eeprom_manager.cpp
@@ -6,15 +6,15 @@
 #include "error/Error.h"
 
 using lattice::mesh::PeerInfo;
-using lattice::utils::EepromManager;
 using lattice::utils::EEPROM_SIZES::PEER_RECORD_SIZE;
 
 // -----------------------------------------------------------------------
 // Test fixture
 //
-// The EepromManager is a Meyers singleton — isInitialized stays true for
-// the process lifetime. Between tests we clear the Preferences static store
-// to get a clean slate.
+// lattice::eeprom holds its state in file-static storage (Phase H2 item AA:
+// migrated off the old Meyers-singleton EepromManager class) — isInitialized
+// stays true for the process lifetime. Between tests we clear the
+// Preferences static store to get a clean slate.
 // -----------------------------------------------------------------------
 
 class EEPROMMgrTest : public ::testing::Test {
@@ -24,10 +24,10 @@ protected:
     // Clear the Preferences static store
     Preferences::_store.clear();
     // Init the singleton (idempotent — no-op after first call)
-    auto& mgr = EepromManager::getInstance();
-    mgr.init();
+    namespace mgr = lattice::eeprom;
+    mgr::init();
     // Reset devMode to false (singleton persists across tests)
-    mgr.setDevMode(false);
+    mgr::setDevMode(false);
   }
 };
 
@@ -37,13 +37,13 @@ protected:
 
 TEST_F(EEPROMMgrTest, Init_SucceedsFirstTime) {
   // Already initialized in SetUp
-  EXPECT_TRUE(EepromManager::getInstance().init());
+  EXPECT_TRUE(lattice::eeprom::init());
 }
 
 TEST_F(EEPROMMgrTest, Init_IdempotentOnSecondCall) {
-  auto& mgr = EepromManager::getInstance();
-  EXPECT_TRUE(mgr.init());
-  EXPECT_TRUE(mgr.init()); // Second call should return true
+  namespace mgr = lattice::eeprom;
+  EXPECT_TRUE(mgr::init());
+  EXPECT_TRUE(mgr::init()); // Second call should return true
 }
 
 // -----------------------------------------------------------------------
@@ -51,20 +51,20 @@ TEST_F(EEPROMMgrTest, Init_IdempotentOnSecondCall) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, BootEpoch_StartsAtZeroWhenUnset) {
-  uint32_t epoch = EepromManager::getInstance().loadBootEpoch();
+  uint32_t epoch = lattice::eeprom::loadBootEpoch();
   EXPECT_EQ(epoch, 0u);
 }
 
 TEST_F(EEPROMMgrTest, BootEpoch_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveBootEpoch(12345);
-  EXPECT_EQ(mgr.loadBootEpoch(), 12345u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveBootEpoch(12345);
+  EXPECT_EQ(mgr::loadBootEpoch(), 12345u);
 }
 
 TEST_F(EEPROMMgrTest, BootEpoch_WrapsAtMax) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveBootEpoch(0xFFFFFFFE);
-  EXPECT_EQ(mgr.loadBootEpoch(), 0xFFFFFFFEu);
+  namespace mgr = lattice::eeprom;
+  mgr::saveBootEpoch(0xFFFFFFFE);
+  EXPECT_EQ(mgr::loadBootEpoch(), 0xFFFFFFFEu);
 }
 
 // -----------------------------------------------------------------------
@@ -72,23 +72,23 @@ TEST_F(EEPROMMgrTest, BootEpoch_WrapsAtMax) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, MasterFlag_DefaultsToFalse) {
-  EXPECT_FALSE(EepromManager::getInstance().loadMasterFlag());
+  EXPECT_FALSE(lattice::eeprom::loadMasterFlag());
 }
 
 TEST_F(EEPROMMgrTest, MasterFlag_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveMasterFlag(true);
-  EXPECT_TRUE(mgr.loadMasterFlag());
-  mgr.saveMasterFlag(false);
-  EXPECT_FALSE(mgr.loadMasterFlag());
+  namespace mgr = lattice::eeprom;
+  mgr::saveMasterFlag(true);
+  EXPECT_TRUE(mgr::loadMasterFlag());
+  mgr::saveMasterFlag(false);
+  EXPECT_FALSE(mgr::loadMasterFlag());
 }
 
 TEST_F(EEPROMMgrTest, MasterFlag_SkipSaveInDevMode) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(true);
-  mgr.saveMasterFlag(true);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(true);
+  mgr::saveMasterFlag(true);
   // Should not be saved
-  EXPECT_FALSE(mgr.loadMasterFlag());
+  EXPECT_FALSE(mgr::loadMasterFlag());
 }
 
 // -----------------------------------------------------------------------
@@ -96,15 +96,15 @@ TEST_F(EEPROMMgrTest, MasterFlag_SkipSaveInDevMode) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, DevFlag_DefaultsToFalse) {
-  EXPECT_FALSE(EepromManager::getInstance().loadDevFlag());
+  EXPECT_FALSE(lattice::eeprom::loadDevFlag());
 }
 
 TEST_F(EEPROMMgrTest, DevFlag_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveDevFlag(true);
-  EXPECT_TRUE(mgr.loadDevFlag());
-  mgr.saveDevFlag(false);
-  EXPECT_FALSE(mgr.loadDevFlag());
+  namespace mgr = lattice::eeprom;
+  mgr::saveDevFlag(true);
+  EXPECT_TRUE(mgr::loadDevFlag());
+  mgr::saveDevFlag(false);
+  EXPECT_FALSE(mgr::loadDevFlag());
 }
 
 // -----------------------------------------------------------------------
@@ -112,29 +112,29 @@ TEST_F(EEPROMMgrTest, DevFlag_SaveAndLoad_RoundTrip) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, MeshKey_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   
   uint8_t key[16];
   for (int i = 0; i < 16; ++i) {
     key[i] = static_cast<uint8_t>(i + 100);
   }
 
-  mgr.saveMeshKey(key, 16);
+  mgr::saveMeshKey(key, 16);
 
   uint8_t loaded[16]{};
-  EXPECT_TRUE(mgr.loadMeshKey(loaded, 16));
+  EXPECT_TRUE(mgr::loadMeshKey(loaded, 16));
   EXPECT_EQ(memcmp(loaded, key, 16), 0);
 }
 
 TEST_F(EEPROMMgrTest, MeshKey_Load_NotFound_ReturnsFalse) {
   uint8_t key[16]{};
-  EXPECT_FALSE(EepromManager::getInstance().loadMeshKey(key, 16));
+  EXPECT_FALSE(lattice::eeprom::loadMeshKey(key, 16));
 }
 
 TEST_F(EEPROMMgrTest, MeshKey_WrongSize_ReturnsFalse) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   uint8_t key[16]{};
-  EXPECT_FALSE(mgr.loadMeshKey(key, 8)); // Wrong size
+  EXPECT_FALSE(mgr::loadMeshKey(key, 8)); // Wrong size
 }
 
 // -----------------------------------------------------------------------
@@ -142,10 +142,10 @@ TEST_F(EEPROMMgrTest, MeshKey_WrongSize_ReturnsFalse) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, PeerList_LoadWhenEmpty_FillsWithFF_ReturnsFalse) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   uint8_t loadBuf[PEER_RECORD_SIZE]{};
-  bool ok = mgr.loadPeerList(loadBuf, 1);
+  bool ok = mgr::loadPeerList(loadBuf, 1);
   
   EXPECT_FALSE(ok);
   // Verify buffer is filled with 0xFF
@@ -155,7 +155,7 @@ TEST_F(EEPROMMgrTest, PeerList_LoadWhenEmpty_FillsWithFF_ReturnsFalse) {
 }
 
 TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_SinglePeer) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   // Build a 38-byte peer record: 6-byte MAC + 32-byte public key
   uint8_t peerRecord[PEER_RECORD_SIZE]{};
@@ -168,10 +168,10 @@ TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_SinglePeer) {
   peerRecord[6] = 0x01;  // publicKey[0]
   peerRecord[37] = 0x7F; // publicKey[31]
 
-  mgr.savePeerList(peerRecord, 1);
+  mgr::savePeerList(peerRecord, 1);
 
   uint8_t loaded[PEER_RECORD_SIZE]{};
-  bool ok = mgr.loadPeerList(loaded, 1);
+  bool ok = mgr::loadPeerList(loaded, 1);
 
   EXPECT_TRUE(ok);
   EXPECT_EQ(loaded[0], 0xAA);
@@ -182,7 +182,7 @@ TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_SinglePeer) {
 }
 
 TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_MaxPeers) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   constexpr size_t MAX = 10;
   uint8_t peers[MAX * PEER_RECORD_SIZE]{};
@@ -190,10 +190,10 @@ TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_MaxPeers) {
     peers[i * PEER_RECORD_SIZE] = static_cast<uint8_t>(i + 1); // Unique first MAC byte
   }
 
-  mgr.savePeerList(peers, MAX);
+  mgr::savePeerList(peers, MAX);
 
   uint8_t loaded[MAX * PEER_RECORD_SIZE]{};
-  bool ok = mgr.loadPeerList(loaded, MAX);
+  bool ok = mgr::loadPeerList(loaded, MAX);
 
   EXPECT_TRUE(ok);
   for (size_t i = 0; i < MAX; ++i) {
@@ -202,39 +202,39 @@ TEST_F(EEPROMMgrTest, PeerList_SaveAndLoad_MaxPeers) {
 }
 
 TEST_F(EEPROMMgrTest, PeerList_SaveZero_ClearsList) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   // First save some peers
   uint8_t peerRecord[PEER_RECORD_SIZE]{};
   peerRecord[0] = 0xAA;
-  mgr.savePeerList(peerRecord, 1);
-  EXPECT_TRUE(mgr.hasPeers());
+  mgr::savePeerList(peerRecord, 1);
+  EXPECT_TRUE(mgr::hasPeers());
 
   // Now save zero peers
-  mgr.savePeerList(peerRecord, 0);
-  EXPECT_FALSE(mgr.hasPeers());
+  mgr::savePeerList(peerRecord, 0);
+  EXPECT_FALSE(mgr::hasPeers());
 }
 
 TEST_F(EEPROMMgrTest, PeerList_HasPeers_ReturnsFalseWhenEmpty) {
-  EXPECT_FALSE(EepromManager::getInstance().hasPeers());
+  EXPECT_FALSE(lattice::eeprom::hasPeers());
 }
 
 TEST_F(EEPROMMgrTest, PeerList_HasPeers_ReturnsTrueAfterSave) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   uint8_t peerRecord[PEER_RECORD_SIZE]{};
-  mgr.savePeerList(peerRecord, 1);
-  EXPECT_TRUE(mgr.hasPeers());
+  mgr::savePeerList(peerRecord, 1);
+  EXPECT_TRUE(mgr::hasPeers());
 }
 
 TEST_F(EEPROMMgrTest, PeerList_ClearPeerList_RemovesAllPeers) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   
   uint8_t peerRecord[PEER_RECORD_SIZE]{};
-  mgr.savePeerList(peerRecord, 1);
-  EXPECT_TRUE(mgr.hasPeers());
+  mgr::savePeerList(peerRecord, 1);
+  EXPECT_TRUE(mgr::hasPeers());
 
-  mgr.clearPeerList();
-  EXPECT_FALSE(mgr.hasPeers());
+  mgr::clearPeerList();
+  EXPECT_FALSE(mgr::hasPeers());
 }
 
 // -----------------------------------------------------------------------
@@ -242,13 +242,13 @@ TEST_F(EEPROMMgrTest, PeerList_ClearPeerList_RemovesAllPeers) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, AdapterType_DefaultIsZero) {
-  EXPECT_EQ(EepromManager::getInstance().loadAdapterType(), 0u);
+  EXPECT_EQ(lattice::eeprom::loadAdapterType(), 0u);
 }
 
 TEST_F(EEPROMMgrTest, AdapterType_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveAdapterType(3);
-  EXPECT_EQ(mgr.loadAdapterType(), 3u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveAdapterType(3);
+  EXPECT_EQ(mgr::loadAdapterType(), 3u);
 }
 
 // -----------------------------------------------------------------------
@@ -256,23 +256,23 @@ TEST_F(EEPROMMgrTest, AdapterType_SaveAndLoad_RoundTrip) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, RebootCount_DefaultIsZero) {
-  EXPECT_EQ(EepromManager::getInstance().loadRebootCount(), 0u);
+  EXPECT_EQ(lattice::eeprom::loadRebootCount(), 0u);
 }
 
 TEST_F(EEPROMMgrTest, RebootCount_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveRebootCount(5);
-  EXPECT_EQ(mgr.loadRebootCount(), 5u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveRebootCount(5);
+  EXPECT_EQ(mgr::loadRebootCount(), 5u);
 }
 
 TEST_F(EEPROMMgrTest, RebootReason_DefaultIs0xFF) {
-  EXPECT_EQ(EepromManager::getInstance().loadRebootReason(), 0xFFu);
+  EXPECT_EQ(lattice::eeprom::loadRebootReason(), 0xFFu);
 }
 
 TEST_F(EEPROMMgrTest, RebootReason_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveRebootReason(42);
-  EXPECT_EQ(mgr.loadRebootReason(), 42u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveRebootReason(42);
+  EXPECT_EQ(mgr::loadRebootReason(), 42u);
 }
 
 // -----------------------------------------------------------------------
@@ -280,7 +280,7 @@ TEST_F(EEPROMMgrTest, RebootReason_SaveAndLoad_RoundTrip) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, Keypair_SaveAndLoad_ValidCRC) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   uint8_t privKey[32]{}, pubKey[32]{};
   for (int i = 0; i < 32; ++i) {
@@ -288,10 +288,10 @@ TEST_F(EEPROMMgrTest, Keypair_SaveAndLoad_ValidCRC) {
     pubKey[i] = static_cast<uint8_t>(i + 32);
   }
 
-  mgr.saveKeypair(privKey, pubKey);
+  mgr::saveKeypair(privKey, pubKey);
 
   uint8_t loadedPriv[32]{}, loadedPub[32]{};
-  EXPECT_TRUE(mgr.loadKeypair(loadedPriv, loadedPub));
+  EXPECT_TRUE(mgr::loadKeypair(loadedPriv, loadedPub));
   EXPECT_EQ(memcmp(loadedPriv, privKey, 32), 0);
   EXPECT_EQ(memcmp(loadedPub, pubKey, 32), 0);
 }
@@ -299,23 +299,23 @@ TEST_F(EEPROMMgrTest, Keypair_SaveAndLoad_ValidCRC) {
 TEST_F(EEPROMMgrTest, Keypair_Load_NotFound_ReturnsFalse) {
   // No keypair saved — should return false
   uint8_t p1[32]{}, p2[32]{};
-  EXPECT_FALSE(EepromManager::getInstance().loadKeypair(p1, p2));
+  EXPECT_FALSE(lattice::eeprom::loadKeypair(p1, p2));
 }
 
 TEST_F(EEPROMMgrTest, Keypair_Load_CorruptedData_ReturnsFalse) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
 
   uint8_t priv[32];
   memset(priv, 42, 32);
   uint8_t pub[32];
   memset(pub, 99, 32);
-  mgr.saveKeypair(priv, pub);
+  mgr::saveKeypair(priv, pub);
 
   // Manually corrupt the CRC in the NVS store
   Preferences::_store["lattice/" + std::string(lattice::utils::NVS_KEYS::KEYPAIR_CRC)] = {0xFF, 0xFF, 0xFF, 0xFF};
 
   uint8_t p1[32]{}, p2[32]{};
-  EXPECT_FALSE(mgr.loadKeypair(p1, p2));
+  EXPECT_FALSE(mgr::loadKeypair(p1, p2));
 }
 
 // -----------------------------------------------------------------------
@@ -323,15 +323,15 @@ TEST_F(EEPROMMgrTest, Keypair_Load_CorruptedData_ReturnsFalse) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, EnrolledFlag_DefaultsToFalse) {
-  EXPECT_FALSE(EepromManager::getInstance().loadEnrolledFlag());
+  EXPECT_FALSE(lattice::eeprom::loadEnrolledFlag());
 }
 
 TEST_F(EEPROMMgrTest, EnrolledFlag_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveEnrolledFlag(true);
-  EXPECT_TRUE(mgr.loadEnrolledFlag());
-  mgr.saveEnrolledFlag(false);
-  EXPECT_FALSE(mgr.loadEnrolledFlag());
+  namespace mgr = lattice::eeprom;
+  mgr::saveEnrolledFlag(true);
+  EXPECT_TRUE(mgr::loadEnrolledFlag());
+  mgr::saveEnrolledFlag(false);
+  EXPECT_FALSE(mgr::loadEnrolledFlag());
 }
 
 // -----------------------------------------------------------------------
@@ -339,42 +339,42 @@ TEST_F(EEPROMMgrTest, EnrolledFlag_SaveAndLoad_RoundTrip) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, KnownMasterMac_UnsetReturnsFalse) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   uint8_t mac[6] = {};
-  bool found = mgr.loadKnownMasterMac(mac);
+  bool found = mgr::loadKnownMasterMac(mac);
   EXPECT_FALSE(found);
 }
 
 TEST_F(EEPROMMgrTest, KnownMasterMac_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   const uint8_t expected[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
-  mgr.saveKnownMasterMac(expected);
+  mgr::saveKnownMasterMac(expected);
 
   uint8_t loaded[6] = {};
-  bool found = mgr.loadKnownMasterMac(loaded);
+  bool found = mgr::loadKnownMasterMac(loaded);
 
   EXPECT_TRUE(found);
   EXPECT_EQ(memcmp(loaded, expected, 6), 0);
 }
 
 TEST_F(EEPROMMgrTest, KnownMasterMac_Clear_ResetsToUnset) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   const uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-  mgr.saveKnownMasterMac(mac);
-  mgr.clearKnownMasterMac();
+  mgr::saveKnownMasterMac(mac);
+  mgr::clearKnownMasterMac();
 
   uint8_t loaded[6] = {};
-  bool found = mgr.loadKnownMasterMac(loaded);
+  bool found = mgr::loadKnownMasterMac(loaded);
   EXPECT_FALSE(found);
 }
 
 TEST_F(EEPROMMgrTest, KnownMasterMac_AllFF_TreatedAsUnset) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   const uint8_t mac[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  mgr.saveKnownMasterMac(mac);
+  mgr::saveKnownMasterMac(mac);
 
   uint8_t loaded[6] = {};
-  bool found = mgr.loadKnownMasterMac(loaded);
+  bool found = mgr::loadKnownMasterMac(loaded);
   EXPECT_FALSE(found);
 }
 
@@ -383,32 +383,32 @@ TEST_F(EEPROMMgrTest, KnownMasterMac_AllFF_TreatedAsUnset) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_UnsetReturnsFalse) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   uint8_t mac[6] = {};
-  bool found = mgr.loadKnownMasterMacSecondary(mac);
+  bool found = mgr::loadKnownMasterMacSecondary(mac);
   EXPECT_FALSE(found);
 }
 
 TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_SaveAndLoad_RoundTrip) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   const uint8_t expected[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
-  mgr.saveKnownMasterMacSecondary(expected);
+  mgr::saveKnownMasterMacSecondary(expected);
 
   uint8_t loaded[6] = {};
-  bool found = mgr.loadKnownMasterMacSecondary(loaded);
+  bool found = mgr::loadKnownMasterMacSecondary(loaded);
 
   EXPECT_TRUE(found);
   EXPECT_EQ(memcmp(loaded, expected, 6), 0);
 }
 
 TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_Clear_ResetsToUnset) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   const uint8_t mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-  mgr.saveKnownMasterMacSecondary(mac);
-  mgr.clearKnownMasterMacSecondary();
+  mgr::saveKnownMasterMacSecondary(mac);
+  mgr::clearKnownMasterMacSecondary();
 
   uint8_t loaded[6] = {};
-  bool found = mgr.loadKnownMasterMacSecondary(loaded);
+  bool found = mgr::loadKnownMasterMacSecondary(loaded);
   EXPECT_FALSE(found);
 }
 
@@ -417,14 +417,14 @@ TEST_F(EEPROMMgrTest, KnownMasterMacSecondary_Clear_ResetsToUnset) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, TxPower_DefaultIsOutdoor) {
-  auto preset = EepromManager::getInstance().loadTxPowerPreset();
+  auto preset = lattice::eeprom::loadTxPowerPreset();
   EXPECT_EQ(preset, lattice::config::TxPowerPreset::OUTDOOR);
 }
 
 TEST_F(EEPROMMgrTest, TxPower_SaveAndLoad) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveTxPowerPreset(lattice::config::TxPowerPreset::INDOOR);
-  EXPECT_EQ(mgr.loadTxPowerPreset(), lattice::config::TxPowerPreset::INDOOR);
+  namespace mgr = lattice::eeprom;
+  mgr::saveTxPowerPreset(lattice::config::TxPowerPreset::INDOOR);
+  EXPECT_EQ(mgr::loadTxPowerPreset(), lattice::config::TxPowerPreset::INDOOR);
 }
 
 // -----------------------------------------------------------------------
@@ -432,20 +432,20 @@ TEST_F(EEPROMMgrTest, TxPower_SaveAndLoad) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, NodeId_DefaultIsZero) {
-  EXPECT_EQ(EepromManager::getInstance().loadNodeId(), 0u);
+  EXPECT_EQ(lattice::eeprom::loadNodeId(), 0u);
 }
 
 TEST_F(EEPROMMgrTest, NodeId_SaveAndLoad) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveNodeId(42);
-  EXPECT_EQ(mgr.loadNodeId(), 42u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveNodeId(42);
+  EXPECT_EQ(mgr::loadNodeId(), 42u);
 }
 
 TEST_F(EEPROMMgrTest, NodeId_SaveZeroRoundtrips) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveNodeId(7);
-  mgr.saveNodeId(0);
-  EXPECT_EQ(mgr.loadNodeId(), 0u);
+  namespace mgr = lattice::eeprom;
+  mgr::saveNodeId(7);
+  mgr::saveNodeId(0);
+  EXPECT_EQ(mgr::loadNodeId(), 0u);
 }
 
 // -----------------------------------------------------------------------
@@ -453,19 +453,19 @@ TEST_F(EEPROMMgrTest, NodeId_SaveZeroRoundtrips) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, ClearAll_RemovesAllData) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   
   // Save various data
-  mgr.saveMasterFlag(true);
-  mgr.saveDevFlag(true);
-  mgr.saveNodeId(42);
+  mgr::saveMasterFlag(true);
+  mgr::saveDevFlag(true);
+  mgr::saveNodeId(42);
   
-  mgr.clearAll();
+  mgr::clearAll();
   
   // Verify all data is cleared
-  EXPECT_FALSE(mgr.loadMasterFlag());
-  EXPECT_FALSE(mgr.loadDevFlag());
-  EXPECT_EQ(mgr.loadNodeId(), 0u);
+  EXPECT_FALSE(mgr::loadMasterFlag());
+  EXPECT_FALSE(mgr::loadDevFlag());
+  EXPECT_EQ(mgr::loadNodeId(), 0u);
 }
 
 // -----------------------------------------------------------------------
@@ -473,17 +473,17 @@ TEST_F(EEPROMMgrTest, ClearAll_RemovesAllData) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, FlushIfDirty_IsNoOp) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveNodeId(42);
-  mgr.flushIfDirty(); // Should be a no-op
-  EXPECT_EQ(mgr.loadNodeId(), 42u); // Data should already be persisted
+  namespace mgr = lattice::eeprom;
+  mgr::saveNodeId(42);
+  mgr::flushIfDirty(); // Should be a no-op
+  EXPECT_EQ(mgr::loadNodeId(), 42u); // Data should already be persisted
 }
 
 TEST_F(EEPROMMgrTest, ForceFlush_IsNoOp) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.saveNodeId(42);
-  mgr.forceFlush(); // Should be a no-op
-  EXPECT_EQ(mgr.loadNodeId(), 42u); // Data should already be persisted
+  namespace mgr = lattice::eeprom;
+  mgr::saveNodeId(42);
+  mgr::forceFlush(); // Should be a no-op
+  EXPECT_EQ(mgr::loadNodeId(), 42u); // Data should already be persisted
 }
 
 // -----------------------------------------------------------------------
@@ -491,28 +491,28 @@ TEST_F(EEPROMMgrTest, ForceFlush_IsNoOp) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, SaveBootEpoch_DevMode_UsesRAMSeed) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(true);
-  mgr.saveBootEpoch(5);
-  EXPECT_EQ(mgr.loadBootEpoch(), 5u);
-  mgr.saveBootEpoch(7);
-  EXPECT_EQ(mgr.loadBootEpoch(), 7u);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(true);
+  mgr::saveBootEpoch(5);
+  EXPECT_EQ(mgr::loadBootEpoch(), 5u);
+  mgr::saveBootEpoch(7);
+  EXPECT_EQ(mgr::loadBootEpoch(), 7u);
 }
 
 TEST_F(EEPROMMgrTest, SaveBootEpoch_DevMode_DoesNotTouchNVS) {
-  auto& mgr = EepromManager::getInstance();
+  namespace mgr = lattice::eeprom;
   Preferences::_store.clear();
-  mgr.setDevMode(true);
-  mgr.saveBootEpoch(42);
+  mgr::setDevMode(true);
+  mgr::saveBootEpoch(42);
   // NVS store must be empty — DEV never persists.
   EXPECT_TRUE(Preferences::_store.empty());
 }
 
 TEST_F(EEPROMMgrTest, SaveBootEpoch_ProdMode_Persists) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(false);
-  mgr.saveBootEpoch(9);
-  EXPECT_EQ(mgr.loadBootEpoch(), 9u);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(false);
+  mgr::saveBootEpoch(9);
+  EXPECT_EQ(mgr::loadBootEpoch(), 9u);
 }
 
 // -----------------------------------------------------------------------
@@ -520,38 +520,38 @@ TEST_F(EEPROMMgrTest, SaveBootEpoch_ProdMode_Persists) {
 // -----------------------------------------------------------------------
 
 TEST_F(EEPROMMgrTest, SaveBootEpoch_ProdMode_ShortWrite_Fatal) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(false);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(false);
   Preferences::_shortWriteKey =
       lattice::utils::NVS_KEYS::BOOT_EPOCH; // mock: next putUInt for this key returns 0
-  EXPECT_THROW(mgr.saveBootEpoch(1), lattice::err::FatalError);
+  EXPECT_THROW(mgr::saveBootEpoch(1), lattice::err::FatalError);
   Preferences::_shortWriteKey = nullptr;
 }
 
 TEST_F(EEPROMMgrTest, SaveKnownMasterMac_ShortWrite_Fatal) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(false);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(false);
   uint8_t mac[6] = {1,2,3,4,5,6};
   Preferences::_shortWriteKey = lattice::utils::NVS_KEYS::KNOWN_MASTER_MAC;
-  EXPECT_THROW(mgr.saveKnownMasterMac(mac), lattice::err::FatalError);
+  EXPECT_THROW(mgr::saveKnownMasterMac(mac), lattice::err::FatalError);
   Preferences::_shortWriteKey = nullptr;
 }
 
 TEST_F(EEPROMMgrTest, SaveBootEpoch_ProdMode_FullWrite_NoFatal) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(false);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(false);
   int before = lattice_test_errFailCount;
-  mgr.saveBootEpoch(3);
+  mgr::saveBootEpoch(3);
   EXPECT_EQ(lattice_test_errFailCount, before);
-  EXPECT_EQ(mgr.loadBootEpoch(), 3u);
+  EXPECT_EQ(mgr::loadBootEpoch(), 3u);
 }
 
 TEST_F(EEPROMMgrTest, SaveRebootCount_ShortWrite_WarnsNoFatal) {
-  auto& mgr = EepromManager::getInstance();
-  mgr.setDevMode(false);
+  namespace mgr = lattice::eeprom;
+  mgr::setDevMode(false);
   int before = lattice_test_errFailCount;
   Preferences::_shortWriteKey = lattice::utils::NVS_KEYS::REBOOT_COUNT;
-  mgr.saveRebootCount(1);                 // Non-security setter: must NOT escalate
+  mgr::saveRebootCount(1);                 // Non-security setter: must NOT escalate
   EXPECT_EQ(lattice_test_errFailCount, before);
   Preferences::_shortWriteKey = nullptr;
 }

--- a/tests/unit/test_pir_adapter.cpp
+++ b/tests/unit/test_pir_adapter.cpp
@@ -26,7 +26,7 @@ class PIRHealthTest : public ::testing::Test {
 protected:
   void SetUp() override {
     EEPROM.reset();
-    lattice::utils::EepromManager::getInstance().init();
+    lattice::eeprom::init();
     resetMillis();
     resetWifiMock();
     lastTxType = adapter_types::UNKNOWN_ADAPTER;
@@ -168,7 +168,7 @@ TEST_F(PIRHealthTest, OpNodeIdSet_AssignsNodeId_WhenTargetMatchesMac) {
 
   pir->onMeshData(msg);
 
-  EXPECT_EQ(lattice::utils::EepromManager::getInstance().loadNodeId(), 99u);
+  EXPECT_EQ(lattice::eeprom::loadNodeId(), 99u);
   delete pir;
 }
 
@@ -192,6 +192,6 @@ TEST_F(PIRHealthTest, OpNodeIdSet_IgnoresMessage_WhenTargetMismatch) {
 
   pir->onMeshData(msg);
 
-  EXPECT_EQ(lattice::utils::EepromManager::getInstance().loadNodeId(), 0u);
+  EXPECT_EQ(lattice::eeprom::loadNodeId(), 0u);
   delete pir;
 }


### PR DESCRIPTION
## Summary
- Migrate `EepromManager` and `ErrorCore` off Meyers-singleton `getInstance()` to namespaces of free functions (`lattice::eeprom`, `lattice::err_core`) backed by file-static state — drops a `__cxa_guard_*` prologue at ~27 callsites.
- `PirAdapter` is deliberately **not** migrated: its `instance` pointer is read/set by ISR-safe static trampolines and the class itself can't go away (concrete `Adapter` subclass created polymorphically by `AdapterFactory`), so migrating its one `getInstance()` accessor would save nothing. Note: the task brief's premise that PirAdapter had "no external callers" was inaccurate — `SerialAdapter.cpp:153` calls it under `#if SIMULATE_MODE`. The skip decision still holds for the reason above; see task-6-report.md for detail.
- `Mesh::getInstance()` is untouched, per the design doc's existing deferral (same ISR-trampoline constraint, larger blast radius).
- The e2e harness's per-node byte-image snapshot/restore (`NodeContext.cpp`) now targets each module's `detail::State` struct via a `UNIT_TEST`-only `debugStateForTest()` accessor instead of the old singleton object — same memcpy technique, new anchor type.
- `BootManager::check()` and `ButtonHandler::tick()` drop their now-moot `EepromManager&` parameter (nothing to bind it to once the class is gone).

## Test plan
- [x] `cd tests && cmake --build build -j2 && ctest --parallel 1` — 293/293 passed
- [x] `idf.py -DLATTICE_ALLOW_EXAMPLE_PIN=1 reconfigure && make -j2 -C build` — builds clean
- [x] Measured flash delta for this diff alone (stash/build-baseline/pop/rebuild on this branch): **-976 bytes** (639852+136544 → 639112+136308 .text+.rodata; `0xd8610` → `0xd8240` bin size)

Full details in `.superpowers/sdd/2026-08-05-phaseH2-refactor-sweep/task-6-report.md` (gitignored, local to this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)