### PR TITLE
fix(logging): LATTICE_LOGF macro elides snprintf under LOG_NONE (item R regression)

### DIFF
--- a/firmware/main/src/adapter/Adapter.cpp
+++ b/firmware/main/src/adapter/Adapter.cpp
@@ -162,9 +162,7 @@ void Adapter::opNodeIdSet(const lattice::mesh::mesh_message& message, bool /*reb
     return;
   uint8_t nodeId = message.data[7];
   lattice::eeprom::saveNodeId(nodeId);
-  char buf[32];
-  snprintf(buf, sizeof(buf), "Node ID set: %u", (unsigned)nodeId);
-  LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_INFO);
+  LATTICE_LOGF("ADAPTER", LogLevel::LOG_INFO, "Node ID set: %u", (unsigned)nodeId);
 }
 
 void Adapter::opHealthReq(const lattice::mesh::mesh_message& /*message*/,
@@ -192,9 +190,7 @@ void Adapter::opTxPowerSet(const lattice::mesh::mesh_message& message, bool rebr
   esp_err_t txErr = esp_wifi_set_max_tx_power(
       static_cast<int8_t>(lattice::config::TX_POWER_VALUES[presetByte]));
   if (txErr != ESP_OK) {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
-    LATTICE_LOGLN("ADAPTER", buf, LogLevel::LOG_WARN);
+    LATTICE_LOGF("ADAPTER", LogLevel::LOG_WARN, "TX power set failed: %s", esp_err_to_name(txErr));
   } else {
     LATTICE_LOGLN("ADAPTER", "TX power preset applied", LogLevel::LOG_INFO);
   }

--- a/firmware/main/src/adapter/serial/SerialAdapter.cpp
+++ b/firmware/main/src/adapter/serial/SerialAdapter.cpp
@@ -26,9 +26,8 @@ void SerialAdapter::sendHealthReport() {
 SerialAdapter::SerialAdapter(uint8_t pin) : Adapter(pin), lastReportedHopCount(0) {
   _adapterType = adapter_types::SERIAL_ADAPTER;
 
-  char buf[48];
-  snprintf(buf, sizeof(buf), "Serial_Adapter constructed with pin %u", (unsigned)pin);
-  LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_INFO, "Serial_Adapter constructed with pin %u",
+               (unsigned)pin);
 }
 
 bool SerialAdapter::init() {
@@ -53,16 +52,14 @@ void SerialAdapter::loop() {
     // still a full interval out, matching the original combined check.
     if (!intervalDue)
       resetHealthTick(now);
-    {
-      char buf[80];
-      if (stateChanged) {
-        snprintf(buf, sizeof(buf), "Health report triggered by state change (hopCount: %lu)",
-                 (unsigned long)currentHopCount);
-      } else {
-        snprintf(buf, sizeof(buf), "Sending periodic health report (hopCount: %lu)",
-                 (unsigned long)currentHopCount);
-      }
-      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
+    if (stateChanged) {
+      LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+                   "Health report triggered by state change (hopCount: %lu)",
+                   (unsigned long)currentHopCount);
+    } else {
+      LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+                   "Sending periodic health report (hopCount: %lu)",
+                   (unsigned long)currentHopCount);
     }
     sendHealthReport();
     lastReportedHopCount = currentHopCount;
@@ -77,14 +74,10 @@ void SerialAdapter::loop() {
 }
 
 void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
-  {
-    char buf[96];
-    snprintf(buf, sizeof(buf),
-             "Processing incoming mesh message - Type: %u DataType: %ld HopCount: %u",
-             (unsigned)message.message_type, (long)message.data_type,
-             (unsigned)message.hop_count);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+               "Processing incoming mesh message - Type: %u DataType: %ld HopCount: %u",
+               (unsigned)message.message_type, (long)message.data_type,
+               (unsigned)message.hop_count);
 
   // Control opcodes (CONFIG_SET/NODE_ID_SET/HEALTH_REQ/TX_POWER_SET) received
   // via mesh are all handled once, in Adapter::onMeshData() (base class),
@@ -103,11 +96,8 @@ void SerialAdapter::onMeshDataImpl(const lattice::mesh::mesh_message& message) {
     return;
   }
 
-  {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Encoded mesh message to %u bytes, sending to serial", (unsigned)n);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+               "Encoded mesh message to %u bytes, sending to serial", (unsigned)n);
 
   // 2-byte little-endian length prefix
   uint8_t lenLE[2] = {static_cast<uint8_t>(n & 0xFF), static_cast<uint8_t>((n >> 8) & 0xFF)};
@@ -139,11 +129,8 @@ void SerialAdapter::relayEnrollmentToServer(const uint8_t* mac, const uint8_t* p
 }
 
 void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
-  {
-    char buf[48];
-    snprintf(buf, sizeof(buf), "Handling complete frame of %u bytes", (unsigned)len);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_INFO, "Handling complete frame of %u bytes",
+               (unsigned)len);
 
 #if SIMULATE_MODE
   if (len >= 1) {
@@ -193,12 +180,8 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
     return;
   }
 
-  {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Decoded message - Type: %u DataType: %ld",
-             (unsigned)msg.message_type, (long)msg.data_type);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_INFO);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_INFO, "Decoded message - Type: %u DataType: %ld",
+               (unsigned)msg.message_type, (long)msg.data_type);
 
   // JOIN_ACK (type=4): server responded to an enrollment request
   if (msg.message_type == MESH_TYPE_JOIN_ACK) {
@@ -279,9 +262,8 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
           destMac, static_cast<adapter_types>(msg.data_type), fwdData);
     }
   } else {
-    char buf[48];
-    snprintf(buf, sizeof(buf), "Unknown message type: %u", (unsigned)msg.message_type);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
+    LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_WARN, "Unknown message type: %u",
+                 (unsigned)msg.message_type);
   }
 
   // Control opcodes (CONFIG_SET/NODE_ID_SET/HEALTH_REQ/TX_POWER_SET), sent by
