### PR TITLE
fix(firmware): unblock first-boot production role assignment

### DIFF
--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -157,21 +157,26 @@ extern "C" void housekeeping_task_fn(void*) {
     // Phase I Task 10: unlike the old loop(), which `return`ed immediately in
     // this branch (skipping the trailing delay(1) entirely and effectively
     // busy-looping while unenrolled), this task always falls through to the
-    // single vTaskDelay(pdMS_TO_TICKS(10)) at the bottom — only the
-    // adapter/button work below is conditionally skipped. Same behavior for
-    // everything that must keep ticking (mesh.loop(), checkMasterTimeout(),
-    // DisplayManager, WDT reset), with a real yield guaranteed every pass.
+    // single vTaskDelay(pdMS_TO_TICKS(10)) at the bottom — only adapter data
+    // forwarding is conditionally skipped. Same behavior for everything that
+    // must keep ticking (mesh.loop(), checkMasterTimeout(), DisplayManager,
+    // WDT reset), with a real yield guaranteed every pass.
+    //
+    // ButtonHandler::tick() must run unconditionally, NOT gated behind
+    // skipDataForwarding: the config button is the only way to become master
+    // (and isMaster() is itself what makes tickEnrollmentBroadcast() return
+    // false). Gating it here would mean a fresh, unenrolled solo node with no
+    // master on the mesh can never use the button to become master — the
+    // exact button press meant to escape that state would never be polled.
     bool skipDataForwarding = mesh.tickEnrollmentBroadcast(nowMs);
 
     esp_task_wdt_reset();
 
-    if (!skipDataForwarding) {
-      if (adapter) {
-        adapter->loop();
-      }
-      lattice::app::ButtonHandler::tick(configButton, resetButton, mesh, greenLed, redLed,
-                                        isDevMode, devMasterFlag);
+    if (!skipDataForwarding && adapter) {
+      adapter->loop();
     }
+    lattice::app::ButtonHandler::tick(configButton, resetButton, mesh, greenLed, redLed, isDevMode,
+                                      devMasterFlag);
 
     vTaskDelay(pdMS_TO_TICKS(10)); // 100 Hz — real yield
   }

--- a/firmware/main/src/adapter/AdapterFactory.cpp
+++ b/firmware/main/src/adapter/AdapterFactory.cpp
@@ -1,4 +1,5 @@
 #include "AdapterFactory.h"
+#include "project_config.h"
 #include "src/logging/Logger.h"
 #include "src/error/Error.h"
 #include "src/persistence/eeprom/EepromDeviceConfig.h"
@@ -81,10 +82,13 @@ void AdapterFactory::initializeDefaultsIfUnset() {
     return; // Don't initialize EEPROM in dev mode
   }
 
-  // Check if adapter type is unset (0xFF) and set default if needed
+  // loadAdapterType() itself returns 0 (UNKNOWN_ADAPTER) when the NVS key was
+  // never written (EepromDeviceConfig.cpp's nvsGetU8(..., 0)) — that's the
+  // real "unset" sentinel on a blank board, not 0xFF. Persist the configured
+  // default so createFromEEPROM() has a valid type to load afterward.
   uint8_t currentType = lattice::eeprom::loadAdapterType();
-  if (currentType == 0xFF) {
-    lattice::eeprom::saveAdapterType(adapterTypeToEEPROM(adapter_types::PIR_ADAPTER));
+  if (currentType == adapterTypeToEEPROM(adapter_types::UNKNOWN_ADAPTER)) {
+    lattice::eeprom::saveAdapterType(adapterTypeToEEPROM(lattice::config::DEFAULT_ADAPTER));
   }
 }
 

--- a/tools/gen_master_pubkey_pin.py
+++ b/tools/gen_master_pubkey_pin.py
@@ -9,11 +9,12 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUT = REPO_ROOT / "firmware/main/config/master_pubkey_pin.h"
 
-def die(msg):
+def die(msg) -> NoReturn:
     print(f"gen_master_pubkey_pin: {msg}", file=sys.stderr)
     sys.exit(1)
 
@@ -26,11 +27,15 @@ def main(argv):
         die(f"masterkey.json not found: {keyfile}")
     data = json.loads(keyfile.read_text())
     pub_b64 = data.get("publicKey") or data.get("PublicKey")
-    if not pub_b64:
-        die("publicKey field not found in masterkey.json")
-    pub = base64.b64decode(pub_b64)
+    pub_array = data.get("public_key")
+    if pub_b64:
+        pub = base64.b64decode(pub_b64)
+    elif pub_array is not None:
+        pub = bytes(pub_array)
+    else:
+        die("publicKey/public_key field not found in masterkey.json")
     if len(pub) != 32:
-        die(f"publicKey wrong length: {len(pub)}")
+        die(f"public key wrong length: {len(pub)}")
     mac_hex = re.sub(r"[^0-9a-fA-F]", "", mac_str)
     if len(mac_hex) != 12:
         die(f"MAC must be 6 bytes (12 hex chars): got {mac_str}")


### PR DESCRIPTION
## Summary

Two independent bugs both prevented a fresh (blank-EEPROM) board from ever booting/becoming master in production mode (`DEV_MODE=false`), found while bringing up a real master node against `lattice-hub`:

- `AdapterFactory::initializeDefaultsIfUnset()` checked for the "unset" EEPROM adapter-type sentinel as `0xFF`, but `loadAdapterType()` actually returns `0` (`UNKNOWN_ADAPTER`) when the NVS key was never written — confirmed by the existing test `EepromDeviceConfigTest.AdapterType_DefaultIsZero`. The unset-check never fired, `createFromEEPROM()` resolved to `UNKNOWN_ADAPTER`, `createAdapter()` rejected it, and the board fatally restarted forever (display error code `0513`). Also switched the persisted default to `lattice::config::DEFAULT_ADAPTER` instead of a hardcoded `PIR_ADAPTER`, so it respects `project_config.h` as documented.
- `ButtonHandler::tick()` was gated behind `skipDataForwarding`, which is `true` exactly when a node is unenrolled and not master. Since the config button is the only way to become master, and `isMaster()` is what makes `skipDataForwarding` false, a solo unenrolled node with no master on the mesh could never poll the button meant to escape that state — a structural deadlock. Button ticking now runs every loop iteration; only adapter data forwarding stays gated.

Also fixes `tools/gen_master_pubkey_pin.py`: it only accepted a base64 `publicKey` field, but `lattice-hub`'s real `masterkey.json` (Go `[32]byte` struct fields) serializes as plain `public_key`/`private_key` int arrays — the documented bench-test flow in `getting_started.md` was apparently never validated against real hub output.

## Test plan

- [x] Existing unit test suite run before/after (via `git stash` isolation) — confirmed identical pre-existing failures (unrelated `MeshSimTest`/`MeshLogicTest` set), no new regressions from this change.
- [x] Verified end-to-end against a real ESP32 board and a real `lattice-hub` orchestrator: fresh flash no longer boot-loops, config button now successfully toggles leaf↔master (confirmed via LED blink count + `SW_CPU_RESET` in live serial monitor + orchestrator health reports).
- [x] Discovered follow-up issues (adapter-init `fatal()` halt still unreachable from buttons, unrelated to this fix) filed separately as #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)