### PR TITLE
fix: master embedded its own pubkey, not the node's, in JOIN_ACK fingerprint

### DIFF
--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -156,9 +156,22 @@ void Mesh::handleReceivedMessage(const uint8_t* srcMac, const mesh_message& msg)
 
   switch (msg.message_type) {
   case MESH_TYPE_ENROLLMENT:
-    if (isMaster)
+    if (isMaster) {
+      // Cache the enrolling node's real Curve25519 public key now, while we
+      // have it (this is the only point the master ever sees it directly —
+      // the server's later JOIN_ACK response echoes back only a 4-byte
+      // fingerprint plus this master's OWN public key, never the node's).
+      // Without this, MeshMessenger::enrollPeer had nothing correct to build
+      // the outbound JOIN_ACK's fingerprint from, so every node's
+      // Enrollment::processJoinAck fingerprint check failed permanently —
+      // no leaf could ever complete enrollment (lattice-hub#178).
+      // allowRekey=false: a later forged ENROLLMENT for the same MAC must
+      // not override the first key seen.
+      lattice::mesh::registerPeerWithKey(msg.origin_mac_address, msg.enrollment_public_key,
+                                         /*allowRekey=*/false, peers, enrollment,
+                                         _dualMasterMode);
       enrollment.processRequest(msg);
-    else
+    } else
       messenger.relayEnrollmentUplink(msg, deviceMacAddress, currentMaster, txState, peers,
                                       enrollment, e2eKeys, uplinkRouter, neighbors, transport);
     break;

--- a/firmware/main/src/mesh/Mesh.cpp
+++ b/firmware/main/src/mesh/Mesh.cpp
@@ -168,8 +168,7 @@ void Mesh::handleReceivedMessage(const uint8_t* srcMac, const mesh_message& msg)
       // allowRekey=false: a later forged ENROLLMENT for the same MAC must
       // not override the first key seen.
       lattice::mesh::registerPeerWithKey(msg.origin_mac_address, msg.enrollment_public_key,
-                                         /*allowRekey=*/false, peers, enrollment,
-                                         _dualMasterMode);
+                                         /*allowRekey=*/false, peers, enrollment, _dualMasterMode);
       enrollment.processRequest(msg);
     } else
       messenger.relayEnrollmentUplink(msg, deviceMacAddress, currentMaster, txState, peers,

--- a/firmware/main/src/mesh/MeshMessenger.cpp
+++ b/firmware/main/src/mesh/MeshMessenger.cpp
@@ -222,14 +222,16 @@ void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* /*publicKey32*
                                MeshTransport& transport) {
   // `publicKey32` (as forwarded by SerialAdapter::handleCompleteFrame from the
   // server's JOIN_ACK) is NOT the enrolling node's key — per the server's wire
-  // contract that field carries this master's OWN public key, echoed back for
-  // the node's benefit (see Enrollment::processJoinAck, which registers the
-  // master with it). The node's real key was cached in `peers` when its
-  // original JOIN_REQUEST was first heard (Mesh::handleReceivedMessage,
-  // MESH_TYPE_ENROLLMENT/isMaster branch) — that cached copy is the only
-  // correct source for both the peer registration below and the JOIN_ACK
-  // fingerprint. Using the wrong key here meant no node could ever pass its
-  // own fingerprint check (lattice-hub#178).
+  // contract that field carries this master's server-side identity key
+  // (ms.masterPublicKey from masterkey.json), which is unrelated to and NOT
+  // interchangeable with the on-device keypair actually used below for E2E
+  // (see the ack.enrollment_public_key comment further down). It must not be
+  // used as the enrolling node's own key either: the node's real key was
+  // cached in `peers` when its original JOIN_REQUEST was first heard
+  // (Mesh::handleReceivedMessage, MESH_TYPE_ENROLLMENT/isMaster branch) — that
+  // cached copy is the only correct source for the peer registration and JOIN_ACK
+  // fingerprint below. Conflating the two meant no node could ever pass its own
+  // fingerprint check (lattice-hub#178).
   const PeerInfo* cachedPeer = peers.find(mac);
   if (!cachedPeer) {
     LATTICE_LOGLN("MESH", "enrollPeer: no cached public key for this MAC — dropping ACK",
@@ -263,8 +265,16 @@ void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* /*publicKey32*
   ack.hop_count = 0;
   // Include first 4 bytes of approved node's pubkey as fingerprint
   memcpy(ack.data, nodePublicKey, 4);
-  // Include OUR public key so the enrolling node can register this master as
-  // an encrypted, routable peer in its own registry (see Enrollment::processJoinAck).
+  // Include OUR public key — this node's own on-device keypair — so the
+  // enrolling node registers the ACTUAL key this master will use for E2E
+  // ECDH (peerE2EKeys/masterE2EKeys both key off enrollment.getPrivateKey();
+  // see E2EKeyLookup.h). This must be enrollment.getPublicKey(), not the
+  // server-relayed publicKey32 (ms.masterPublicKey from masterkey.json) — that
+  // is a separate identity the server holds no matching on-device private key
+  // for, so using it here would pass the leaf's master_pubkey_pin check while
+  // permanently breaking E2E (ECDH would never agree on both sides). The pin
+  // itself must be generated from THIS node's real on-device key, not
+  // masterkey.json, to be consistent with what's actually sent here.
   memcpy(ack.enrollment_public_key, enrollment.getPublicKey(), 32);
   // Stamp the server-provided secondary-master identity, if any, so the
   // enrolling node can TOFU-learn its failover master from this same ACK

--- a/firmware/main/src/mesh/MeshMessenger.cpp
+++ b/firmware/main/src/mesh/MeshMessenger.cpp
@@ -241,8 +241,8 @@ void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* /*publicKey32*
   uint8_t nodePublicKey[32];
   memcpy(nodePublicKey, cachedPeer->publicKey, 32);
 
-  if (!lattice::mesh::registerPeerWithKey(mac, nodePublicKey, /*allowRekey=*/true, peers, enrollment,
-                                          dualMasterMode))
+  if (!lattice::mesh::registerPeerWithKey(mac, nodePublicKey, /*allowRekey=*/true, peers,
+                                          enrollment, dualMasterMode))
     return; // registry full — do not ACK an enrollment we could not record
 
   // Send JOIN_ACK unicast to new node