@@ -292,18 +274,16 @@ void SerialAdapter::handleCompleteFrame(const uint8_t* data, size_t len) {
   // must still propagate to the rest of the mesh, unlike one arriving via the
   // mesh itself (already broadcast once).
   if (msg.data_type == adapter_types::SERIAL_ADAPTER) {
-    uint8_t op = msg.data[0];
-    {
-      char buf[64];
-      snprintf(buf, sizeof(buf), "Processing SERIAL_ADAPTER control opcode: 0x%02X", op);
-      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-    }
+    // msg.data[0] read inline (rather than a local `op`) so that under LOG_NONE,
+    // where both LATTICE_LOGF calls below fold to ((void)0), there's no
+    // now-unused local left behind to warn about.
+    LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+                 "Processing SERIAL_ADAPTER control opcode: 0x%02X", msg.data[0]);
 
     bool handled = dispatchControlOp(msg, /*rebroadcastOnMaster=*/true);
     if (!handled) {
-      char buf[64];
-      snprintf(buf, sizeof(buf), "Unknown SERIAL_ADAPTER opcode: 0x%02X", op);
-      LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_WARN);
+      LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_WARN, "Unknown SERIAL_ADAPTER opcode: 0x%02X",
+                   msg.data[0]);
     }
   }
 

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -17,12 +17,9 @@ using lattice::hw::readOwnMac;
 
 size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* out, size_t maxLen) {
   using namespace lattice::utils;
-  {
-    char buf[80];
-    snprintf(buf, sizeof(buf), "Encoding mesh message - Type: %u DataType: %ld HopCount: %u",
-             (unsigned)msg.message_type, (long)msg.data_type, (unsigned)msg.hop_count);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+               "Encoding mesh message - Type: %u DataType: %ld HopCount: %u",
+               (unsigned)msg.message_type, (long)msg.data_type, (unsigned)msg.hop_count);
 
   mesh_MeshMessage pbMsg = mesh_MeshMessage_init_zero;
   pbMsg.messageType = static_cast<uint32_t>(msg.message_type);
@@ -91,22 +88,15 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     return 0;
   }
 
