### PR TITLE
fix(logging): bench-debug log levels compile again, single-source the level, CI build at LOG_ERROR

### DIFF
--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -52,3 +52,30 @@ jobs:
           path: |
             firmware/build/*.bin
             firmware/build/size_info/
+
+  # Issue #117: at the shipped LATTICE_DEFAULT_LOG_LEVEL (LOG_NONE) the LATTICE_LOG /
+  # LATTICE_LOGLN / LATTICE_LOGF call sites fold to ((void)0) and are never compiled, so
+  # the job above cannot catch errors in them (nor in anything behind
+  # `#if LATTICE_DEFAULT_LOG_LEVEL != LATTICE_LOG_LEVEL_NONE`). Build once more at
+  # LOG_ERROR so that code is type-checked. The level is injected as a CMake cache entry
+  # that firmware/main/CMakeLists.txt forwards as a -D define; the shipped default and
+  # the job above are unchanged. Compile check only: no size report, no artifacts.
+  build-log-error:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Stub master_pubkey_pin.h from placeholder for CI
+        run: cp firmware/main/config/master_pubkey_pin.h.example firmware/main/config/master_pubkey_pin.h
+
+      - name: Build with ESP-IDF at LATTICE_DEFAULT_LOG_LEVEL=3 (LOG_ERROR)
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.5.1
+          target: esp32
+          path: firmware
+          command: idf.py -DLATTICE_DEFAULT_LOG_LEVEL=3 build

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Every constant a first-time user should review before their first flash
 | `SEVSEG_DATA_PIN` / `SEVSEG_CLK_PIN` | `23` / `22` | TM1637 seven-segment display DIO/CLK. |
 | `ENABLE_SEVSEG_DISPLAY` | `true` | Set `false` if no display is wired up. |
 | `DEFAULT_PEERS` | *(2 placeholder MACs)* | Initial ESP-NOW peer list written to EEPROM on first boot (non-dev-mode, only if EEPROM has none yet). Replace with your real device MACs before flashing. |
-| `DEFAULT_LOG_LEVEL` | `LogLevel::LOG_NONE` | Verbosity of serial log output. **Must stay `LOG_NONE`** on any `SERIAL_ADAPTER` node talking to the hub — log text would corrupt the framed protocol on the shared UART. |
+| `DEFAULT_LOG_LEVEL` | `LogLevel::LOG_NONE` | Verbosity of serial log output. **Must stay `LOG_NONE`** on any `SERIAL_ADAPTER` node talking to the hub — log text would corrupt the framed protocol on the shared UART. Derived from `LATTICE_DEFAULT_LOG_LEVEL` in `src/logging/LogLevelConfig.h`; for bench debugging raise it there or build with `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=0 build` (0=DEBUG … 4=NONE). |
 | `DEFAULT_TX_POWER_PRESET` | `TxPowerPreset::OUTDOOR` | Named RF power preset (`SHORT_RANGE`=2dBm, `INDOOR`=14dBm, `OUTDOOR`=20dBm), persisted to EEPROM. |
 | `SIMULATE_MODE` | `0` | Enables serial-injected fake sensor events for hardware-free dev/testing. Never enable in production. |
 | `MAX_HOPS` | `8` | Maximum relay hops across the mesh. |

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -177,7 +177,7 @@ init failure or an unset transmit callback from the code alone — the numeric c
 disambiguate. The only thing that distinguishes them is the log message passed to `fail()`
 (e.g. "PIR_Adapter: PIR hardware failed to initialize." vs. "Adapter: Transmit function not set"),
 and by default that message is **compiled out**: `LATTICE_LOGLN` folds to `((void)0)` when
-`LATTICE_DEFAULT_LOG_LEVEL` is `LATTICE_LOG_LEVEL_NONE` (the `project_config.h` default), so on a
+`LATTICE_DEFAULT_LOG_LEVEL` is `LATTICE_LOG_LEVEL_NONE` (the `src/logging/LogLevelConfig.h` default), so on a
 production build there is genuinely no way to tell these apart remotely — only the on-device
 7-segment code, full stop. If you need to disambiguate a collision in the field, temporarily raise
 the log level and reproduce, or narrow by which subsystem could plausibly be active at the time.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -354,7 +354,7 @@ tune it.
 | `SEVSEG_DATA_PIN` / `SEVSEG_CLK_PIN` | GPIO pins for the optional seven-segment status display. | Defaults are `23` / `22`. |
 | `ENABLE_SEVSEG_DISPLAY` | Whether the firmware drives a seven-segment display at all. | `true` if you have the display wired up; `false` if you don't (saves a little overhead and frees those pins). |
 | `DEFAULT_PEERS` | The initial list of other nodes' MAC addresses, written into storage on first boot. Ships with two obvious placeholder addresses and a `TODO: Replace these` comment. | Fine to leave as placeholders for your very first single-board smoke test (a lone node has no peers to talk to yet). Once you have real hardware to pair, get each node's real MAC address from its own serial output on first boot (see [Step 7](#9-step-7-first-boot--provisioning)) and update this list, then reflash. |
-| `DEFAULT_LOG_LEVEL` | How much debug text the firmware prints over serial. **For any node using `SERIAL_ADAPTER` to talk to the hub, this must stay `LOG_NONE`** — any extra text corrupts the binary protocol the hub expects on that same wire. | Leave at `LOG_NONE`. Only change this (to `LOG_DEBUG` or similar) for bench-testing a node that is *not* simultaneously talking to a hub over the same USB connection. |
+| `DEFAULT_LOG_LEVEL` | How much debug text the firmware prints over serial. **For any node using `SERIAL_ADAPTER` to talk to the hub, this must stay `LOG_NONE`** — any extra text corrupts the binary protocol the hub expects on that same wire. | Leave at `LOG_NONE`. Only raise it for bench-testing a node that is *not* simultaneously talking to a hub over the same USB connection — and do that via `LATTICE_DEFAULT_LOG_LEVEL` in `src/logging/LogLevelConfig.h`, or without a source edit with `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=0 build` (0=`LOG_DEBUG` … 4=`LOG_NONE`). This constant is derived from that macro, so editing it here is not the knob. |
 | `DEFAULT_TX_POWER_PRESET` | Named radio transmit-power preset: `SHORT_RANGE` (same room), `INDOOR` (through walls), `OUTDOOR` (maximum range). | Ships as `OUTDOOR` — reasonable to leave as-is unless you specifically want to reduce range/interference. |
 | `SIMULATE_MODE` | Enables fake, serial-injected sensor events for testing without real sensor hardware. | Leave at `0` (off) for a real flash. |
 
@@ -652,8 +652,9 @@ data transfer, not a charge-only cable.
 
 **Flashing succeeds, but I never see `LATTICE_PUBKEY:...` or anything else
 in the monitor.**
-Make sure `DEFAULT_LOG_LEVEL` in `project_config.h` wasn't left at something
-other than intended, and that you're opening the monitor at the same port
+Make sure `LATTICE_DEFAULT_LOG_LEVEL` in `src/logging/LogLevelConfig.h` (or a
+`-DLATTICE_DEFAULT_LOG_LEVEL` build flag) wasn't left at something other than
+intended, and that you're opening the monitor at the same port
 you flashed to. If truly nothing prints at all and no LED lights either,
 see the "Total hardware failure" row in the [LED table](#10-step-8-understanding-the-leds-and-display) —
 double check your board is genuinely powered and your LED/board wiring

--- a/docs/macos_dev_bringup.md
+++ b/docs/macos_dev_bringup.md
@@ -229,10 +229,6 @@ grep -n '<a line from the fix>' <file>   # confirms the fix is actually there ri
   rather than assuming the board itself is broken.
 - [lattice-nodes#116](https://github.com/superbrobenji/lattice-nodes/issues/116) — `DUAL_MASTER_MODE`
   should be a runtime setting, not a compile-time flag requiring a mesh-wide reflash to toggle.
-- [lattice-nodes#117](https://github.com/superbrobenji/lattice-nodes/issues/117) — raising
-  `DEFAULT_LOG_LEVEL` above `LOG_NONE` for bench debugging currently doesn't compile cleanly out of
-  the box (several files, plus the override mechanism itself is fragile to include order). If you
-  need to bench-debug with real log output, read that issue first.
 - [lattice-nodes#118](https://github.com/superbrobenji/lattice-nodes/issues/118) — the display's
   master indicator (decimal point) doesn't currently render for a master whose node ID is 0, which
   is every master today. Don't rely on the display to distinguish master from leaf yet, let alone

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -92,3 +92,15 @@ target_include_directories(${COMPONENT_LIB} PUBLIC
   src/persistence
   src/persistence/eeprom
 )
+
+# Compile-time log level override (issue #117). `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=<0..4> build`
+# creates a CMake cache entry; forward it as a preprocessor define so it wins over the #ifndef
+# default in src/logging/LogLevelConfig.h in every translation unit of this component, with no
+# source edit (0=DEBUG 1=INFO 2=WARN 3=ERROR 4=NONE). Unset (the shipped default) changes nothing.
+# CI's build-log-error job uses this to compile the LATTICE_LOG* call sites that fold to ((void)0)
+# under the default. The cache entry persists in the build directory — use a separate `-B <dir>`
+# or `idf.py fullclean` to return to the default.
+if(DEFINED LATTICE_DEFAULT_LOG_LEVEL)
+  target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    LATTICE_DEFAULT_LOG_LEVEL=${LATTICE_DEFAULT_LOG_LEVEL})
+endif()

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -298,7 +298,9 @@ static void initDrivers() {
       .parity = UART_PARITY_DISABLE,
       .stop_bits = UART_STOP_BITS_1,
       .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+      .rx_flow_ctrl_thresh = 0,
       .source_clk = UART_SCLK_DEFAULT,
+      .flags = {},
   };
   ESP_ERROR_CHECK(uart_driver_install(UART_NUM_0, 1024, 0, 0, NULL, 0)); // RX 1024, TX unbuffered
   ESP_ERROR_CHECK(uart_param_config(UART_NUM_0, &uartCfg));

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -204,7 +204,7 @@ static inline void validateServerConfiguration() {
         "CONFIG",
         "WARNING: SERIAL_ADAPTER with logging enabled will interfere with server communication",
         LogLevel::LOG_WARN);
-    Logger::logln("CONFIG", "Set DEFAULT_LOG_LEVEL = LOG_NONE in project_config.h",
+    Logger::logln("CONFIG", "Set LATTICE_DEFAULT_LOG_LEVEL = LOG_NONE (4) in LogLevelConfig.h",
                   LogLevel::LOG_WARN);
   }
 }

--- a/firmware/main/project_config.h
+++ b/firmware/main/project_config.h
@@ -1,20 +1,8 @@
 #ifndef PROJECT_CONFIG_H
 #define PROJECT_CONFIG_H
 
-// Compile-time mirror of DEFAULT_LOG_LEVEL (§6 "Logging" below, LogLevel::LOG_NONE) used by
-// LATTICE_LOG/LATTICE_LOGLN (Logger.h) to fold to a no-op at compile time when logging is fully
-// disabled. Must be defined before Logger.h is first included in a translation unit for the
-// gating to take effect there — Logger.h's own header guard means its #if is only evaluated once,
-// at first inclusion — hence this sits above every #include in this file. Logger.h carries its
-// own LOG_NONE fallback (same value) for translation units that include it directly without going
-// through this file first; the #ifndef below avoids a harmless-but-noisy macro-redefinition
-// warning when that fallback already fired earlier in the same translation unit. The static_assert
-// next to DEFAULT_LOG_LEVEL below catches drift between the two.
-#ifndef LATTICE_DEFAULT_LOG_LEVEL
-#define LATTICE_DEFAULT_LOG_LEVEL 4 // mirrors lattice::utils::LogLevel::LOG_NONE
-#endif
-
 #include <cstdint>
+#include "src/logging/LogLevelConfig.h"
 #include "src/logging/Logger.h"
 #include "src/adapter/Adapter.h"
 
@@ -94,12 +82,20 @@ constexpr int NUM_DEFAULT_PEERS = sizeof(DEFAULT_PEERS) / sizeof(DEFAULT_PEERS[0
 // 6. Logging
 // =====================
 // CRITICAL: For server communication, MUST be LOG_NONE to prevent text output
-// Only enable logging (LOG_DEBUG, LOG_INFO, etc.) for development/debugging
-constexpr lattice::utils::LogLevel DEFAULT_LOG_LEVEL = lattice::utils::LogLevel::LOG_NONE;
-static_assert(static_cast<int>(DEFAULT_LOG_LEVEL) == LATTICE_DEFAULT_LOG_LEVEL,
-              "LATTICE_DEFAULT_LOG_LEVEL (top of this file) must mirror DEFAULT_LOG_LEVEL here — "
-              "LATTICE_LOG/LATTICE_LOGLN (Logger.h) key off the macro at compile time; keep both "
-              "in sync when changing either.");
+// Only enable logging (LOG_DEBUG, LOG_INFO, etc.) for development/debugging.
+//
+// Not set here: DEFAULT_LOG_LEVEL is derived from the LATTICE_DEFAULT_LOG_LEVEL macro in
+// src/logging/LogLevelConfig.h, the single place the level lives. Logger.h's compile-time
+// LATTICE_LOG/LATTICE_LOGLN/LATTICE_LOGF gating keys off the same macro, so the runtime value and
+// the compile-time gate can never disagree, whichever header a translation unit includes first
+// (issue #117). To raise the level for bench debugging, edit the default in LogLevelConfig.h or
+// build with `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=<0..4> build` (0=DEBUG .. 3=ERROR, 4=NONE).
+constexpr lattice::utils::LogLevel DEFAULT_LOG_LEVEL =
+    static_cast<lattice::utils::LogLevel>(LATTICE_DEFAULT_LOG_LEVEL);
+static_assert(LATTICE_DEFAULT_LOG_LEVEL >= static_cast<int>(lattice::utils::LogLevel::LOG_DEBUG) &&
+                  LATTICE_DEFAULT_LOG_LEVEL <= static_cast<int>(lattice::utils::LogLevel::LOG_NONE),
+              "LATTICE_DEFAULT_LOG_LEVEL must be 0 (LOG_DEBUG) .. 4 (LOG_NONE) — see "
+              "src/logging/LogLevelConfig.h.");
 
 // =====================
 // 7. TX Power Presets

--- a/firmware/main/src/logging/LogLevelConfig.h
+++ b/firmware/main/src/logging/LogLevelConfig.h
@@ -1,0 +1,31 @@
+#ifndef LATTICE_LOG_LEVEL_CONFIG_H
+#define LATTICE_LOG_LEVEL_CONFIG_H
+
+// ---------------------------------------------------------------------------------------------
+// Compile-time log level — the single place it is set (issue #117).
+//
+// Numeric values mirror lattice::utils::LogLevel (Logger.h) exactly, so the preprocessor can
+// compare against them before the enum exists:
+//   0 = LOG_DEBUG   1 = LOG_INFO   2 = LOG_WARN   3 = LOG_ERROR   4 = LOG_NONE
+//
+// Both Logger.h (compile-time gating of LATTICE_LOG/LATTICE_LOGLN/LATTICE_LOGF) and
+// project_config.h (runtime lattice::config::DEFAULT_LOG_LEVEL, derived from this macro) include
+// this header, so every translation unit sees the same value no matter which of those two it
+// reaches first. Previously each carried its own #ifndef fallback and whichever was included
+// first won per translation unit, so raising the level in project_config.h alone tripped its
+// own static_assert in any file that pulled in Logger.h before it.
+//
+// CRITICAL: for hub communication this MUST stay LATTICE_LOG_LEVEL_NONE. On a SERIAL_ADAPTER node
+// Logger and SerialAdapter share UART0, and log text corrupts the framed protocol. Only raise it
+// for bench-testing a node that is not talking to a hub over the same USB connection.
+//
+// To raise it, either edit the default below, or pass a CMake cache entry — no source edit —
+//   idf.py -DLATTICE_DEFAULT_LOG_LEVEL=3 build      (main/CMakeLists.txt forwards it as a -D)
+// The #ifndef is what lets that command-line definition win over the default here.
+#define LATTICE_LOG_LEVEL_NONE 4
+
+#ifndef LATTICE_DEFAULT_LOG_LEVEL
+#define LATTICE_DEFAULT_LOG_LEVEL LATTICE_LOG_LEVEL_NONE
+#endif
+
+#endif // LATTICE_LOG_LEVEL_CONFIG_H

--- a/firmware/main/src/logging/Logger.h
+++ b/firmware/main/src/logging/Logger.h
@@ -5,23 +5,6 @@
 #include <cstdarg>
 #include <cstdio>
 
-#ifndef LATTICE_LOG_LEVEL
-#define LATTICE_LOG_LEVEL 3 // 0=none 1=error 2=warn 3=info 4=debug
-#endif
-
-#if LATTICE_LOG_LEVEL >= 4
-#define LOG_D(tag, fmt, ...)                                                                       \
-  do {                                                                                             \
-    char _buf[128];                                                                                \
-    snprintf(_buf, sizeof(_buf), fmt, ##__VA_ARGS__);                                              \
-    Logger::logln(tag, _buf, LogLevel::LOG_DEBUG);                                                 \
-  } while (0)
-#else
-#define LOG_D(tag, fmt, ...)                                                                       \
-  do {                                                                                             \
-  } while (0)
-#endif
-
 // ---------------------------------------------------------------------------------------------
 // LATTICE_LOG / LATTICE_LOGLN — compile-time log-level gating (design doc §1, Phase G).
 //
@@ -54,15 +37,14 @@
 // LOG_NONE they ran (and the format strings stayed in .rodata) even though the
 // LOGLN call itself folded to ((void)0). LATTICE_LOGF closes that gap by gating the
 // snprintf and its format string inside the same #if as LATTICE_LOG/LATTICE_LOGLN
-// above (mirrors the LOG_D pattern), so under LOG_NONE the whole call — buffer,
+// above, so under LOG_NONE the whole call — buffer,
 // snprintf, and format-string literal — folds to ((void)0) and is eligible for the
 // linker to drop from .rodata via -fdata-sections/--gc-sections.
 //
 // Buffer size: 128 bytes. Audited every existing snprintf+LATTICE_LOGLN call site
 // being migrated onto this macro; the largest local buffer among them was 96 bytes
 // (Error.h checkEsp, ErrorCore.cpp signalError, EepromCore.cpp persistOrEscalate,
-// SerialAdapter.cpp onMeshDataImpl). 128 covers all of them with headroom, and
-// matches LOG_D's existing buffer size above for consistency.
+// SerialAdapter.cpp onMeshDataImpl). 128 covers all of them with headroom.
 #if LATTICE_DEFAULT_LOG_LEVEL == LATTICE_LOG_LEVEL_NONE
 #define LATTICE_LOGF(tag, level, fmt, ...) ((void)0)
 #else

--- a/firmware/main/src/logging/Logger.h
+++ b/firmware/main/src/logging/Logger.h
@@ -25,22 +25,16 @@
 // ---------------------------------------------------------------------------------------------
 // LATTICE_LOG / LATTICE_LOGLN — compile-time log-level gating (design doc §1, Phase G).
 //
-// Numeric values mirror lattice::utils::LogLevel exactly (DEBUG=0 .. NONE=4) so the #if below
-// can compare against it directly, without needing the enum type available yet at this point in
-// the header. When LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE (the production default — see
-// project_config.h §6 "Logging"), both macros fold to ((void)0): the tag/message/level arguments
-// are never evaluated, so format strings and String concatenations at call sites never reach the
-// translation unit's .rodata / heap. Otherwise they route to the existing runtime-dispatched
-// Logger::log/logln (unchanged behaviour).
-#define LATTICE_LOG_LEVEL_NONE 4
-
-// project_config.h defines LATTICE_DEFAULT_LOG_LEVEL above its own #include of this header, so
-// that value is authoritative when present. This fallback only covers translation units that
-// include Logger.h directly without going through project_config.h first; it is pinned to
-// LOG_NONE (the production default) so such a TU never silently gets logging turned on.
-#ifndef LATTICE_DEFAULT_LOG_LEVEL
-#define LATTICE_DEFAULT_LOG_LEVEL LATTICE_LOG_LEVEL_NONE
-#endif
+// LATTICE_DEFAULT_LOG_LEVEL and LATTICE_LOG_LEVEL_NONE come from LogLevelConfig.h — the single
+// source of truth shared with project_config.h (issue #117) — so the #if below sees the same value
+// in every translation unit regardless of include order. Numeric values mirror
+// lattice::utils::LogLevel exactly (DEBUG=0 .. NONE=4; static_assert'd after the enum below) so the
+// #if can compare against them without needing the enum type available yet at this point in the
+// header. When LATTICE_DEFAULT_LOG_LEVEL == LOG_NONE (the production default), both macros fold
+// to ((void)0): the tag/message/level arguments are never evaluated, so format strings and String
+// concatenations at call sites never reach the translation unit's .rodata / heap. Otherwise they
+// route to the existing runtime-dispatched Logger::log/logln (unchanged behaviour).
+#include "LogLevelConfig.h"
 
 #if LATTICE_DEFAULT_LOG_LEVEL == LATTICE_LOG_LEVEL_NONE
 #define LATTICE_LOG(tag, msg, level) ((void)0)
@@ -90,6 +84,9 @@ enum class LogLevel : uint8_t {
   LOG_ERROR = 3,
   LOG_NONE = 4
 };
+static_assert(static_cast<int>(LogLevel::LOG_NONE) == LATTICE_LOG_LEVEL_NONE,
+              "LATTICE_LOG_LEVEL_NONE (LogLevelConfig.h) must mirror LogLevel::LOG_NONE — the "
+              "LATTICE_LOG* compile-time gating above compares the macros, not the enum.");
 
 class Logger {
 public:

--- a/firmware/main/src/mesh/FrameAuthorizer.cpp
+++ b/firmware/main/src/mesh/FrameAuthorizer.cpp
@@ -9,6 +9,8 @@
 namespace lattice {
 namespace mesh {
 
+using namespace lattice::utils;
+
 AuthResult FrameAuthorizer::authorize(const mesh_message& msg, bool isMaster, bool addressedToSelf,
                                       const MasterInfo& currentMaster, PeerRegistry& peers,
                                       Enrollment& enrollment, E2EKeyStore& e2eKeys,

--- a/firmware/main/src/mesh/MeshMessenger.cpp
+++ b/firmware/main/src/mesh/MeshMessenger.cpp
@@ -11,6 +11,8 @@
 namespace lattice {
 namespace mesh {
 
+using namespace lattice::utils;
+
 mesh_message MeshMessenger::buildMessage(adapter_types type, const uint8_t* data,
                                          MeshMessageType msgType, const uint8_t* deviceMac,
                                          const MasterInfo& currentMaster,

--- a/firmware/main/src/mesh/MeshTransport.h
+++ b/firmware/main/src/mesh/MeshTransport.h
@@ -154,10 +154,8 @@ private:
   TaskHandle_t drainNotifyHandle_ = nullptr;
 
   static void onDataSentCallback(const wifi_tx_info_t* mac_addr, esp_now_send_status_t status);
-  void IRAM_ATTR onDataRecvCallback(const esp_now_recv_info* mac, const uint8_t* incomingData,
-                                    int len);
-  static void IRAM_ATTR dataRecvTrampoline(const esp_now_recv_info* mac_addr, const uint8_t* data,
-                                           int len);
+  void onDataRecvCallback(const esp_now_recv_info* mac, const uint8_t* incomingData, int len);
+  static void dataRecvTrampoline(const esp_now_recv_info* mac_addr, const uint8_t* data, int len);
 };
 
 } // namespace mesh

--- a/firmware/main/src/mesh/PeerEnrollment.cpp
+++ b/firmware/main/src/mesh/PeerEnrollment.cpp
@@ -10,6 +10,8 @@
 namespace lattice {
 namespace mesh {
 
+using namespace lattice::utils;
+
 // Moved verbatim from Mesh::registerPeerWithKey (Mesh.cpp:756-794 pre-Task-10)
 // — only change: `peers`/`enrollment`/`dualMasterMode` are now explicit
 // parameters instead of implicit Mesh member access. The

--- a/firmware/main/src/mesh/PendingRelayQueue.cpp
+++ b/firmware/main/src/mesh/PendingRelayQueue.cpp
@@ -4,6 +4,8 @@
 namespace lattice {
 namespace mesh {
 
+using namespace lattice::utils;
+
 PendingRelayQueue::PendingRelayQueue() {
   _queue = xRingbufferCreateStatic(sizeof(_storage), RINGBUF_TYPE_NOSPLIT, _storage, &_queueStruct);
 }

--- a/firmware/main/src/mesh/RouteReportHandler.cpp
+++ b/firmware/main/src/mesh/RouteReportHandler.cpp
@@ -11,6 +11,8 @@
 namespace lattice {
 namespace mesh {
 
+using namespace lattice::utils;
+
 bool RouteReportHandler::sendRouteReport(bool isMaster, UplinkRouter& uplinkRouter,
                                          MasterInfo& currentMaster, PeerRegistry& peers,
                                          NeighborTable& neighbors, Enrollment& enrollment,


### PR DESCRIPTION
## Summary
Raising the log level for bench debugging did not compile, for two independent reasons (#117): five `src/mesh/*.cpp` files pass bare `LogLevel::…` to `LATTICE_LOGLN`/`LATTICE_LOGF` and only ever compiled because those macros fold to `((void)0)` at the shipped `LOG_NONE`; and the `LATTICE_DEFAULT_LOG_LEVEL` macro was defined in two places under `#ifndef` (`project_config.h` and a fallback in `Logger.h`), so whichever header a translation unit reached first won, while the `constexpr DEFAULT_LOG_LEVEL` didn't care about include order — tripping `project_config.h`'s own `static_assert` in 14 TUs and, in those same TUs, keeping the macros folded so the first bug stayed hidden. This PR qualifies the five files the way every other `src/mesh/*.cpp` already does, moves the level to a single tiny header (`src/logging/LogLevelConfig.h`) that both `Logger.h` and `project_config.h` consume, derives the `constexpr` from it, lets `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=<0..4> build` override it with no source edit, and adds a CI job that builds once at `LOG_ERROR` so compiled-out log code is type-checked from now on. Two small pre-existing issues found along the way are fixed in their own commits (see below).

Closes #117
Closes #134 (duplicate `IRAM_ATTR` on MeshTransport recv callbacks, fixed in the warnings commit)
Closes #139 (`uart_config_t` missing initializers in main.cpp, same commit).

### Why a new header rather than `Logger.h` including `project_config.h`
`project_config.h` needs `lattice::utils::LogLevel`, which `Logger.h` only defines *below* its macro block, so `Logger.h → project_config.h` is a cycle: any TU that includes `Logger.h` first would evaluate `project_config.h`'s `constexpr lattice::utils::LogLevel DEFAULT_LOG_LEVEL` before the enum exists. A 31-line header with no includes that both of them pull in is the smallest single source of truth. The `constexpr` is now `static_cast<LogLevel>(LATTICE_DEFAULT_LOG_LEVEL)`, so there is nothing left to keep in sync; the old mirror `static_assert` became a 0..4 range check, and `Logger.h` gained a `static_assert` that `LATTICE_LOG_LEVEL_NONE` mirrors `LogLevel::LOG_NONE`.

### How the level is injected (CI and bench)
`firmware/main/CMakeLists.txt` forwards a CMake cache entry as a compile definition for every TU of the `main` component:
```cmake
if(DEFINED LATTICE_DEFAULT_LOG_LEVEL)
  target_compile_definitions(${COMPONENT_LIB} PRIVATE LATTICE_DEFAULT_LOG_LEVEL=${LATTICE_DEFAULT_LOG_LEVEL})
endif()
```
so `idf.py -DLATTICE_DEFAULT_LOG_LEVEL=3 build` is all CI needs (`build-log-error` job in `firmware-build.yml`). Considered and rejected: ESP-IDF's `EXTRA_CXXFLAGS` env var (the `esp-idf-ci-action` runs `docker run` with only `IDF_TARGET` in the environment, so it would need extra plumbing) and a Kconfig option (heavier, touches `sdkconfig`, and the bench-debug flow is documented around the header). Unset, the shipped build is byte-for-byte the same configuration as before (verified: no define in the default build's `flags.make`).

### Out-of-scope fixes, separate commits
- `fix: clear the two pre-existing firmware build warnings` — `main.cpp` `uart_config_t` missing initializers (`-Wmissing-field-initializers`), and `MeshTransport.h` declaring `IRAM_ATTR` on two callbacks that also carry it on their definitions (`-Wattributes`, GCC dropped the second unique `.iram1.N` section). Placement-neutral: `nm` shows both callbacks at the same IRAM addresses (`0x4008300c` / `0x40083084`) before and after. Default build is now warning-free apart from the Kconfig warnings tracked in #137.
- `refactor(logging): drop unused LOG_D / LATTICE_LOG_LEVEL legacy macro` — zero call sites, inverted scale (0=none..4=debug) vs. everything else, and the same latent bare-`LogLevel::` defect as #117 inside its body.
- Filed #143: host unit tests fail whenever a `firmware/main/config/master_pubkey_pin.h` exists (quoted `__has_include` defeats the `tests/mocks` include-order trick). Not fixed here: it lives in the pin wrapper that #126 is touching.
- Filed #137 for the four `sdkconfig.defaults` symbols ESP-IDF v5.5.1 doesn't know (`COMPILER_OPTIMIZATION_LTO` among them, so the Phase G LTO size lever has never actually applied). Not fixed here: needs a decision, not a one-liner.

### Assumptions
- `LOG_ERROR` (3) is enough for the CI job: the gating is `== LOG_NONE` vs. anything else, so every non-`NONE` level compiles the same code.
- The bench-debug knob moving from `project_config.h` to `src/logging/LogLevelConfig.h` (or the `-D`) is acceptable; README, `docs/getting_started.md`, `docs/error_codes.md` and the runtime hint in `main.cpp` were updated to match, and the #117 known-issue bullet in `docs/macos_dev_bringup.md` was removed.
- Removed the dead `LOG_D` macro rather than qualifying it: nothing uses it, so a "fix" would be unverifiable.

## Type of change
- [x] Bug fix
- [ ] New adapter
- [ ] Protocol change
- [x] Documentation
- [x] CI/tooling
- [ ] Other:

## Checklist
- [x] `clang-format --style=file` applied — `git diff --check` clean
- [x] No `new` / `malloc` after `setup()` (Tiger Style memory policy) — no allocation touched
- [x] All errors route through `src/error/Error.h` — no error-handling touched
- [ ] Unit tests added / updated for any logic change — no host-testable logic changed; the "test" for this class of bug is the new `build-log-error` CI job (a firmware build at a non-`LOG_NONE` level), which fails on `main` today and passes here
- [x] Documentation updated if behaviour changes
- [x] `project_config.h` example MACs remain as `AA:BB:CC:...` placeholders

## Testing done
No hardware; everything below is local ESP-IDF v5.5.1 (`idf.py build`, Makefile generator) in a clean worktree with the CI's placeholder `master_pubkey_pin.h`.

**RED (reproduce, on `origin/main` with the reporter's two-line edit of `project_config.h` to `LOG_ERROR`):** 15 TUs of `main` fail —
```
firmware/main/src/mesh/MeshMessenger.cpp:68:70: error: 'LogLevel' has not been declared
   68 |       LATTICE_LOGLN("MESH", "E2E seal unavailable — uplink dropped", LogLevel::LOG_WARN);
firmware/main/project_config.h:99:51: error: static assertion failed: LATTICE_DEFAULT_LOG_LEVEL (top of this file) must mirror DEFAULT_LOG_LEVEL here — …
```
6 × `'LogLevel' has not been declared` (MeshMessenger.cpp only) and 14 × the `static_assert` (Enrollment, PeerRegistry, PeerEnrollment, RouteReportHandler, PirAdapter, SerialAdapter, Eeprom*). The other four bare-`LogLevel` files did not even error: in those TUs `Logger.h`'s fallback had won, so their `LATTICE_LOGLN` calls were still folded.

**Step A (single source of truth only):** rebuild at `LOG_ERROR` — no `static_assert` failures; now all five files surface `'LogLevel' has not been declared` (27 errors: FrameAuthorizer 5, MeshMessenger 6, PeerEnrollment 6, PendingRelayQueue 2, RouteReportHandler 8). Confirms defect 2 was masking defect 1.

**GREEN (full branch):**
- `idf.py build` (shipped default): exit 0, 0 errors, 0 compiler warnings, `lattice-nodes.bin` 0xa21b0 bytes, no `LATTICE_DEFAULT_LOG_LEVEL` define on the compile line.
- `idf.py -B build-logerror -DLATTICE_DEFAULT_LOG_LEVEL=3 build` (the exact CI command, fresh build dir): exit 0, 0 errors, 0 compiler warnings, `lattice-nodes.bin` 0xa46a0 bytes; `-DLATTICE_DEFAULT_LOG_LEVEL=3` present in all 38 `main` entries of `compile_commands.json`.
- Same level set by editing the header default instead of `-D`: exit 0, identical 0xa46a0 binary.
- `xtensa-esp32-elf-nm`: `MeshTransport::onDataRecvCallback` / `dataRecvTrampoline` at `0x4008300c` / `0x40083084` (IRAM) in both builds, before and after the `IRAM_ATTR` change.
- Host unit tests (`cmake -B tests/build tests/ -DCMAKE_BUILD_TYPE=Release && cmake --build tests/build --parallel 4 && ctest --test-dir tests/build --output-on-failure --label-exclude e2e`): **100% tests passed out of 299**, 0 host-compile warnings. Note: with the firmware-build placeholder `master_pubkey_pin.h` copied into `firmware/main/config/` (as CI's *firmware* job does), 7 `MeshLogicTest` TOFU cases fail on any branch because the wrapper's quoted `__has_include` finds that file before `tests/mocks/` — independent of this diff, filed as #143; the `unit-tests` CI job never has that file.
- `clang-format --style=file --dry-run --Werror` over all of `firmware/main/src` (the CI lint command): clean; `git diff --check`: clean; workflow YAML parses.

**Not verified locally:** `cppcheck` (not installed here; the `static-analysis` job will run it), and the new CI job end-to-end (it runs on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFT6VnxRJ9UirLK58N2Pmq

