### PR TITLE
fix: regenerate mesh.pb.h for protocol v0.6.0, add proto-sync drift check

### DIFF
--- a/.github/workflows/proto-sync.yml
+++ b/.github/workflows/proto-sync.yml
@@ -1,0 +1,46 @@
+name: Proto Sync
+
+# Guards the checked-in serial-link nanopb codec
+# (firmware/main/src/mesh/serialization/mesh.pb.{h,c}) against drifting from
+# the lattice-protocol submodule's proto/mesh.proto + proto/mesh.options.
+# The generated files are committed so the firmware builds without a Python
+# toolchain, which is exactly how retired v0.6.0 fields (15/16) lingered in
+# firmware unnoticed (#113). Regenerates with the pinned nanopb generator and
+# fails if the result differs from what is committed — same pattern as
+# lattice-protocol's `make check` and lattice-hub's `proto-sync` job.
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  proto-sync:
+    name: Proto sync (mesh.pb.h)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned nanopb generator (+ protoc via grpcio-tools)
+        # The generator must match the vendored runtime version in
+        # nanopb/pb.h (tools/gen_mesh_pb.sh refuses to run otherwise), so
+        # read the pin from there rather than duplicating it here.
+        # grpcio-tools supplies the protoc binary nanopb_generator shells
+        # out to; the emitted header does not depend on the protoc version.
+        run: |
+          ver=$(sed -n 's/^#define NANOPB_VERSION "nanopb-\(.*\)"$/\1/p' \
+            firmware/main/src/mesh/serialization/nanopb/pb.h)
+          echo "nanopb runtime pin: ${ver}"
+          python -m pip install "nanopb==${ver}" "grpcio-tools==1.80.0"
+
+      - name: Regenerate mesh.pb.h/.c and fail if drifted from committed
+        run: tools/gen_mesh_pb.sh --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ The workflow runs automatically on every push and PR:
 - **unit-tests** — CMake build + CTest (Linux native, no ESP32 toolchain needed)
 - **lint-format** — `clang-format --dry-run --Werror` over all `main/src/*.{h,cpp}`
 - **static-analysis** — `cppcheck` with `--error-exitcode=1`
+- **proto-sync** — regenerates `mesh.pb.h`/`.c` from the `lattice-protocol` submodule and fails on
+  drift (`tools/gen_mesh_pb.sh --check`)
 
 PR merges are blocked until all three jobs are green.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@ Lattice follows Tiger-Style engineering principles: safety first, performance al
 
 ## 0. Quick checklist before opening a PR
 
-- [ ] `arduino-cli compile -e --fqbn esp32:esp32:esp32da main` builds with **no warnings** (run locally — not in CI).
+- [ ] `cd firmware && idf.py build` (ESP-IDF v5.5.1) builds with **no warnings** — CI's
+      **Firmware Build** job compiles it too, but check locally first.
 - [ ] `clang-format -style=file` applied; `git diff --check` shows no whitespace errors.
 - [ ] No `new`, `malloc`, or unbounded `std::vector` growth after setup.
 - [ ] All errors funnel through `src/error/Error.h` (`lattice::err::*`).
@@ -43,19 +44,22 @@ Assertions live in unit-tests, not production.
 
 ## 6. CI pipeline (GitHub Actions)
 
-The workflow runs automatically on every push and PR:
+The workflows run automatically on every push to `main`/`develop` and every PR:
 
 - **unit-tests** — CMake build + CTest (Linux native, no ESP32 toolchain needed)
+- **e2e** — the host-side multi-node mesh simulation suite (ctest label `e2e`)
+- **firmware-build** — ESP-IDF v5.5.1 `idf.py build` + size report (stubs `master_pubkey_pin.h`
+  from the committed `.example`)
 - **lint-format** — `clang-format --dry-run --Werror` over all `main/src/*.{h,cpp}`
 - **static-analysis** — `cppcheck` with `--error-exitcode=1`
 - **proto-sync** — regenerates `mesh.pb.h`/`.c` from the `lattice-protocol` submodule and fails on
   drift (`tools/gen_mesh_pb.sh --check`)
 
-PR merges are blocked until all three jobs are green.
+PR merges are blocked until every job is green. (CodeQL and Dependency Review run alongside
+these as security gates.)
 