-  {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Successfully encoded mesh message to %u bytes",
-             (unsigned)stream.bytes_written);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG,
+               "Successfully encoded mesh message to %u bytes", (unsigned)stream.bytes_written);
   return stream.bytes_written;
 }
 
 bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_message& outMsg) {
   using namespace lattice::utils;
-  {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Decoding protobuf message of %u bytes", (unsigned)len);
-    LATTICE_LOGLN("Serial_Adapter", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Serial_Adapter", LogLevel::LOG_DEBUG, "Decoding protobuf message of %u bytes",
+               (unsigned)len);
 
   memset(&outMsg, 0, sizeof(outMsg));
 

--- a/firmware/main/src/app/ButtonHandler.h
+++ b/firmware/main/src/app/ButtonHandler.h
@@ -38,23 +38,15 @@ private:
           bool newMaster = !mesh.getIsMaster();
           mesh.setIsMaster(newMaster);
           devMasterFlag = newMaster;
-          {
-            char buf[48];
-            snprintf(buf, sizeof(buf), "DEV MODE: Role toggled. Now %s",
-                     newMaster ? "MASTER" : "NODE");
-            LATTICE_LOGLN("MAIN", buf, lattice::utils::LogLevel::LOG_INFO);
-          }
+          LATTICE_LOGF("MAIN", lattice::utils::LogLevel::LOG_INFO, "DEV MODE: Role toggled. Now %s",
+                       newMaster ? "MASTER" : "NODE");
           greenLed.blink(newMaster ? 3 : 2, 150, 150);
         } else {
           bool wasMaster = lattice::eeprom::loadMasterFlag();
           bool newMaster = !wasMaster;
           lattice::eeprom::saveMasterFlag(newMaster);
-          {
-            char buf[64];
-            snprintf(buf, sizeof(buf), "Button held 5s: CONFIG TOGGLED. Now %s",
-                     newMaster ? "MASTER" : "NODE");
-            LATTICE_LOGLN("MAIN", buf, lattice::utils::LogLevel::LOG_INFO);
-          }
+          LATTICE_LOGF("MAIN", lattice::utils::LogLevel::LOG_INFO,
+                       "Button held 5s: CONFIG TOGGLED. Now %s", newMaster ? "MASTER" : "NODE");
           LATTICE_LOGLN("MAIN", "Restarting in 2 seconds for new role...",
                         lattice::utils::LogLevel::LOG_INFO);
           greenLed.blink(newMaster ? 3 : 2, 200, 200);

--- a/firmware/main/src/error/Error.h
+++ b/firmware/main/src/error/Error.h
@@ -79,9 +79,8 @@ inline bool check(bool condition, utils::ErrorType type, const char* msg) {
 inline bool checkEsp(esp_err_t status, utils::ErrorType type, const char* msg) {
   if (status == ESP_OK)
     return true;
-  char buf[96];
-  snprintf(buf, sizeof(buf), "%s: %s", msg ? msg : "", esp_err_to_name(status));
-  LATTICE_LOGLN("ESP", buf, utils::LogLevel::LOG_ERROR);
+  LATTICE_LOGF("ESP", utils::LogLevel::LOG_ERROR, "%s: %s", msg ? msg : "",
+               esp_err_to_name(status));
   return fail(type, msg);
 }
 } // namespace err

--- a/firmware/main/src/error/ErrorCore.cpp
+++ b/firmware/main/src/error/ErrorCore.cpp
@@ -98,9 +98,7 @@ void signalError(ErrorTypeDigit t, ModuleDigit m, uint8_t sub, const char* msg) 
 
 void signalError(ErrorType type, const char* msg) {
   if (msg) {
-    char buf[96];
-    snprintf(buf, sizeof(buf), "ERROR: %s", msg);
-    LATTICE_LOGLN("Error", buf, lattice::utils::LogLevel::LOG_ERROR);
+    LATTICE_LOGF("Error", lattice::utils::LogLevel::LOG_ERROR, "ERROR: %s", msg);
   }
   if (_state.initialized && _state.errorLed) {
     if (_state.inCallbackContext) {

--- a/firmware/main/src/hardware/output/Led.cpp
+++ b/firmware/main/src/hardware/output/Led.cpp
@@ -30,18 +30,13 @@ bool Led::init() {
       lattice::err::fail(lattice::core::ErrorTypeDigit::CONFIG, lattice::core::ModuleDigit::HW, 1,
                          "Led: Invalid pin number");
     }
-    char buf[48];
-    snprintf(buf, sizeof(buf), "ERROR: Invalid pin number for LED: %u", (unsigned)_pin);
-    LATTICE_LOGLN("Led", buf, LogLevel::LOG_ERROR);
+    LATTICE_LOGF("Led", LogLevel::LOG_ERROR, "ERROR: Invalid pin number for LED: %u",
+                 (unsigned)_pin);
     return false;
   }
   digitalWrite(_pin, LOW);
   _isOn = false;
-  {
-    char buf[48];
-    snprintf(buf, sizeof(buf), "Initialized LED on pin %u", (unsigned)_pin);
-    LATTICE_LOGLN("Led", buf, LogLevel::LOG_INFO);
-  }
+  LATTICE_LOGF("Led", LogLevel::LOG_INFO, "Initialized LED on pin %u", (unsigned)_pin);
   return true;
 }
 
@@ -96,11 +91,8 @@ bool Led::setState(bool state) {
     return true;
   digitalWrite(_pin, state ? HIGH : LOW);
   _isOn = state;
-  {
-    char buf[48];
-    snprintf(buf, sizeof(buf), "LED on pin %u %s", (unsigned)_pin, state ? "ON" : "OFF");
-    LATTICE_LOGLN("Led", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Led", LogLevel::LOG_DEBUG, "LED on pin %u %s", (unsigned)_pin,
+               state ? "ON" : "OFF");
   return true;
 }
 
@@ -124,11 +116,8 @@ bool Led::blink(uint8_t times, unsigned int onTimeMs, unsigned int offTimeMs) {
     if (i < times - 1)
       delay(offTimeMs);
   }
-  {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Blink pattern: %ux on pin %u", (unsigned)times, (unsigned)_pin);
-    LATTICE_LOGLN("Led", buf, LogLevel::LOG_DEBUG);
-  }
+  LATTICE_LOGF("Led", LogLevel::LOG_DEBUG, "Blink pattern: %ux on pin %u", (unsigned)times,
+               (unsigned)_pin);
   return true;
 }
 

--- a/firmware/main/src/logging/Logger.h
+++ b/firmware/main/src/logging/Logger.h
@@ -49,6 +49,36 @@
 #define LATTICE_LOGLN(tag, msg, level) ::lattice::utils::Logger::logln(tag, msg, level)
 #endif
 
+// ---------------------------------------------------------------------------------------------
+// LATTICE_LOGF — printf-style variant (fix for a Phase H2 regression, item R / PR #86).
+//
+// Item R converted ~35 String-concat LATTICE_LOGLN call sites to a
+// `char buf[N]; snprintf(buf, sizeof(buf), fmt, args...); LATTICE_LOGLN(tag, buf, level);`
+// pattern. That put the snprintf call and its format-string literal OUTSIDE the
+// LATTICE_LOGLN macro, as plain statements — so under LATTICE_DEFAULT_LOG_LEVEL ==
+// LOG_NONE they ran (and the format strings stayed in .rodata) even though the
+// LOGLN call itself folded to ((void)0). LATTICE_LOGF closes that gap by gating the
+// snprintf and its format string inside the same #if as LATTICE_LOG/LATTICE_LOGLN
+// above (mirrors the LOG_D pattern), so under LOG_NONE the whole call — buffer,
+// snprintf, and format-string literal — folds to ((void)0) and is eligible for the
+// linker to drop from .rodata via -fdata-sections/--gc-sections.
+//
+// Buffer size: 128 bytes. Audited every existing snprintf+LATTICE_LOGLN call site
+// being migrated onto this macro; the largest local buffer among them was 96 bytes
+// (Error.h checkEsp, ErrorCore.cpp signalError, EepromManager.cpp persistOrEscalate,
+// SerialAdapter.cpp onMeshDataImpl). 128 covers all of them with headroom, and
+// matches LOG_D's existing buffer size above for consistency.
+#if LATTICE_DEFAULT_LOG_LEVEL == LATTICE_LOG_LEVEL_NONE
+#define LATTICE_LOGF(tag, level, fmt, ...) ((void)0)
+#else
+#define LATTICE_LOGF(tag, level, fmt, ...)                                                         \
+  do {                                                                                             \
+    char _lf_buf[128];                                                                             \
+    ::snprintf(_lf_buf, sizeof(_lf_buf), fmt, ##__VA_ARGS__);                                      \
+    ::lattice::utils::Logger::logln(tag, _lf_buf, level);                                          \
+  } while (0)
+#endif
+
 namespace lattice {
 namespace utils {
 

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -75,11 +75,9 @@ void Mesh::readMacAddress() {
     // is a memcpy instead of a repeat esp_wifi_get_mac() syscall.
     lattice::hw::cacheDeviceMac(deviceMacAddress);
     LATTICE_LOG("MESH", "Device MAC: ", LogLevel::LOG_DEBUG);
-    char macBuf[18];
-    snprintf(macBuf, sizeof(macBuf), "%02X:%02X:%02X:%02X:%02X:%02X", deviceMacAddress[0],
-             deviceMacAddress[1], deviceMacAddress[2], deviceMacAddress[3], deviceMacAddress[4],
-             deviceMacAddress[5]);
-    LATTICE_LOGLN("MESH", macBuf, LogLevel::LOG_DEBUG);
+    LATTICE_LOGF("MESH", LogLevel::LOG_DEBUG, "%02X:%02X:%02X:%02X:%02X:%02X", deviceMacAddress[0],
+                 deviceMacAddress[1], deviceMacAddress[2], deviceMacAddress[3], deviceMacAddress[4],
+                 deviceMacAddress[5]);
   }
 }
 
@@ -234,11 +232,7 @@ bool Mesh::init() {
   uint32_t epoch = lattice::eeprom::loadBootEpoch() + 1;
   lattice::eeprom::saveBootEpoch(epoch);
   replay.init(epoch);
-  {
-    char buf[32];
-    snprintf(buf, sizeof(buf), "Boot epoch: %lu", (unsigned long)replay.bootEpoch);
-    LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
-  }
+  LATTICE_LOGF("MESH", LogLevel::LOG_INFO, "Boot epoch: %lu", (unsigned long)replay.bootEpoch);
 
   // Phase D (#42): DEV_MODE bypasses the beacon origin-MAC pin (dev firmware
   // regenerates a fresh keypair/MAC each boot, so pinning would reject the
@@ -258,9 +252,7 @@ bool Mesh::init() {
     uint8_t txPowerVal = lattice::config::TX_POWER_VALUES[static_cast<uint8_t>(preset)];
     esp_err_t txErr = esp_wifi_set_max_tx_power(static_cast<int8_t>(txPowerVal));
     if (txErr != ESP_OK) {
-      char buf[64];
-      snprintf(buf, sizeof(buf), "TX power set failed: %s", esp_err_to_name(txErr));
-      LATTICE_LOGLN("MESH", buf, LogLevel::LOG_WARN);
+      LATTICE_LOGF("MESH", LogLevel::LOG_WARN, "TX power set failed: %s", esp_err_to_name(txErr));
     } else {
       LATTICE_LOGLN("MESH", "TX power preset applied", LogLevel::LOG_INFO);
     }
@@ -332,10 +324,11 @@ bool Mesh::setupEspNow() {
 // ------------------------------------------------
 
 void Mesh::onDataSentCallback(const wifi_tx_info_t* mac_addr, esp_now_send_status_t status) {
-  const char* statusStr = (status == ESP_NOW_SEND_SUCCESS) ? "Delivery Success" : "Delivery Fail";
-  char buf[48];
-  snprintf(buf, sizeof(buf), "Last Packet Send Status: %s", statusStr);
-  LATTICE_LOGLN("MESH", buf, LogLevel::LOG_DEBUG);
+  // Inlined into the LATTICE_LOGF call (rather than a local `statusStr`) so that
+  // under LOG_NONE, where the whole call folds to ((void)0), there's no
+  // now-unused local left behind to warn about.
+  LATTICE_LOGF("MESH", LogLevel::LOG_DEBUG, "Last Packet Send Status: %s",
+               (status == ESP_NOW_SEND_SUCCESS) ? "Delivery Success" : "Delivery Fail");
 }
 
 void IRAM_ATTR Mesh::onDataRecvCallback(const esp_now_recv_info* info, const uint8_t* incomingData,
@@ -694,9 +687,7 @@ bool Mesh::sendBroadcast(const mesh_message& msg) {
   esp_err_t err =
       esp_now_send(BROADCAST_MAC, reinterpret_cast<const uint8_t*>(&msg), sizeof(msg));
   if (err != ESP_OK) {
-    char buf[64];
-    snprintf(buf, sizeof(buf), "Broadcast send failed: %s", esp_err_to_name(err));
-    LATTICE_LOGLN("MESH", buf, LogLevel::LOG_WARN);
+    LATTICE_LOGF("MESH", LogLevel::LOG_WARN, "Broadcast send failed: %s", esp_err_to_name(err));
     return false;
   }
   return true;
@@ -707,12 +698,20 @@ void Mesh::debugDumpRadio() {
     return;
   uint8_t ch;
   esp_wifi_get_channel(&ch, nullptr);
+  // Doesn't fit LATTICE_LOGF's single-fmt-string shape (variable-length hex dump
+  // built in a loop), so it's gated by hand with the same #if LATTICE_LOGF uses —
+  // under LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE this whole block (buffer,
+  // snprintf calls, format-string literals) compiles out entirely instead of
+  // relying solely on the runtime getDevMode() check above (fix for the same
+  // regression class as LATTICE_LOGF — item R / PR #86).
+#if LATTICE_DEFAULT_LOG_LEVEL != LATTICE_LOG_LEVEL_NONE
   char buf[96];
   int off = snprintf(buf, sizeof(buf), "DBG Channel=%u Key=", (unsigned)ch);
   for (int i = 0; i < MESH_KEY_SIZE && off > 0 && off < (int)sizeof(buf); ++i) {
     off += snprintf(buf + off, sizeof(buf) - off, "%02X ", meshKey[i]);
   }
   LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
+#endif
 }
 
 void Mesh::checkMasterTimeout() {
@@ -828,9 +827,7 @@ void Mesh::processMasterBeacon(const mesh_message& msg) {
   uint8_t derived = (min_d == 0xFF) ? 0xFF : static_cast<uint8_t>(min_d + 1);
   if (derived != currentMaster.distance) {
     currentMaster.distance = derived;
-    char buf[40];
-    snprintf(buf, sizeof(buf), "Route distance derived: %u", (unsigned)derived);
-    LATTICE_LOGLN("MESH", buf, LogLevel::LOG_INFO);
+    LATTICE_LOGF("MESH", LogLevel::LOG_INFO, "Route distance derived: %u", (unsigned)derived);
   }
 
   if (!isMaster) {

--- a/firmware/main/src/persistence/EepromManager.cpp
+++ b/firmware/main/src/persistence/EepromManager.cpp
@@ -11,8 +11,8 @@ namespace {
 
 detail::State _state;
 
-// Runs at process-exit (static-storage-duration teardown), mirroring the old
-// EepromManager::~EepromManager()'s "close NVS if we ever opened it" behavior.
+// Runs at process-exit (static-storage-duration teardown): closes NVS if it
+// was ever opened.
 struct Cleanup {
   ~Cleanup() {
     if (_state.isInitialized) {
@@ -31,9 +31,7 @@ bool ensureInitialized() {
 
 void logOperation(const char* operation, const char* details = nullptr) {
   if (details) {
-    char buf[80];
-    snprintf(buf, sizeof(buf), "%s: %s", operation, details);
-    LATTICE_LOGLN("NVS", buf, lattice::utils::LogLevel::LOG_DEBUG);
+    LATTICE_LOGF("NVS", lattice::utils::LogLevel::LOG_DEBUG, "%s: %s", operation, details);
   } else {
     LATTICE_LOGLN("NVS", operation, lattice::utils::LogLevel::LOG_DEBUG);
   }
@@ -62,12 +60,8 @@ bool persistOrEscalate(const char* key, size_t got, size_t want, bool securityRe
                        "NVS write failed (security-relevant key)");
     return false; // unreachable outside UNIT_TEST
   }
-  {
-    char buf[96];
-    snprintf(buf, sizeof(buf), "write failed key=%s got=%u want=%u", key, (unsigned)got,
-             (unsigned)want);
-    LATTICE_LOGLN("NVS", buf, lattice::utils::LogLevel::LOG_ERROR);
-  }
+  LATTICE_LOGF("NVS", lattice::utils::LogLevel::LOG_ERROR, "write failed key=%s got=%u want=%u",
+               key, (unsigned)got, (unsigned)want);
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Item R (PR #86, Task 1 of Phase H2) converted ~35 String-concat `LATTICE_LOGLN` sites to a `char buf[N]; snprintf(...); LATTICE_LOGLN(...)` pattern. The `snprintf` call and its format-string literal sit **outside** the `LATTICE_LOGLN` macro, so under `LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE` (production) they still ran and the format strings stayed in `.rodata`, even though the LOGLN call itself folded to `((void)0)`.
- Adds `LATTICE_LOGF(tag, level, fmt, ...)` to `Logger.h`, gating the snprintf + format string inside the same `#if` as `LATTICE_LOG`/`LATTICE_LOGLN` (mirrors the existing `LOG_D` pattern), and migrates all affected call sites onto it.
- `Mesh::debugDumpRadio()`'s variable-length hex-dump loop doesn't fit `LATTICE_LOGF`'s single-format-string shape, so it's hand-gated with the same `#if LATTICE_DEFAULT_LOG_LEVEL != LATTICE_LOG_LEVEL_NONE` instead of relying solely on its runtime `getDevMode()` check.
- Fixes a stale singleton-era comment in `EepromManager.cpp` (referencing the old `EepromManager::~EepromManager()` destructor, removed by item AA in the same base commit).

## Measured size delta (vs `2df2499`, ESP-IDF release build, `idf.py size`)

| Section  | Before (2df2499) | After  | Delta   |
|----------|------------------:|-------:|--------:|
| `.text`  | 639112 B          | 637928 B | **-1184 B** |
| `.rodata`| 136052 B          | 134900 B | **-1152 B** |
| `.bss`   | 22040 B           | 22040 B  | 0       |
| `.data`  | 15984 B           | 15984 B  | 0       |
| Total image | 885191 B       | 882855 B | **-2336 B** |

## Test plan
- [x] `cd tests && cmake --build build -j2 && ctest --parallel 1` — 260/293 passing, identical to baseline (33 pre-existing e2e/unit failures untouched by this change; confirmed via `git stash` A/B).
- [x] `idf.py reconfigure && idf.py build` — succeeds, no new warnings (two unused-variable warnings that appeared transiently from inlining locals into `LATTICE_LOGF` were fixed by reading the values inline instead of through a now-dead local).
- [x] `idf.py size` — confirms the `.rodata`/`.text` shrink above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)