--- a/firmware/main/src/mesh/MeshMessenger.cpp
+++ b/firmware/main/src/mesh/MeshMessenger.cpp
@@ -215,12 +215,31 @@ void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32,
              dualMasterMode, transport);
 }
 
-void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32,
+void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* /*publicKey32*/,
                                const uint8_t* secondaryMac, const uint8_t* secondaryPubKey32,
                                const uint8_t* deviceMac, OutboundSequenceState& txState,
                                PeerRegistry& peers, Enrollment& enrollment, bool dualMasterMode,
                                MeshTransport& transport) {
-  if (!lattice::mesh::registerPeerWithKey(mac, publicKey32, /*allowRekey=*/true, peers, enrollment,
+  // `publicKey32` (as forwarded by SerialAdapter::handleCompleteFrame from the
+  // server's JOIN_ACK) is NOT the enrolling node's key — per the server's wire
+  // contract that field carries this master's OWN public key, echoed back for
+  // the node's benefit (see Enrollment::processJoinAck, which registers the
+  // master with it). The node's real key was cached in `peers` when its
+  // original JOIN_REQUEST was first heard (Mesh::handleReceivedMessage,
+  // MESH_TYPE_ENROLLMENT/isMaster branch) — that cached copy is the only
+  // correct source for both the peer registration below and the JOIN_ACK
+  // fingerprint. Using the wrong key here meant no node could ever pass its
+  // own fingerprint check (lattice-hub#178).
+  const PeerInfo* cachedPeer = peers.find(mac);
+  if (!cachedPeer) {
+    LATTICE_LOGLN("MESH", "enrollPeer: no cached public key for this MAC — dropping ACK",
+                  LogLevel::LOG_ERROR);
+    return;
+  }
+  uint8_t nodePublicKey[32];
+  memcpy(nodePublicKey, cachedPeer->publicKey, 32);
+
+  if (!lattice::mesh::registerPeerWithKey(mac, nodePublicKey, /*allowRekey=*/true, peers, enrollment,
                                           dualMasterMode))
     return; // registry full — do not ACK an enrollment we could not record
 
@@ -243,7 +262,7 @@ void MeshMessenger::enrollPeer(const uint8_t* mac, const uint8_t* publicKey32,
   memcpy(ack.last_hop_mac_address, deviceMac, 6);
   ack.hop_count = 0;
   // Include first 4 bytes of approved node's pubkey as fingerprint
-  memcpy(ack.data, publicKey32, 4);
+  memcpy(ack.data, nodePublicKey, 4);
   // Include OUR public key so the enrolling node can register this master as
   // an encrypted, routable peer in its own registry (see Enrollment::processJoinAck).
   memcpy(ack.enrollment_public_key, enrollment.getPublicKey(), 32);

--- a/tests/e2e/scenarios/test_harness_smoke.cpp
+++ b/tests/e2e/scenarios/test_harness_smoke.cpp
@@ -181,6 +181,8 @@ TEST(FakeHubTest, ReceivesHealthReportAndAnswersHealthReq) {
 
   // DEFAULT_PEERS placeholder MACs are now stripped automatically by
   // SimNode::boot() (see SimNode.cpp) -- no per-test workaround needed.
+  size_t masterPeersBeforeRequest = master->with(
+      [](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) { return m.peers.count(); });
 
   // Nothing sent yet: the 30s periodic interval hasn't elapsed and no
   // HEALTH_REQ has been issued. Unrelated to the Task 6b fix.
@@ -217,14 +219,27 @@ TEST(FakeHubTest, ReceivesHealthReportAndAnswersHealthReq) {
 
   // approveEnrollment() exercises FakeHub's remaining surface (sendFrame via the
   // JOIN_ACK it builds) and drives a real Mesh::enrollPeer() call on the master.
-  size_t masterPeersBefore = master->with(
-      [](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) { return m.peers.count(); });
+  //
+  // The master now caches the node's real public key as soon as it first
+  // relays the node's JOIN_REQUEST (Mesh::handleReceivedMessage,
+  // MESH_TYPE_ENROLLMENT/isMaster branch) rather than waiting for approval --
+  // MeshMessenger::enrollPeer needs that cached copy to build a correct
+  // JOIN_ACK fingerprint, since the server's JOIN_ACK response never carries
+  // the node's own key back down (lattice-hub#178). So `node` is already a
+  // registered peer by this point in the flow, before approval; assert
+  // against the pre-request baseline instead of a before/after-approval delta.
+  EXPECT_EQ(masterPeersBeforeRequest + 1, master->with([](lattice::mesh::Mesh& m,
+                                                           lattice::adapter::Adapter*) {
+              return m.peers.count();
+            }))
+      << "master must register the node as a peer by the time its JOIN_REQUEST is relayed";
+
   hub.approveEnrollment(node->mac(), enr->enrollment_public_key);
   world.run(50);
   size_t masterPeersAfter = master->with(
       [](lattice::mesh::Mesh& m, lattice::adapter::Adapter*) { return m.peers.count(); });
-  EXPECT_EQ(masterPeersAfter, masterPeersBefore + 1)
-      << "master must register the approved node as a peer";
+  EXPECT_EQ(masterPeersAfter, masterPeersBeforeRequest + 1)
+      << "master must still have exactly the approved node registered as a peer after approval";
 }
 
 // Exercises the surface the previous test's reconciliation note flagged as


### PR DESCRIPTION
## Summary
- `Enrollment::processJoinAck()`'s fingerprint check failed on **every single enrollment, for every node, unconditionally** — root-caused live while enrolling a real PIR leaf against a real hub.
- The master's `SerialAdapter.cpp` JOIN_ACK handler mistook the server's echoed-back **master identity key** (`msg.enrollment_public_key`, `ms.masterPublicKey` from the hub's `masterkey.json`) for the **enrolling node's** key, and used it both to register the node's peer entry and to build the broadcast JOIN_ACK's fingerprint — guaranteeing a mismatch every time.
- Fixed by caching the node's real public key into `PeerRegistry` the moment the master first relays its JOIN_REQUEST (the only point the master ever legitimately sees it), and having `MeshMessenger::enrollPeer` use that cached copy for the peer registration and the fingerprint.
- The C++ e2e `FakeHub` test harness never caught this because it simulates the JOIN_ACK backwards relative to the real Go hub (puts the node's key where the master's key belongs) — see the linked issue for the full trace.

**Update (2nd commit):** the branch's first version of this fix also changed `ack.enrollment_public_key` (the field the leaf registers as "the master's key" for E2E) to use the server-relayed `ms.masterPublicKey`, to satisfy the leaf's separate `master_pubkey_pin` check. That was wrong — E2E crypto (`E2EKeyLookup.h`) derives ECDH secrets from the master's own on-device keypair, not `masterkey.json`, so that change passed the pin check while permanently breaking E2E (confirmed live: leaf enrolled but its health reports never reached the hub). Reverted to the original `enrollment.getPublicKey()` in the 2nd commit. The pin-check failure this now re-exposes is real and tracked separately — see #126; it's a distinct, deeper issue (the pin and E2E need different keys, and nothing currently reconciles `masterkey.json` with the master's on-device keypair) that shouldn't block landing this fingerprint fix.

Closes #124.

## Test plan
- [x] Host suite (`ctest`, 340 tests): zero new failures — pre-existing 33 failures on `main` unchanged before/after (verified via `git stash`), re-verified after the 2nd commit's revert.
- [x] Updated `FakeHubTest.ReceivesHealthReportAndAnswersHealthReq` — master now registers the peer at JOIN_REQUEST time rather than approval time; assertion moved to match.
- [x] Verified live: real hub + real ESP32 board enrolling as a PIR leaf. Before: `"JOIN_ACK fingerprint mismatch — ignoring"` on every attempt. After this fix: fingerprint passes (confirmed via the pin check being the new, different failure point — see #126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)