### PR TITLE
fix(ci): bump codeql-action init/analyze together to v4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: cpp
           build-mode: manual
@@ -48,7 +48,7 @@ jobs:
           cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
           cmake --build tests/build --target lattice_e2e --parallel 2
 
-      - uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: '/language:cpp'
           upload: failure-only


### PR DESCRIPTION
## Summary
Dependabot split one lockstep-coupled codeql-action version bump into 2 separate single-step PRs (#71 init, #73 analyze). `init`/`analyze` must run matching versions or the action hard-fails with a config-version error. Branch protection makes `Analyze (cpp)` a required check, so neither PR can merge individually — this commit bumps both together.

Supersedes #71, #73 — those will be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)