### PR TITLE
fix(ci): lock codeql-action trio to v4.37.9, group future bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
     labels:
       - dependencies
       - ci
+    groups:
+      codeql-action:
+        # init/analyze/upload-sarif must land on the same version — CodeQL's
+        # init step stamps a config file with its own version, and
+        # analyze/upload-sarif refuse to run against a config from a
+        # different version ("Loaded a configuration file for version
+        # X, but running version Y"). One atomic PR avoids that skew.
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: gitsubmodule
     directory: /

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: cpp
           build-mode: manual
@@ -48,7 +48,7 @@ jobs:
           cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release
           cmake --build tests/build --target lattice_e2e --parallel 2
 
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: '/language:cpp'
           upload: failure-only
@@ -68,6 +68,6 @@ jobs:
           input: sarif-results/cpp.sarif
           output: sarif-results/cpp.sarif
 
-      - uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: sarif-results/cpp.sarif


### PR DESCRIPTION
## Summary
- init/analyze/upload-sarif must share one codeql-action version or CI fails with "Loaded a configuration file for version X, but running version Y".
- Dependabot was bumping each of the three independently (#127, #128, #129), breaking `Analyze (cpp)` — root cause traced in the 2026-08-11 close-open-prs investigation (finding A2).
- Bumps all three together to v4.37.9 and adds a dependabot `groups:` block so future bumps land as one atomic PR (same pattern already used for react/react-dom in lattice-hub).

Supersedes #127, #128, #129 — closing those as superseded once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)