-> **Note:** Arduino / ESP32 toolchain compilation is not in CI (large binary
-> download, ~10 min). Run `arduino-cli compile --fqbn esp32:esp32:esp32da main`
-> locally before submitting a PR that touches firmware source.
+> **Note:** the firmware is built with ESP-IDF only — there is no Arduino IDE / `arduino-cli`
+> path. See the README's Requirements / Quick Start for toolchain setup.
 
 ---
 Thank you for keeping Lattice rock-solid! 💪

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ This repo is the **firmware** piece of a three-repo system:
 - **[`lattice-protocol`](https://github.com/superbrobenji/lattice-protocol)** — the shared
   wire-format source of truth. Vendored here as a git submodule at
   [`firmware/main/lib/lattice-protocol`](firmware/main/lib/lattice-protocol) (currently pinned to
-  `v0.6.0`); `lattice-hub` imports the same schema as a Go module.
+  `v0.6.0`); `lattice-hub` imports the same schema as a Go module. The master's serial-link
+  nanopb codec (`firmware/main/src/mesh/serialization/mesh.pb.{h,c}`) is generated from that
+  submodule — after bumping the pin, regenerate it with `tools/gen_mesh_pb.sh` (see
+  [Regenerating the serial nanopb codec](#regenerating-the-serial-nanopb-codec)).
 
 See each sibling repo's own README for details — this repo only describes the firmware.
 
@@ -223,6 +226,26 @@ They run on every PR to `main` in their own **E2E Tests** GitHub Action (also av
 via `workflow_dispatch`); the unit-test job stays unit-only via `--label-exclude e2e`. A few
 scenarios are committed disabled where they depend on unimplemented multi-hop data routing — see
 [`docs/design-gaps/multihop-data-uplink.md`](docs/design-gaps/multihop-data-uplink.md).
+
+### Regenerating the serial nanopb codec
+
+The master ↔ server serial link carries a nanopb-encoded `mesh_MeshMessage`. Its codec is generated
+from the `lattice-protocol` submodule's `proto/mesh.proto` + `proto/mesh.options` and checked in at
+`firmware/main/src/mesh/serialization/mesh.pb.{h,c}` so the firmware builds without a Python
+toolchain. Whenever the submodule pin changes, regenerate and commit the result — never hand-edit
+the generated files:
+
+```bash
+python3 -m pip install "nanopb==0.4.9.1"   # must match NANOPB_VERSION in
+                                           # firmware/main/src/mesh/serialization/nanopb/pb.h
+tools/gen_mesh_pb.sh          # regenerate in place
+tools/gen_mesh_pb.sh --check  # what CI runs: exit 1 if the committed files are stale
+```
+
+`nanopb_generator` shells out to `protoc`; if you don't have one installed,
+`python3 -m pip install grpcio-tools` supplies a bundled fallback. The **Proto Sync** GitHub Action
+(`.github/workflows/proto-sync.yml`) runs the `--check` form on every PR, so a submodule bump
+without a matching regen fails CI.
 
 ### Adding a New Adapter
 

--- a/docs/server_requirements.md
+++ b/docs/server_requirements.md
@@ -55,33 +55,33 @@ There are **two different, related-but-distinct wire schemas** in this system:
    == 200)`. This is protocol v5 of the RF mesh wire format. It has 15 fields, including several
    (`route_len`, `route_path`, `auth_tag`, `auth_path`) that carry mesh-internal routing/crypto
    metadata.
-2. **`mesh_MeshMessage`** (`firmware/main/src/mesh/serialization/mesh.pb.h`) — a separate,
-   hand-maintained **nanopb** (protobuf-C) message that the master encodes to / decodes from over
-   the USB-serial link. **This is the schema the server actually implements.** No `.proto` source
-   file for this schema is checked into this repo — `mesh.pb.h`/`mesh.pb.c` are hand-authored
-   nanopb output, not generated from a tracked `.proto`.
+2. **`mesh_MeshMessage`** (`firmware/main/src/mesh/serialization/mesh.pb.h`) — a separate
+   **nanopb** (protobuf-C) message that the master encodes to / decodes from over the USB-serial
+   link. **This is the schema the server actually implements.** `mesh.pb.h`/`mesh.pb.c` are
+   generated from the submodule's `proto/mesh.proto` + `proto/mesh.options` by
+   `tools/gen_mesh_pb.sh`, and CI (`.github/workflows/proto-sync.yml`) fails if they drift from
+   the submodule pin — so the serial schema's *field set* is exactly the RF proto's field set.
 
 These two schemas are **not the same**, and not just in field count:
 
-- The RF struct's `route_len`/`route_path`/`auth_tag`/`auth_path` fields exist in the submodule's
-  canonical `proto/mesh.proto` (tags 12–14, 17) but the serial-side `mesh.pb.h` schema only carries
-  three of them — `routeLen`(12)/`routePath`(13)/`authTag`(14) — as *dead, always-unset* fields (no
-  `authPath` at all). `SerialFraming::encode()` (`firmware/main/src/adapter/serial/
-  SerialFraming.cpp`) simply never populates them when building an outbound serial frame. **The
+- The RF struct's `route_len`/`route_path`/`auth_tag`/`auth_path` fields exist in the serial-side
+  `mesh.pb.h` schema too (tags 12–14, 17), but only as *dead, always-unset* fields.
+  `SerialFraming::encode()` (`firmware/main/src/adapter/serial/SerialFraming.cpp`) simply never
+  populates them when building an outbound serial frame, and `decode()` ignores them. **The
   server cannot see mesh topology (route paths) or AEAD tags today — full stop.** See §4 and §9.
-- The serial schema additionally defines two fields the RF struct's canonical proto does not have
-  at the top level at all: `secondaryMasterMac`(15) and `secondaryPublicKey`(16). These are a
-  serial-only convenience projection of two 6/32-byte ranges inside the RF struct's `data[64]`
-  payload (`data[4..10]` and `data[10..42]`) — see §8 for why.
+- There are **no** top-level secondary-master fields: protocol v0.6.0 retired tags 15/16
+  (`secondaryMasterMac`/`secondaryPublicKey`) from both schemas. The dual-master secondary identity
+  travels *inside* a `JOIN_ACK`'s `data[64]` payload (`data[4..10]` = MAC, `data[10..42]` =
+  pubkey) — see §8b/§10.
 - Even the fields both schemas nominally share are handled asymmetrically by the encoder/decoder —
   see §3.
 
 **Why two schemas exist**: `mesh_message` is the RF/ESP-NOW mesh protocol, designed around what
 relaying nodes need (routing metadata, AEAD tags, hop tracking). The serial link only ever talks to
 one endpoint (the master) and one message shape flows in each direction, so the serial schema is
-deliberately narrower — but because it was hand-authored rather than derived mechanically from the
-RF proto, it has its own quirks (dead fields, an outdated `routePath` byte-array size — see §4) that
-a server implementer needs to know about rather than infer from the RF proto.
+deliberately narrower in what it actually *populates* — the field set itself is generated from the
+RF proto, but several fields are dead on the serial wire (see §4), which a server implementer needs
+to know about rather than infer from the RF proto.
 
 ---
 
@@ -94,20 +94,18 @@ Source: `firmware/main/src/adapter/serial/SerialFraming.h`/`.cpp`.
   - Master→server writes: `SerialAdapter::onMeshDataImpl` / `relayEnrollmentToServer`
     (`SerialAdapter.cpp`).
   - Server→master reads: `SerialFraming::injectByte()`'s state machine (`SerialFraming.cpp`).
-- **Max payload**: 256 bytes (`MAX_PAYLOAD`). The nanopb schema's theoretical worst-case encoded
-  size, if every optional field were set simultaneously, is 289 bytes (`mesh_MeshMessage_size` in
-  `mesh.pb.h`) — larger than `MAX_PAYLOAD`. In practice this never happens: `routeLen`/`routePath`/
-  `authTag` are never populated by `encode()` at all (§2/§4), and `public_key`/`secondaryMasterMac`/
-  `secondaryPublicKey` are only ever populated together on a `JOIN_ACK`, which comfortably fits
-  within 256 bytes on its own. The server does not need to special-case this — just be aware the
-  master will reject/reset-parse any incoming frame declaring a length over 256 bytes.
+- **Max payload**: 256 bytes (`MAX_PAYLOAD`). `mesh.pb.h` publishes no static
+  `mesh_MeshMessage_size` (field 17 `authPath` is callback-typed, see §4), but the fields
+  `encode()` can actually populate — everything except `routeLen`/`routePath`/`authTag`/`authPath`,
+  which are never set (§2/§4) — total well under 256 bytes even on a `JOIN_ACK` carrying a
+  `public_key` and a full 64-byte `data`. The server does not need to special-case this — just be
+  aware the master will reject/reset-parse any incoming frame declaring a length over 256 bytes.
 - **Field population is asymmetric by direction and by message type** — this matters for what the
   server must and must not rely on:
   - **`SerialFraming::encode()`** (master→server, i.e. what the server reads) always sets:
     `messageType`, `dataType`, `hopCount`, `epochNum`, `seqNum`, `protoVersion`, all three MAC
     fields, and `data` (always the full 64 bytes). It conditionally includes `public_key` (only for
-    `ENROLLMENT`/`JOIN_ACK` frames, and only if non-zero) and `secondaryMasterMac`/
-    `secondaryPublicKey` (only for `JOIN_ACK`, and only if non-zero).
+    `ENROLLMENT`/`JOIN_ACK` frames, and only if non-zero). Nothing else is ever set.
   - **`SerialFraming::decode()`** (server→master, i.e. what the server writes) has an important
     asymmetry: for **`JOIN_ACK` and `SERIAL_CMD_BROADCAST`** frames it trusts the server's
     `originMacAddress`/`lastHopMacAddress` values as sent. For **every other message type** it
@@ -124,10 +122,11 @@ Source: `firmware/main/src/adapter/serial/SerialFraming.h`/`.cpp`.
 firmware code paths actually consume, by message type:
   - `SERIAL_CMD_BROADCAST` (server→node commands): `messageType`, `dataType`, `targetMacAddress`,
     `data`. See §6/§7.
-  - `JOIN_ACK` (enrollment approval): `messageType`, `targetMacAddress`, `public_key`, optionally
-    `secondaryMasterMac`/`secondaryPublicKey`. See §8.
+  - `JOIN_ACK` (enrollment approval): `messageType`, `targetMacAddress`, `public_key`, and — for
+    dual-master deployments only — the secondary master's identity inside `data[4..42]`. See §8.
   - Everything else on an outbound frame (`originMacAddress`, `lastHopMacAddress`, `hopCount`,
-    `epochNum`, `seqNum`, `protoVersion`, `routeLen`/`routePath`/`authTag`) is either overwritten,
+    `epochNum`, `seqNum`, `protoVersion`, `routeLen`/`routePath`/`authTag`/`authPath`) is either
+    overwritten,
     ignored, or not consumed by any current firmware code path for server→master traffic — don't
     spend engineering effort populating these precisely; leaving them zero-valued is safe.
 
@@ -135,12 +134,13 @@ firmware code paths actually consume, by message type:
 
 ## 4. Wire schema — the nanopb `mesh_MeshMessage` (what the server actually implements)
 
-Source: `firmware/main/src/mesh/serialization/mesh.pb.h` (nanopb-generated; verified directly, not
-just from research notes).
+Source: the submodule's `firmware/main/lib/lattice-protocol/proto/mesh.proto` +
+`proto/mesh.options`, from which `firmware/main/src/mesh/serialization/mesh.pb.h` is generated by
+`tools/gen_mesh_pb.sh` (CI-enforced, see `.github/workflows/proto-sync.yml`). Annotated copy:
 
 ```proto
-// NOT a tracked .proto file in this repo — this is the schema mesh.pb.h/.c
-// implement, reconstructed here for the server team to generate code from.
+// Mirror of the submodule's proto/mesh.proto with serial-wire annotations;
+// the byte capacities come from proto/mesh.options.
 syntax = "proto3";
 package mesh;
 
@@ -157,10 +157,10 @@ message MeshMessage {
   uint32 protoVersion        = 10;
   optional bytes public_key         = 11; // 32 bytes — enrollment/JOIN_ACK pubkey, see §8
   optional uint32 routeLen          = 12; // DEAD FIELD — never set by encode(); see §2
-  optional bytes  routePath         = 13; // DEAD FIELD — never set; 60-byte capacity (stale size, see note below)
+  optional bytes  routePath         = 13; // DEAD FIELD — never set; 48-byte capacity (MAX_HOPS 8 × 6)
   optional bytes  authTag           = 14; // DEAD FIELD — never set; AEAD tag never reaches serial
-  optional bytes  secondaryMasterMac   = 15; // 6 bytes — dual-master, JOIN_ACK only, see §8/§10
-  optional bytes  secondaryPublicKey   = 16; // 32 bytes — dual-master, JOIN_ACK only, see §8/§10
+  optional bytes  authPath          = 17; // DEAD FIELD — never set; no max_size in mesh.options, so
+                                          // nanopb makes it callback-typed; master skips it on decode
 }
 ```
 
@@ -180,10 +180,9 @@ Field-by-field notes:
 | 10 | `protoVersion` | Not validated on serial-received frames (§3). |
 | 11 | `public_key` | 32-byte X25519 pubkey. **Load-bearing for `ENROLLMENT`/`JOIN_ACK`** — see §8. |
 | 12 | `routeLen` | **Dead on the serial wire.** Never populated by `encode()`. Do not expect route-length data from the server-facing side. |
-| 13 | `routePath` | **Dead on the serial wire.** Never populated. Note the nanopb struct's byte-array capacity is `PB_BYTES_ARRAY_T(60)` — an even older size than the RF struct's current 48-byte (`MAX_HOPS(8) × 6`) capacity — this mismatch is harmless precisely because the field is never set, but is a sign this schema was hand-maintained rather than kept in lockstep with the RF proto. |
+| 13 | `routePath` | **Dead on the serial wire.** Never populated. Capacity `PB_BYTES_ARRAY_T(48)`, matching the RF struct's `MAX_HOPS(8) × 6`. |
 | 14 | `authTag` | **Dead on the serial wire.** The AEAD tag never reaches the server — see §9. |
-| 15 | `secondaryMasterMac` | 6-byte MAC. Only meaningful (and only ever set) on `JOIN_ACK`, and only when a secondary/failover master is being designated. See §8/§10. |
-| 16 | `secondaryPublicKey` | 32-byte pubkey, paired with field 15. See §8/§10. |
+| 17 | `authPath` | **Dead on the serial wire.** Never populated. `mesh.options` gives it no `max_size`, so nanopb emits it as a callback field with no handler installed — the master ignores it on decode and never encodes it. (Tags 15/16, the old top-level `secondaryMasterMac`/`secondaryPublicKey`, were retired in protocol v0.6.0; that data now rides in `data[4..42]` — see §8b.) |
 
 ---
 
@@ -325,9 +324,8 @@ implications (see the TOFU note in §8d), not just functional bugs.
 | `messageType` (1) | `4` (`MESH_TYPE_JOIN_ACK`) |
 | `targetMacAddress` (4) | MAC of the node being approved |
 | `public_key` (11) | **The enrolling node's own 32-byte pubkey**, exactly as received in §8a. Used only as a 4-byte fingerprint check further downstream — see §8d, step 1. |
-| `secondaryMasterMac` (15) — optional, dual-master only | MAC of a designated failover master, or omit/leave zero for single-master. See §10. |
-| `secondaryPublicKey` (16) — optional, dual-master only | Pubkey of that failover master, or omit/leave zero. See §10. |
-| `originMacAddress` (3), `data` (6), everything else | **Effectively unused/ignored** by the master's `JOIN_ACK` handler. It only checks `public_key` (non-zero = approve, all-zero = reject) and reads `targetMacAddress`; it does not inspect `originMacAddress` or the raw `data` bytes you send for this message type before acting. |
+| `data` (6) — dual-master only | `data[4..10]` = MAC of a designated failover master, `data[10..42]` = that master's 32-byte pubkey. Leave all-zero (or omit `data`) for single-master. These two ranges are the only bytes of `data` the master reads on a `JOIN_ACK`. See §10. |
+| `originMacAddress` (3), everything else | **Effectively unused/ignored** by the master's `JOIN_ACK` handler. It only checks `public_key` (non-zero = approve, all-zero = reject), reads `targetMacAddress`, and reads the secondary-master ranges of `data`; it does not inspect `originMacAddress` for this message type before acting. |
 
 **Rejection**: if the server sends a `JOIN_ACK` with an all-zero `public_key`, the master logs
 "Server rejected enrollment request" and takes no further action.

--- a/firmware/main/src/adapter/serial/SerialFraming.cpp
+++ b/firmware/main/src/adapter/serial/SerialFraming.cpp
@@ -53,34 +53,10 @@ size_t SerialFraming::encode(const lattice::mesh::mesh_message& msg, uint8_t* ou
     }
   }
 
-  // secondary master identity (Phase 4 dual-master failover): the server
-  // stamps this onto a JOIN_ACK to designate a failover master alongside
-  // enrollment approval (see SerialAdapter::handleCompleteFrame /
-  // Mesh::enrollPeer's 4-arg overload). Protocol v0.6.0 (wire shrink §8)
-  // packs this into the JOIN_ACK data[] payload rather than top-level
-  // MeshMessage fields: data[4..10] = secondaryMasterMac,
-  // data[10..42] = secondaryPublicKey. Only present, and only meaningful, on
-  // JOIN_ACK; encode only when non-zero so ordinary single-master JOIN_ACKs
-  // stay byte-identical to before this field existed.
-  if (msg.message_type == MESH_TYPE_JOIN_ACK) {
-    const uint8_t* secondaryMasterMac = msg.data + 4;
-    const uint8_t* secondaryPublicKey = msg.data + 10;
-    bool hasSecondary = false;
-    for (int i = 0; i < 6; ++i) {
-      if (secondaryMasterMac[i]) {
-        hasSecondary = true;
-        break;
-      }
-    }
-    if (hasSecondary) {
-      pbMsg.has_secondaryMasterMac = true;
-      pbMsg.secondaryMasterMac.size = 6;
-      memcpy(pbMsg.secondaryMasterMac.bytes, secondaryMasterMac, 6);
-      pbMsg.has_secondaryPublicKey = true;
-      pbMsg.secondaryPublicKey.size = 32;
-      memcpy(pbMsg.secondaryPublicKey.bytes, secondaryPublicKey, 32);
-    }
-  }
+  // Dual-master secondary identity (Phase 4 failover) has no dedicated
+  // fields since protocol v0.6.0 (wire shrink §8): it rides inside the
+  // JOIN_ACK data[] payload copied above (data[4..10] = secondary MAC,
+  // data[10..42] = secondary pubkey), so nothing more to encode here.
 
   pb_ostream_t stream = pb_ostream_from_buffer(out, maxLen);
   if (!pb_encode(&stream, mesh_MeshMessage_fields, &pbMsg)) {
@@ -125,20 +101,9 @@ bool SerialFraming::decode(const uint8_t* data, size_t len, lattice::mesh::mesh_
     memcpy(outMsg.enrollment_public_key, pbMsg.public_key.bytes, 32);
   }
 
-  // Protocol v0.6.0 (wire shrink §8): secondary master identity lives in
-  // outMsg.data[4..42], not top-level fields. See encode() above. data[] is
-  // now a general-purpose payload shared by every message type, so also
-  // gate on message_type == JOIN_ACK (defense in depth): if the hub ever
-  // mis-sets these has_* flags on a non-JOIN_ACK frame, this must not
-  // silently corrupt that frame's data payload.
-  if (outMsg.message_type == MESH_TYPE_JOIN_ACK) {
-    if (pbMsg.has_secondaryMasterMac) {
-      memcpy(outMsg.data + 4, pbMsg.secondaryMasterMac.bytes, 6);
-    }
-    if (pbMsg.has_secondaryPublicKey) {
-      memcpy(outMsg.data + 10, pbMsg.secondaryPublicKey.bytes, 32);
-    }
-  }
+  // Protocol v0.6.0 (wire shrink §8): a JOIN_ACK's secondary master identity
+  // arrives inside data[4..42], already copied above — there are no
+  // top-level fields for it (SerialAdapter reads it from outMsg.data).
 
   // For server-to-device messages (JOIN_ACK, SERIAL_CMD_BROADCAST) the MAC
   // fields on the wire are meaningful and must not be overwritten.

--- a/firmware/main/src/mesh/serialization/mesh.pb.h
+++ b/firmware/main/src/mesh/serialization/mesh.pb.h
@@ -12,10 +12,8 @@
 /* Struct definitions */
 typedef PB_BYTES_ARRAY_T(64) mesh_MeshMessage_data_t;
 typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_public_key_t;
-typedef PB_BYTES_ARRAY_T(60) mesh_MeshMessage_routePath_t;
+typedef PB_BYTES_ARRAY_T(48) mesh_MeshMessage_routePath_t;
 typedef PB_BYTES_ARRAY_T(16) mesh_MeshMessage_authTag_t;
-typedef PB_BYTES_ARRAY_T(6) mesh_MeshMessage_secondaryMasterMac_t;
-typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_secondaryPublicKey_t;
 typedef struct _mesh_MeshMessage {
     uint32_t messageType;
     int32_t dataType;
@@ -36,10 +34,7 @@ typedef struct _mesh_MeshMessage {
     mesh_MeshMessage_routePath_t routePath;
     bool has_authTag;
     mesh_MeshMessage_authTag_t authTag;
-    bool has_secondaryMasterMac;
-    mesh_MeshMessage_secondaryMasterMac_t secondaryMasterMac;
-    bool has_secondaryPublicKey;
-    mesh_MeshMessage_secondaryPublicKey_t secondaryPublicKey;
+    pb_callback_t authPath;
 } mesh_MeshMessage;
 
 
@@ -48,8 +43,8 @@ extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define mesh_MeshMessage_init_default            {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, 0, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}}
-#define mesh_MeshMessage_init_zero               {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, 0, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}, false, {0, {0}}}
+#define mesh_MeshMessage_init_default            {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, 0, false, {0, {0}}, false, {0, {0}}, {{NULL}, NULL}}
+#define mesh_MeshMessage_init_zero               {0, 0, {0}, {0}, {0}, false, {0, {0}}, 0, 0, 0, 0, false, {0, {0}}, false, 0, false, {0, {0}}, false, {0, {0}}, {{NULL}, NULL}}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define mesh_MeshMessage_messageType_tag         1
@@ -66,8 +61,7 @@ extern "C" {
 #define mesh_MeshMessage_routeLen_tag            12
 #define mesh_MeshMessage_routePath_tag           13
 #define mesh_MeshMessage_authTag_tag             14
-#define mesh_MeshMessage_secondaryMasterMac_tag  15
-#define mesh_MeshMessage_secondaryPublicKey_tag  16
+#define mesh_MeshMessage_authPath_tag            17
 
 /* Struct field encoding specification for nanopb */
 #define mesh_MeshMessage_FIELDLIST(X, a) \
@@ -85,9 +79,8 @@ X(a, STATIC,   OPTIONAL, BYTES,    public_key,       11) \
 X(a, STATIC,   OPTIONAL, UINT32,   routeLen,         12) \
 X(a, STATIC,   OPTIONAL, BYTES,    routePath,        13) \
 X(a, STATIC,   OPTIONAL, BYTES,    authTag,          14) \
-X(a, STATIC,   OPTIONAL, BYTES,    secondaryMasterMac,  15) \
-X(a, STATIC,   OPTIONAL, BYTES,    secondaryPublicKey,  16)
-#define mesh_MeshMessage_CALLBACK NULL
+X(a, CALLBACK, OPTIONAL, BYTES,    authPath,         17)
+#define mesh_MeshMessage_CALLBACK pb_default_field_callback
 #define mesh_MeshMessage_DEFAULT NULL
 
 extern const pb_msgdesc_t mesh_MeshMessage_msg;
@@ -96,8 +89,7 @@ extern const pb_msgdesc_t mesh_MeshMessage_msg;
 #define mesh_MeshMessage_fields &mesh_MeshMessage_msg
 
 /* Maximum encoded size of messages (where known) */
-#define MESH_MESH_PB_H_MAX_SIZE                  mesh_MeshMessage_size
-#define mesh_MeshMessage_size                    289
+/* mesh_MeshMessage_size depends on runtime parameters */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/tools/gen_mesh_pb.sh
+++ b/tools/gen_mesh_pb.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regenerate the serial-link nanopb codec
+#   firmware/main/src/mesh/serialization/mesh.pb.{h,c}
+# from the lattice-protocol submodule's proto/mesh.proto + proto/mesh.options.
+#
+# The submodule is the single source of truth for the wire schema. The
+# generated files are checked in so the firmware builds without a Python
+# toolchain, which means they can silently drift from the submodule pin
+# (that is how retired v0.6.0 fields lingered in firmware, see #113). CI
+# (.github/workflows/proto-sync.yml) runs this script with --check on every
+# PR so a submodule bump without a matching regen fails the build.
+#
+# Usage:
+#   tools/gen_mesh_pb.sh          # regenerate in place
+#   tools/gen_mesh_pb.sh --check  # regenerate, then exit 1 if the result
+#                                 # differs from the committed files
+#
+# Requirements:
+#   - nanopb_generator on PATH at the SAME version as the vendored runtime
+#     (NANOPB_VERSION in firmware/main/src/mesh/serialization/nanopb/pb.h);
+#     the script refuses to run on a mismatch. Install with:
+#         python3 -m pip install "nanopb==<that version>"
+#     (or point NANOPB_GENERATOR at a specific binary)
+#   - protoc: either on PATH, or `python3 -m pip install grpcio-tools`
+#     (nanopb_generator falls back to the protoc bundled with grpc_tools).
+#
+# The generator emits no timestamp (nanopb >= 0.4 default), so the output is
+# byte-for-byte reproducible for a given nanopb version + proto + options.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROTO_DIR="$REPO_ROOT/firmware/main/lib/lattice-protocol/proto"
+OUT_DIR="$REPO_ROOT/firmware/main/src/mesh/serialization"
+RUNTIME_PB_H="$OUT_DIR/nanopb/pb.h"
+GENERATOR="${NANOPB_GENERATOR:-nanopb_generator}"
+
+die() {
+  echo "gen_mesh_pb: $*" >&2
+  exit 1
+}
+
+check=0
+case "${1:-}" in
+"") ;;
+--check) check=1 ;;
+*) die "usage: $0 [--check]" ;;
+esac
+
+[ -f "$PROTO_DIR/mesh.proto" ] ||
+  die "$PROTO_DIR/mesh.proto missing — run: git submodule update --init --recursive"
+[ -f "$PROTO_DIR/mesh.options" ] || die "$PROTO_DIR/mesh.options missing"
+
+# Generator and vendored runtime must agree: a mismatch trips the generated
+# header's PB_PROTO_HEADER_VERSION #error at compile time, and even same-major
+# versions can differ in emitted layout, which would show up as spurious drift.
+runtime_ver="$(sed -n 's/^#define NANOPB_VERSION "nanopb-\(.*\)"$/\1/p' "$RUNTIME_PB_H")"
+[ -n "$runtime_ver" ] || die "could not read NANOPB_VERSION from $RUNTIME_PB_H"
+command -v "$GENERATOR" >/dev/null 2>&1 ||
+  die "$GENERATOR not found — install with: python3 -m pip install \"nanopb==$runtime_ver\""
+gen_ver="$("$GENERATOR" --version 2>&1 | sed -n 's/^nanopb-\(.*\)$/\1/p')"
+[ "$gen_ver" = "$runtime_ver" ] ||
+  die "nanopb_generator is '$gen_ver' but the vendored runtime is $runtime_ver" \
+    "— install with: python3 -m pip install \"nanopb==$runtime_ver\""
+
+# Run from proto/ with -I . so the descriptor's file name is a bare
+# "mesh.proto" — that is what the include guard / type prefix derive from.
+(cd "$PROTO_DIR" && "$GENERATOR" --quiet -I . -D "$OUT_DIR" -f mesh.options mesh.proto)
+
+if [ "$check" -eq 1 ]; then
+  if ! git -C "$REPO_ROOT" diff --exit-code -- "$OUT_DIR/mesh.pb.h" "$OUT_DIR/mesh.pb.c"; then
+    die "mesh.pb.h/.c are out of date relative to the lattice-protocol submodule" \
+      "— run tools/gen_mesh_pb.sh and commit the result"
+  fi
+  submodule_rev="$(git -C "$PROTO_DIR" describe --tags --always 2>/dev/null || echo unknown)"
+  echo "gen_mesh_pb: mesh.pb.h/.c are in sync with lattice-protocol $submodule_rev" \
+    "(nanopb-$gen_ver)"
+fi


### PR DESCRIPTION
## Summary
Regenerates the serial-link nanopb codec (`firmware/main/src/mesh/serialization/mesh.pb.{h,c}`) from the `lattice-protocol` submodule at v0.6.0 with the vendored nanopb version (0.4.9.1), removes the now-dead `secondaryMasterMac`/`secondaryPublicKey` encode/decode blocks from `SerialFraming.cpp` (the secondary identity already travels in the JOIN_ACK `data[4..42]`, which `SerialAdapter` reads), and adds a CI drift check so the checked-in codec can never again fall behind the submodule pin: a new **Proto Sync** workflow runs `tools/gen_mesh_pb.sh --check`, which regenerates and `git diff --exit-code`s the result (same pattern as lattice-protocol's `make check` and lattice-hub's `proto-sync` job). Not a wire-format change: the hub never emitted fields 15/16, so master ↔ hub traffic is byte-identical before and after.

Closes #113

**What the regeneration diff contained beyond fields 15/16** (all faithful to the submodule's `proto/mesh.proto` + `proto/mesh.options` at v0.6.0):
- `routePath` capacity 60 → 48 (`MAX_HOPS` 10 → 8, v0.6.0)
- `authPath` (field 17, added upstream in v0.5.0) was missing entirely; it now appears — as a `pb_callback_t`, because upstream `mesh.options` has no `max_size` for it. A NULL-callback field is skipped on encode and on decode, so this is inert on the serial link; consequence is that `mesh_MeshMessage_CALLBACK` becomes `pb_default_field_callback` and the static `mesh_MeshMessage_size` macro (289) is no longer emitted. Nothing in firmware or tests referenced it. Filed the upstream gap as superbrobenji/lattice-protocol#54 (`mesh.MeshMessage.authPath max_size:8`); once released, bumping the submodule + rerunning the script restores a static field and the size macro.
- `mesh.pb.c` is byte-identical.

**Assumptions / decisions**
- Regenerate faithfully from the submodule rather than adding a firmware-local options overlay for `authPath` — the whole point of the drift check is that the submodule is the single source of truth.
- The generator version is read from `NANOPB_VERSION` in the vendored `nanopb/pb.h` (script refuses on mismatch) rather than pinned a second time; `grpcio-tools` is pinned to 1.80.0 in the workflow only to supply a `protoc` binary — output was verified identical with system protoc 35.1 and the grpc_tools fallback.
- CI uses Python 3.12 (verified green on this PR's Proto Sync run); locally verified on 3.9.
- Separate commit: `CONTRIBUTING.md` still told contributors to build with `arduino-cli` and said firmware compilation is not in CI — both false since the ESP-IDF migration; fixed inline as it was small and contained.

## Type of change
- [x] Bug fix
- [ ] New adapter
- [ ] Protocol change
- [x] Documentation
- [x] CI/tooling
- [ ] Other:

## Checklist
- [x] `clang-format --style=file` applied — `git diff --check` clean
- [x] No `new` / `malloc` after `setup()` (Tiger Style memory policy)
- [x] All errors route through `src/error/Error.h`
- [x] Unit tests added / updated for any logic change — no new gtest cases: the change only deletes dead code; the existing serial codec round-trip tests (`test_serial_framing.cpp`) and the dual-master e2e (`UplinkReachesSecondaryMasterAfterFailover`, which routes a JOIN_ACK-with-secondary through the codec) are the regression guard, and `tools/gen_mesh_pb.sh --check` is the new test for the drift itself
- [x] Documentation updated if behaviour changes
- [x] `project_config.h` example MACs remain as `AA:BB:CC:...` placeholders

## Testing done
Host-only; no hardware flashed.

Drift check as TDD — RED against the stale committed header, GREEN after regeneration (both with system `protoc` and the `grpcio-tools` fallback used in CI):
```
$ tools/gen_mesh_pb.sh --check            # before regen
-typedef PB_BYTES_ARRAY_T(60) mesh_MeshMessage_routePath_t;
+typedef PB_BYTES_ARRAY_T(48) mesh_MeshMessage_routePath_t;
-typedef PB_BYTES_ARRAY_T(6) mesh_MeshMessage_secondaryMasterMac_t;
-typedef PB_BYTES_ARRAY_T(32) mesh_MeshMessage_secondaryPublicKey_t;
+    pb_callback_t authPath;
...
gen_mesh_pb: mesh.pb.h/.c are out of date relative to the lattice-protocol submodule — run tools/gen_mesh_pb.sh and commit the result
exit=1
$ tools/gen_mesh_pb.sh --check            # after regen (staged)
gen_mesh_pb: mesh.pb.h/.c are in sync with lattice-protocol v0.6.0 (nanopb-0.4.9.1)
exit=0
$ NANOPB_GENERATOR=<fake reporting 0.4.8> tools/gen_mesh_pb.sh --check
gen_mesh_pb: nanopb_generator is '0.4.8' but the vendored runtime is 0.4.9.1 — install with: python3 -m pip install "nanopb==0.4.9.1"
exit=1
```

Dead-code removal as TDD — with the regenerated header the host build fails only at the two dead blocks, then passes once they are removed:
```
SerialFraming.cpp:76:13: error: no member named 'has_secondaryMasterMac' in '_mesh_MeshMessage'
SerialFraming.cpp:135:15: error: no member named 'has_secondaryMasterMac' in '_mesh_MeshMessage'
```

Host suites and firmware:
```
$ cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --parallel 4
build exit=0 (0 warnings)
$ ctest --test-dir tests/build --output-on-failure --parallel 4 --label-exclude e2e
100% tests passed out of 299
$ cmake --build tests/build --target lattice_e2e --parallel 4 && ctest --test-dir tests/build --output-on-failure --label-regex e2e
e2e = 1.90 sec*proc (41 tests), 100% passed
$ cp firmware/main/config/master_pubkey_pin.h.example firmware/main/config/master_pubkey_pin.h
$ source ~/esp/esp-idf/export.sh && cd firmware && idf.py set-target esp32 && idf.py build   # ESP-IDF v5.5.1
idf.py build exit=0 — lattice-nodes.bin 0xa20f0 bytes, 37% of app partition free
$ clang-format --style=file --dry-run --Werror firmware/main/src/adapter/serial/SerialFraming.cpp && git diff --check
clean
$ grep -rn -E 'has_secondary|pbMsg\.secondary|mesh_MeshMessage_secondary' firmware/main/src tests
(none)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFT6VnxRJ9UirLK58N2Pmq
